### PR TITLE
Move tile flag reset logic

### DIFF
--- a/src/hubbleds/components/selection_tool/selection_tool.py
+++ b/src/hubbleds/components/selection_tool/selection_tool.py
@@ -133,3 +133,4 @@ class SelectionTool(v.VueTemplate):
             data = {"galaxy_name": name}
         requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad",
                      json=data)
+        self.flagged = False

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -561,7 +561,6 @@ class StageOne(HubbleStage):
         item = self.galaxy_table.selected[0]
         galaxy_name = item["name"]
         self.remove_measurement(galaxy_name)
-        self.selection_tool.flagged = False
 
     def _on_spectrum_flagged(self, flagged):
         if not flagged:


### PR DESCRIPTION
This is a small PR that moves the logic for resetting the `flagged` member of the selection tool into the tool itself. Currently this flag is reset in stage one inside of the function that removes a measurement for a flagged galaxy, which causes a bug where the flag won't get reset if the galaxy hasn't been added to the data set. Putting the reset logic inside the selection tool makes more sense.