### PR TITLE
Fixed issue with dark mode not changing Stage 3 figure colors

### DIFF
--- a/src/hubbleds/data/styles/default_histogram_dark.json
+++ b/src/hubbleds/data/styles/default_histogram_dark.json
@@ -1,0 +1,46 @@
+{
+  "figure": {
+    "background_style": {
+      "fill": "#fffef5"
+    },
+    "fig_margin": {
+      "left": 100,
+      "bottom": 60,
+      "top": 10,
+      "right": 10
+    },
+    "axes": [
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White",
+          "fill": "White"
+        },
+        "label_offset": "3em",
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      },
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White",
+          "fill": "White"
+        },
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      }
+    ]
+  },
+  "viewer": {
+    "bars": {
+      "enable_hover": true
+    },
+    "state": {
+      "size": "3"
+    }
+  }
+}

--- a/src/hubbleds/data/styles/default_histogram_light.json
+++ b/src/hubbleds/data/styles/default_histogram_light.json
@@ -1,0 +1,46 @@
+{
+    "figure": {
+      "background_style": {
+        "fill": "#fffef5"
+      },
+      "fig_margin": {
+        "left": 100,
+        "bottom": 60,
+        "top": 10,
+        "right": 10
+      },
+      "axes": [
+        {
+          "tick_format": ",.0f",
+          "tick_style": {
+            "font-size": "1.5em",
+            "color": "Black",
+            "fill": "Black"
+          },
+          "label_offset": "3em",
+          "color": "Black",
+          "label_color": "Black",
+          "grid_color": "Black"
+        },
+        {
+          "tick_format": ",.0f",
+          "tick_style": {
+            "font-size": "1.5em",
+            "color": "Black",
+            "fill": "Black"
+          },
+          "color": "Black",
+          "label_color": "Black",
+          "grid_color": "Black"
+        }
+      ]
+    },
+    "viewer": {
+      "bars": {
+        "enable_hover": true
+      },
+      "state": {
+        "size": "3"
+      }
+    }
+  }

--- a/src/hubbleds/data/styles/default_scatter_dark.json
+++ b/src/hubbleds/data/styles/default_scatter_dark.json
@@ -1,0 +1,46 @@
+{
+  "figure": {
+    "background_style": {
+      "fill": "#fffef5"
+    },
+    "fig_margin": {
+      "left": 100,
+      "bottom": 60,
+      "top": 10,
+      "right": 10
+    },
+    "axes": [
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White",
+          "fill": "White"
+        },
+        "label_offset": "3em",
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      },
+      {
+        "tick_format": ",.0f",
+        "tick_style": {
+          "font-size": "1.5em",
+          "color": "White",
+          "fill": "White"
+        },
+        "color": "White",
+        "label_color": "White",
+        "grid_color": "White"
+      }
+    ]
+  },
+  "viewer": {
+    "scatter": {
+      "enable_hover": true
+    },
+    "state": {
+      "size": "3"
+    }
+  }
+}

--- a/src/hubbleds/data/styles/default_scatter_light.json
+++ b/src/hubbleds/data/styles/default_scatter_light.json
@@ -1,0 +1,46 @@
+{
+    "figure": {
+      "background_style": {
+        "fill": "#fffef5"
+      },
+      "fig_margin": {
+        "left": 100,
+        "bottom": 60,
+        "top": 10,
+        "right": 10
+      },
+      "axes": [
+        {
+          "tick_format": ",.0f",
+          "tick_style": {
+            "font-size": "1.5em",
+            "color": "Black",
+            "fill": "Black"
+          },
+          "label_offset": "3em",
+          "color": "Black",
+          "label_color": "Black",
+          "grid_color": "Black"
+        },
+        {
+          "tick_format": ",.0f",
+          "tick_style": {
+            "font-size": "1.5em",
+            "color": "Black",
+            "fill": "Black"
+          },
+          "color": "Black",
+          "label_color": "Black",
+          "grid_color": "Black"
+        }
+      ]
+    },
+    "viewer": {
+      "scatter": {
+        "enable_hover": true
+      },
+      "state": {
+        "size": "3"
+      }
+    }
+  }

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -381,6 +381,12 @@ class StageThree(HubbleStage):
                 viewer.state.y_max = 1
                 viewer.state.hist_n_bin = 30
 
+        # set reasonable offset for y-axis labels
+        # it would be better if axis labels were automatically well placed
+        velocity_viewers = [prodata_viewer, comparison_viewer, fit_viewer, morphology_viewer]
+        for viewer in velocity_viewers:
+            viewer.figure.axes[1].label_offset = "5em"
+
         class_distr_viewer.state.x_att = class_sample_data.id['age']
         all_distr_viewer.state.x_att = students_summary_data.id['age']
         sandbox_distr_viewer.state.x_att = students_summary_data.id['age']


### PR DESCRIPTION
This PR fixes the issue where toggling dark mode did not affect the figures in Stage 3. This has been fixed by overriding the `_on_dark_mode_change` method to match what was done in `stage_one.py`.  I've also added the appropriate JSON style files, which should be fairly general. 
