### PR TITLE
Fix bug preventing state update in selection tool callback

### DIFF
--- a/src/hubbleds/components/selection_tool/selection_tool.py
+++ b/src/hubbleds/components/selection_tool/selection_tool.py
@@ -68,9 +68,10 @@ class SelectionTool(v.VueTemplate):
             self.go_to_location(galaxy["ra"], galaxy["decl"], fov=fov)
             self.current_galaxy = galaxy
             self.candidate_galaxy = galaxy
-            gal_names = [k for k in self.selected_data["name"]]
-            if self.current_galaxy["name"] in gal_names:
-                self.candidate_galaxy = {}
+            if not self.selected_data.empty:
+                gal_names = [k for k in self.selected_data["name"]]
+                if self.current_galaxy["name"] in gal_names:
+                    self.candidate_galaxy = {}
             self.state.gal_selected = True
 
         self.widget.set_selection_change_callback(wwt_cb)


### PR DESCRIPTION
This PR fixes a bug that could prevent `gal_selected` in the stage one state from being marked true when a galaxy is selected. There was a bug in the callback we attach to the WWT widget - if the widget's `selected_data` DataFrame is empty, then the call to `self.selected_data['name']` gives an error. This PR adds a check of whether the DataFrame is empty.