### PR TITLE
Replace fit_viewer in Stage 3 with new viewer that supports toggling layers

### DIFF
--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -23,7 +23,7 @@ from ..stage import HubbleStage
 from ..viewers import HubbleFitView, \
     HubbleScatterView
 from ..viewers.viewers import \
-    HubbleClassHistogramView, HubbleHistogramView
+    HubbleClassHistogramView, HubbleHistogramView, HubbleFitLayerView
 
 
 class StageState(CDSState):

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -416,7 +416,7 @@ class StageThree(HubbleStage):
 
         # set reasonable offset for y-axis labels
         # it would be better if axis labels were automatically well placed
-        velocity_viewers = [prodata_viewer, comparison_viewer, fit_viewer, morphology_viewer]
+        velocity_viewers = [prodata_viewer, comparison_viewer, fit_viewer, morphology_viewer, layer_viewer]
         for viewer in velocity_viewers:
             viewer.figure.axes[1].label_offset = "5em"
 
@@ -480,6 +480,9 @@ class StageThree(HubbleStage):
 
         extend_tool(fit_viewer, 'bqplot:rectangle', fit_selection_activate,
                     fit_selection_deactivate)
+        
+        extend_tool(layer_viewer, 'bqplot:rectangle', fit_selection_activate,
+                    fit_selection_deactivate)
 
     @property
     def all_viewers(self):
@@ -492,14 +495,17 @@ class StageThree(HubbleStage):
 
     def _update_viewer_style(self, dark):
         viewers = ['fit_viewer',
+                   'layer_viewer',
                    'comparison_viewer',
                    'morphology_viewer',
                    'prodata_viewer',
                    'class_distr_viewer',
                    'all_distr_viewer',
-                   'sandbox_distr_viewer']
+                   'sandbox_distr_viewer',
+                   ]
 
         viewer_type = ["scatter",
+                       "scatter",
                        "scatter",
                        "scatter",
                        "scatter",

--- a/src/hubbleds/stages/stage_three.vue
+++ b/src/hubbleds/stages/stage_three.vue
@@ -112,7 +112,6 @@
           :class="stage_state.my_galaxies_plot_highlights.includes(stage_state.marker) ? 'pa-1 my-n1' : 'pa-0'"
           outlined
         >
-          <jupyter-widget :widget="viewers.fit_viewer"/>
           <jupyter-widget :widget="viewers.layer_viewer"/>
         </v-card>
       </v-col>

--- a/src/hubbleds/stages/stage_three.vue
+++ b/src/hubbleds/stages/stage_three.vue
@@ -113,6 +113,7 @@
           outlined
         >
           <jupyter-widget :widget="viewers.fit_viewer"/>
+          <jupyter-widget :widget="viewers.layer_viewer"/>
         </v-card>
       </v-col>
     </v-row>

--- a/src/hubbleds/tools/__init__.py
+++ b/src/hubbleds/tools/__init__.py
@@ -2,3 +2,4 @@ from .rest_wavelength_tool import RestWavelengthTool
 from .spectrum_flag_tool import SpectrumFlagTool
 from .wavelength_zoom import WavelengthZoom
 from .hubble_line_fit_tool import HubbleLineFitTool
+from .toggle_layer_tool import LayerToggleTool

--- a/src/hubbleds/tools/toggle_layer_tool.py
+++ b/src/hubbleds/tools/toggle_layer_tool.py
@@ -1,0 +1,37 @@
+from bqplot.marks import Label, Lines
+from echo import add_callback, CallbackProperty
+from glue.config import viewer_tool
+from glue.viewers.common.tool import CheckableTool
+
+from ..utils import H_ALPHA_REST_LAMBDA, MG_REST_LAMBDA
+
+
+@viewer_tool
+class LayerToggleTool(CheckableTool):
+    tool_id = "hubble:togglelayer"
+    action_text = "Toggle 2nd data layer"
+    tool_tip = "Toggle display of the rest wavelength line"
+    mdi_icon = "mdigoogleclassroom"
+
+    base_layer = 'mine'
+    class_layer = 'class'
+
+    class_layer_on = CallbackProperty(False)
+
+    def __init__(self, viewer, **kwargs):
+        super().__init__(viewer, **kwargs)
+        self.active = False
+        
+        # by default, toggle the last layer added
+        self.layer_index = -1
+
+    def activate(self):
+        self.viewer.layers[self.layer_index].visible = True
+        self.class_layer_on = True
+
+    def deactivate(self):
+        self.viewer.layers[self.layer_index].visible = False
+        self.class_layer_on = False
+
+    def _on_view_change(self, event=None):
+        pass

--- a/src/hubbleds/tools/toggle_layer_tool.py
+++ b/src/hubbleds/tools/toggle_layer_tool.py
@@ -1,37 +1,36 @@
 from bqplot.marks import Label, Lines
 from echo import add_callback, CallbackProperty
 from glue.config import viewer_tool
-from glue.viewers.common.tool import CheckableTool
+from glue.viewers.common.tool import CheckableTool, Tool
 
 from ..utils import H_ALPHA_REST_LAMBDA, MG_REST_LAMBDA
 
 
 @viewer_tool
-class LayerToggleTool(CheckableTool):
+class LayerToggleTool(Tool):
     tool_id = "hubble:togglelayer"
-    action_text = "Toggle 2nd data layer"
-    tool_tip = "Toggle display of the rest wavelength line"
-    mdi_icon = "mdigoogleclassroom"
+    action_text = "Toggle display of the classes data"
+    tool_tip = "Toggle display of the classes data"
+    mdi_icon = "mdi-google-classroom"
 
     base_layer = 'mine'
     class_layer = 'class'
 
-    class_layer_on = CallbackProperty(False)
-
     def __init__(self, viewer, **kwargs):
         super().__init__(viewer, **kwargs)
-        self.active = False
-        
-        # by default, toggle the last layer added
-        self.layer_index = -1
+        self.layer_index = 0
+    
 
     def activate(self):
-        self.viewer.layers[self.layer_index].visible = True
-        self.class_layer_on = True
-
-    def deactivate(self):
-        self.viewer.layers[self.layer_index].visible = False
-        self.class_layer_on = False
-
+        # if we have no layers, don't do anything
+        if len(self.viewer.layers) > 0:
+            self.layer_to_toggle.visible = not self.layer_to_toggle.visible
+    
+    def set_layer_to_toggle(self, layer = None):
+        if layer is not None:
+            self.layer_to_toggle = layer
+        else:
+            self.layer_to_toggle = self.viewer.layers[self.layer_index]
+        
     def _on_view_change(self, event=None):
         pass

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -47,9 +47,10 @@ HubbleFitLayerView = cds_viewer(
     name="HubbleFitLayerView",
     viewer_tools=[
         "bqplot:home",
+        "hubble:togglelayer",
+        'bqplot:rectangle',
         "cds:linedraw",
         "hubble:linefit",
-        "hubble:togglelayer"
     ],
     label='Layer View',
     state_cls=HubbleFitViewerState

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -42,6 +42,21 @@ HubbleFitView = cds_viewer(
     state_cls=HubbleFitViewerState
 )
 
+HubbleFitLayerView = cds_viewer(
+    BqplotScatterView,
+    name="HubbleFitLayerView",
+    viewer_tools=[
+        "bqplot:home",
+        "bqplot:rectzoom",
+        "bqplot:rectangle",
+        "cds:linedraw",
+        "hubble:linefit",
+        "hubble:togglelayer"
+    ],
+    label='Fit View',
+    state_cls=HubbleFitViewerState
+)
+
 HubbleScatterView = cds_viewer(
     BqplotScatterView,
     name="HubbleScatterView",

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -47,13 +47,11 @@ HubbleFitLayerView = cds_viewer(
     name="HubbleFitLayerView",
     viewer_tools=[
         "bqplot:home",
-        "bqplot:rectzoom",
-        "bqplot:rectangle",
         "cds:linedraw",
         "hubble:linefit",
         "hubble:togglelayer"
     ],
-    label='Fit View',
+    label='Layer View',
     state_cls=HubbleFitViewerState
 )
 


### PR DESCRIPTION
This PR adds a new viewer (`HubbleFitLayerView`) and tool (`LayerToggleTool`).  It also replaces the the old fit_viewer widget in the vue app (the fit_viewer is still defined in stage3.py)

`HubbleFitLayerView` is essentially the old `HubbleFitView` without the rectangular zoom and with the new layer toggling tool added

`LayerToggleTool` (`hubble:togglelayer`) allows the user to turn a particular layer on and off from the toolbar. The default layer is layer 0 of the viewer, however, a particular layer can be set by either setting 
```python
viewer.toolbar.tools['hubble:togglelayer'].layer_index = -1 # or some index
# OR
layer = viewer.layers[-1] # or however you get the reference to a layer in a viewer
viewer.toolbar.tools['hubble:togglelayer'].set_layer_to_toggle(layer_object)
```
Every time the icon is pressed, the `layer.visible` property is toggled.