### PR TITLE
Ignore step index changes if we aren't on that stage

### DIFF
--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -335,6 +335,10 @@ class StageOne(HubbleStage):
             spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
     def _on_step_index_update(self, index):
+        # If we aren't on this stage, ignore
+        if self.story_state.stage_index != self.index:
+            return
+
         # Change the marker without firing the associated stage callback
         # We can't just use ignore_callback, since other stuff (i.e. the frontend)
         # may depend on marker callbacks

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -259,6 +259,10 @@ class StageTwo(HubbleStage):
             # and start stage 2 at the start coordinates
 
     def _on_step_index_update(self, index):
+        # If we aren't on this stage, ignore
+        if self.story_state.stage_index != self.index:
+            return
+
         # Change the marker without firing the associated stage callback
         # We can't just use ignore_callback, since other stuff (i.e. the frontend)
         # may depend on marker callbacks


### PR DESCRIPTION
This PR, together with https://github.com/cosmicds/cosmicds/pull/154, aims to resolve #36. The issue is indeed callback-related: both stages one and two listen for changes to the story's `step_index`, but we only want them to react to those changes if the story is actually on that stage. This PR adds those checks.