### PR TITLE
add correct axis range behavior when toggling class data layer

### DIFF
--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -402,6 +402,7 @@ class StageThree(HubbleStage):
         
         # add class measurement data and hide by default
         layer_viewer.add_data(class_meas_data)
+        layer_viewer.state.reset_limits()
         class_layer = layer_viewer.layers[-1]
         class_layer.state.zorder=1
         class_layer.state.color="blue"

--- a/src/hubbleds/tools/toggle_layer_tool.py
+++ b/src/hubbleds/tools/toggle_layer_tool.py
@@ -29,10 +29,20 @@ class LayerToggleTool(Tool):
         if len(self.viewer.layers) > 0:
             self.layer_to_toggle.visible = not self.layer_to_toggle.visible
         self.class_layer_toggled += 1
+        
+        if self.layer_to_toggle.visible:
+            x_att = str(self.viewer.state.x_att)
+            y_att = str(self.viewer.state.y_att)
+            # run only the first time the layer is toggled on
+            if self.class_layer_toggled == 1:
+                self.viewer.state.x_att = self.viewer.state.layers_data[self.layer_index].id[x_att]
+                self.viewer.state.y_att = self.viewer.state.layers_data[self.layer_index].id[y_att]
+                self.viewer.state.reset_limits()
     
     def set_layer_to_toggle(self, layer = None):
         if layer is not None:
             self.layer_to_toggle = layer
+            self.layer_index = self.viewer.layers.index(layer)
         else:
             self.layer_to_toggle = self.viewer.layers[self.layer_index]
         

--- a/src/hubbleds/tools/toggle_layer_tool.py
+++ b/src/hubbleds/tools/toggle_layer_tool.py
@@ -38,7 +38,6 @@ class LayerToggleTool(Tool):
                 self.viewer.state.x_att = self.viewer.state.layers_data[self.layer_index].id[x_att]
                 self.viewer.state.y_att = self.viewer.state.layers_data[self.layer_index].id[y_att]
                 self.viewer.state.reset_limits()
-                self.viewer.state.reset_limits()
     
     def set_layer_to_toggle(self, layer = None):
         if layer is not None:


### PR DESCRIPTION
Now, when "Our Data" viewer is loaded, the viewer shows only the range of the students data. Once the class layer has been added, it expands the x/y-axis ranges and keeps them the same regardless of if the class data is show or not