### PR TITLE
Allow showing/hiding of galaxies in selection tool

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
@@ -14,7 +14,7 @@
       class="mb-4"
     >
       <p>
-        Notice that your My Galaxies table now has a row for your selected galaxy, and the marker on your galaxy has changed from green to purple.
+        Notice that your My Galaxies table now has a row for your selected galaxy, and the marker on your galaxy has changed from green to yellow.
       </p>
     </div>
     

--- a/src/hubbleds/components/selection_tool/selection_tool.py
+++ b/src/hubbleds/components/selection_tool/selection_tool.py
@@ -83,7 +83,8 @@ class SelectionTool(v.VueTemplate):
     def show_galaxies(self, show=True):
         if show and self.sdss_layer is None:
             layer = self.widget.layers.add_table_layer(self.table)
-            layer.size_scale = 50
+            layer.marker_type = "gaussian"
+            layer.size_scale = 100
             layer.color = "#00FF00"
             self.sdss_layer = layer
         elif not show:
@@ -104,8 +105,9 @@ class SelectionTool(v.VueTemplate):
         self.selected_count = self.selected_data.shape[0]
         self.table = Table.from_pandas(self.selected_data)
         layer = self.widget.layers.add_table_layer(self.table)
+        layer.marker_type = "gaussian"
         layer.size_scale = 100
-        layer.color = "#FF00FF"
+        layer.color = "#FF0000" # This will mix with #00FF00 above to make yellow
         if self.selected_layer is not None:
             self.widget.layers.remove_layer(self.selected_layer)
         self.selected_layer = layer

--- a/src/hubbleds/components/selection_tool/selection_tool.py
+++ b/src/hubbleds/components/selection_tool/selection_tool.py
@@ -102,8 +102,8 @@ class SelectionTool(v.VueTemplate):
         self.selected_data = self.selected_data.append(galaxy,
                                                        ignore_index=True)
         self.selected_count = self.selected_data.shape[0]
-        table = Table.from_pandas(self.selected_data)
-        layer = self.widget.layers.add_table_layer(table)
+        self.table = Table.from_pandas(self.selected_data)
+        layer = self.widget.layers.add_table_layer(self.table)
         layer.size_scale = 100
         layer.color = "#FF00FF"
         if self.selected_layer is not None:

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -308,6 +308,8 @@ class StageOne(HubbleStage):
             self.story_state.step_complete = True
             self.story_state.step_index = self.stage_state.step_markers.index(
                 new)
+        if advancing and old == "sel_gal1":
+            self.selection_tool.show_galaxies()
         if advancing and old == "sel_gal3":
             self.galaxy_table.selected = []
             self.selection_tool.widget.center_on_coordinates(


### PR DESCRIPTION
This PR adds an option to show/hide the galaxy layer in the selection tool. To set the initial layer visibility, use a `show_galaxies` keyword argument in the selection tool constructor (default is `False`). To change this during runtime, use the `show_galaxies` method with a boolean argument that sets whether or not the layer is displayed (no argument means `True`).

@patudom For testing purposes, I've added an example of enabling this display at a certain point. Feel free to change (or let me know where we want to turn this on and I can tweak it).