### PR TITLE
Updates from state testing, part 1

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
@@ -17,7 +17,7 @@
         Hover your mouse in the Spectrum Viewer. A vertical measuring tool identifies the wavelength as you move the tool left and right.
       </p>
       <p>
-        Align the measuring tool to the <strong>{{ state.element }} (observed)</strong> marker and click. This records the <strong>observed wavelength</strong> in your table.
+        Align the measuring tool to the <strong>{{ state.galaxy.element }} (observed)</strong> marker and click. This records the <strong>observed wavelength</strong> in your table.
       </p>
     </div>
     <v-divider

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
@@ -16,7 +16,7 @@
       <p
         v-if="!state.lambda_on"      
       >
-        Your galaxy spectrum has {{ state.element == 'Mg-I' ? 'a' : 'an' }} {{ state.element }} {{ state.element == 'Mg-I' ? 'absorption' : 'emission' }} line marked.
+        Your galaxy spectrum has {{ state.galaxy.element == 'Mg-I' ? 'a' : 'an' }} {{ state.galaxy.element }} {{ state.galaxy.element == 'Mg-I' ? 'absorption' : 'emission' }} line marked.
       </p>
       <p
         v-if="!state.lambda_used"

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -2,6 +2,7 @@ import logging
 from os.path import join
 from pathlib import Path
 from random import sample
+from turtle import st
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
@@ -9,10 +10,10 @@ from cosmicds.components.generic_state_component import GenericStateComponent
 from cosmicds.components.table import Table
 from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
-from cosmicds.utils import load_template, update_figure_css
+from cosmicds.utils import load_template, update_figure_css, debounce
 from echo import add_callback, ignore_callback, CallbackProperty
 from glue.core import Data
-from glue_jupyter.bqplot.scatter import BqplotScatterView
+from glue.core.message import NumericalDataChangedMessage
 from numpy import isin
 from traitlets import default, Bool
 
@@ -156,13 +157,11 @@ class StageOne(HubbleStage):
         self.stage_state = StageState()
         self.show_team_interface = self.app_state.show_team_interface
 
-        # Set up any Data-based values
-        student_measurements = self.get_data(STUDENT_MEASUREMENTS_LABEL)
-        self.stage_state.gals_total = int(student_measurements.size)
-        measwaves = student_measurements["measwave"]
-        self.stage_state.obswaves_total = measwaves[measwaves != None].size
-        velocities = student_measurements["velocity"]
-        self.stage_state.velocities_total = velocities[velocities != None].size
+        # Set up any Data-based state values
+        self._update_state_from_measurements()
+        self.hub.subscribe(self, NumericalDataChangedMessage,
+                                 filter=lambda msg: msg.data.label == STUDENT_MEASUREMENTS_LABEL,
+                                 handler=self._on_measurements_changed)
 
         # Set up viewers
         spectrum_viewer = self.add_viewer(
@@ -295,6 +294,18 @@ class StageOne(HubbleStage):
         for tool_id in ["hubble:restwave", "hubble:wavezoom", "bqplot:home"]:
             spectrum_viewer.toolbar.set_tool_enabled(tool_id, False)
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_update)
+
+    def _on_measurements_changed(self, msg):
+        self._update_state_from_measurements()
+
+    @debounce(wait=2)
+    def _update_state_from_measurements(self):
+        student_measurements = self.get_data(STUDENT_MEASUREMENTS_LABEL)
+        self.stage_state.gals_total = int(student_measurements.size)
+        measwaves = student_measurements["measwave"]
+        self.stage_state.obswaves_total = measwaves[measwaves != None].size
+        velocities = student_measurements["velocity"]
+        self.stage_state.velocities_total = velocities[velocities != None].size
 
     def _on_marker_update(self, old, new):
         if not self.trigger_marker_update_cb:
@@ -493,10 +504,6 @@ class StageOne(HubbleStage):
         new_value = round(event["domain"]["x"], 0)
         index = self.galaxy_table.index
         data = self.galaxy_table.glue_data
-        curr_value = data["measwave"][index]
-
-        if curr_value is None:
-            self.stage_state.obswaves_total = self.stage_state.obswaves_total + 1
 
         self.stage_state.waveline_set = True
         self.stage_state.lambda_obs = new_value
@@ -522,7 +529,6 @@ class StageOne(HubbleStage):
         velocity = round(self.stage_state.student_vel)
         self.update_data_value(STUDENT_MEASUREMENTS_LABEL, "velocity",
                                velocity, index)
-        self.stage_state.velocities_total = self.stage_state.velocities_total + 1
 
     @property
     def selection_tool(self):
@@ -599,7 +605,6 @@ class StageOne(HubbleStage):
                                  0)
                 self.update_data_value(STUDENT_MEASUREMENTS_LABEL, "velocity",
                                        velocity, index)
-                self.stage_state.velocities_total = self.stage_state.velocities_total + 1
         self.story_state.update_student_data()
         table.update_tool(tool)
 

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -358,7 +358,7 @@ class StageOne(HubbleStage):
 
     def _on_galaxy_update(self, galaxy):
         if galaxy:
-            self.stage_state.load_spectrum_data(galaxy["name"], galaxy["type"])
+            self.story_state.load_spectrum_data(galaxy["name"], galaxy["type"])
             self.galaxy_table.selected = [galaxy]
 
     def _on_galaxy_selected(self, galaxy):

--- a/src/hubbleds/viewers/spectrum_view.py
+++ b/src/hubbleds/viewers/spectrum_view.py
@@ -67,6 +67,7 @@ class SpecView(BqplotScatterView):
         self.figure_size_x = 0
         self.figure_size_y = 230
         self.element = None
+        self._resolution_dirty = True
 
         self.user_line = Lines(
             x=[0, 0],
@@ -249,25 +250,25 @@ class SpecView(BqplotScatterView):
             return
 
         new_x = event['domain']['x']
-        pixel_x = event['pixel']['x']
-        y = event['domain']['y']
-        pixel_y = event['pixel']['y']
-        self.state.resolution_x = (new_x - self.state.x_min) / pixel_x
-        if self.state.resolution_x != 0:
-            self.figure_size_x = (
-                                             self.state.x_max - self.state.x_min) / self.state.resolution_x
-        self.state.resolution_y = (self.state.y_max - y) / (
-                    pixel_y - 10)  # The y-axis has 10px "extra" on the top and bottom
-        if self.state.resolution_y != 0:
-            self.figure_size_y = (
-                                             self.state.y_max - self.state.y_min) / self.state.resolution_y
+
+        if self._resolution_dirty:
+            pixel_x = event['pixel']['x']
+            y = event['domain']['y']
+            pixel_y = event['pixel']['y']
+            self.state.resolution_x = (new_x - self.state.x_min) / pixel_x
+            if self.state.resolution_x != 0:
+                self.figure_size_x = (self.state.x_max - self.state.x_min) / self.state.resolution_x
+            self.state.resolution_y = (self.state.y_max - y) / (
+                        pixel_y - 10)  # The y-axis has 10px "extra" on the top and bottom
+            if self.state.resolution_y != 0:
+                self.figure_size_y = (self.state.y_max - self.state.y_min) / self.state.resolution_y
+            self._resolution_dirty = False
+
         self.user_line_label.text = [self._label_text(new_x)]
         self.user_line.x = [new_x, new_x]
         self.user_line_label.x = [new_x, new_x]
-        self.label_background.x = self._x_background_coordinates(
-            self.user_line_label.x[0])
-        self.label_background.y = self._y_background_coordinates(
-            self.user_line_label.y[0])
+        self.label_background.x = self._x_background_coordinates(self.user_line_label.x[0])
+        self.label_background.y = self._y_background_coordinates(self.user_line_label.y[0])
 
     def _on_click(self, event):
         new_x = event['domain']['x']
@@ -309,6 +310,7 @@ class SpecView(BqplotScatterView):
         self.element_label.text = [element]
         self.element_tick.x = [self.shifted, self.shifted]
         self._update_locations()
+        self._resolution_dirty = True
 
     def add_data(self, data):
         super().add_data(data)


### PR DESCRIPTION
This PR, together with a companion one on the cosmicds repository, contains the first of what I expect will be a few batches of updates resulting from the state testing branch.

This PR includes the following changes:
* Add functionality to restore which galaxy a student had selected
* Update measurement-dependent state values in stage one (i.e. `obswave_total`, `gals_total`, `velocities_total`) automatically whenever the data changes (and based on the loaded data on startup)
* Only update the resolution fields in the spectrum viewer when necessary