### PR TITLE
Updates from state testing, part 2

### DIFF
--- a/src/hubbleds/components/doppler_calc_components/slideshow_doppler_calc_5.vue
+++ b/src/hubbleds/components/doppler_calc_components/slideshow_doppler_calc_5.vue
@@ -837,7 +837,6 @@
             state.doppler_calc_dialog = false; 
             step = 0; 
             state.marker='dop_cal6'; 
-            state.doppler_calc_complete = true;
             student_vel_calc = true}"
         >
           Done

--- a/src/hubbleds/stages/stage_intro.py
+++ b/src/hubbleds/stages/stage_intro.py
@@ -17,6 +17,8 @@ class StageState(CDSState):
 ])
 class StageIntro(Stage):
 
+    _state_cls = StageState
+
     @default('template')
     def _default_template(self):
         return load_template("stage_intro.vue", __file__)
@@ -36,7 +38,6 @@ class StageIntro(Stage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_state = StageState()
         intro_slideshow = IntroSlideshow(self.stage_state, self.app_state)
         self.add_component(intro_slideshow, label='c-intro-slideshow')
         intro_slideshow.observe(self._on_slideshow_complete,

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -123,6 +123,9 @@ class StageState(CDSState):
     def marker_before(self, marker):
         return self.indices[self.marker] < self.indices[marker]
 
+    def marker_after(self, marker):
+        return self.indices[self.marker] > self.indices[marker]
+
 
 @register_stage(story="hubbles_law", index=1, steps=[
     # "Explore celestial sky",
@@ -601,12 +604,11 @@ class StageOne(HubbleStage):
         for item in table.items:
             index = table.indices_from_items([item])[0]
             if index is not None and data["velocity"][index] is None:
-                lamb_obs = data["restwave"][index]
+                lamb_rest = data["restwave"][index]
                 lamb_meas = data["measwave"][index]
-                if lamb_obs is None or lamb_meas is None:
+                if lamb_rest is None or lamb_meas is None:
                     continue
-                velocity = round((3 * (10 ** 5) * (lamb_meas / lamb_obs - 1)),
-                                 0)
+                velocity = velocity_from_wavelengths(lamb_meas, lamb_rest)
                 self.update_data_value(STUDENT_MEASUREMENTS_LABEL, "velocity",
                                        velocity, index)
         self.story_state.update_student_data()

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -126,6 +126,9 @@ class StageState(CDSState):
     def marker_after(self, marker):
         return self.indices[self.marker] > self.indices[marker]
 
+    def marker_reached(self, marker):
+        return self.indices[self.marker] >= self.indices[marker]
+
     def marker_index(self, marker):
         return self.indices[marker]
 
@@ -295,11 +298,13 @@ class StageOne(HubbleStage):
                      self.enable_velocity_tool)
 
         spectrum_viewer = self.get_viewer("spectrum_viewer")
-        restwave_tool = spectrum_viewer.toolbar.tools["hubble:restwave"]
+        spec_toolbar = spectrum_viewer.toolbar
+        restwave_tool = spec_toolbar.tools["hubble:restwave"]
         add_callback(restwave_tool, 'lambda_used', self._on_lambda_used)
         add_callback(restwave_tool, 'lambda_on', self._on_lambda_on)
-        for tool_id in ["hubble:restwave", "hubble:wavezoom", "bqplot:home"]:
-            spectrum_viewer.toolbar.set_tool_enabled(tool_id, False)
+        spec_toolbar.set_tool_enabled("hubble:restwave", self.stage_state.marker_reached("res_wav1"))
+        spec_toolbar.set_tool_enabled("hubble:wavezoom", self.stage_state.marker_reached("obs_wav2"))
+        spec_toolbar.set_tool_enabled("bqplot:home", self.stage_state.marker_reached("obs_wav2"))
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_update)
 
     def _on_measurements_changed(self, msg):

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -22,7 +22,7 @@ from ..data.styles import load_style
 from ..data_management import SDSS_DATA_LABEL, SPECTRUM_DATA_LABEL, \
     STUDENT_MEASUREMENTS_LABEL
 from ..stage import HubbleStage
-from ..utils import GALAXY_FOV, H_ALPHA_REST_LAMBDA, IMAGE_BASE_URL, MG_REST_LAMBDA
+from ..utils import GALAXY_FOV, H_ALPHA_REST_LAMBDA, IMAGE_BASE_URL, MG_REST_LAMBDA, velocity_from_wavelengths
 from ..viewers import SpectrumView
 
 log = logging.getLogger()
@@ -521,9 +521,9 @@ class StageOne(HubbleStage):
         data = self.get_data(STUDENT_MEASUREMENTS_LABEL)
         index = self.galaxy_table.index
         if index is not None:
-            lamb_obs = data["restwave"][index]
+            lamb_rest = data["restwave"][index]
             lamb_meas = data["measwave"][index]
-            velocity = round((3 * (10 ** 5) * (lamb_meas / lamb_obs - 1)), 0)
+            velocity = velocity_from_wavelengths(lamb_meas, lamb_rest)
             self.update_data_value(STUDENT_MEASUREMENTS_LABEL, "velocity",
                                    velocity, index)
             self.story_state.update_student_data()

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -142,6 +142,8 @@ class StageState(CDSState):
 class StageThree(HubbleStage):
     show_team_interface = Bool(False).tag(sync=True)
 
+    _state_cls = StageState
+
     @default('stage_state')
     def _default_state(self):
         return StageState()
@@ -171,7 +173,6 @@ class StageThree(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_state = StageState()
         self.show_team_interface = self.app_state.show_team_interface
 
         student_data = self.get_data(STUDENT_DATA_LABEL)

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -421,8 +421,11 @@ class StageThree(HubbleStage):
         extend_tool(layer_viewer, 'bqplot:rectangle', fit_selection_activate,
                     fit_selection_deactivate)
 
-        # We defer some of the setup for later, to make loading faster
-        add_callback(self.story_state, 'stage_index', self._on_stage_index_changed)
+        # If possible, we defer some of the setup for later, to make loading faster
+        if self.story_state.stage_index != self.index:
+            add_callback(self.story_state, 'stage_index', self._on_stage_index_changed)
+        else:
+            self._deferred_setup()
     
     def _on_marker_update(self, old, new):
         if not self.trigger_marker_update_cb:

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -128,6 +128,9 @@ class StageState(CDSState):
     def marker_before(self, marker):
         return self.indices[self.marker] < self.indices[marker]
 
+    def marker_after(self, marker):
+        return self.indices[self.marker] > self.indices[marker]
+
     def move_marker_forward(self, marker_text, _value=None):
         index = min(self.markers.index(marker_text) + 1, len(self.markers) - 1)
         self.marker = self.markers[index]
@@ -476,7 +479,7 @@ class StageThree(HubbleStage):
         class_layer.state.visible = False
         toggle_tool = layer_viewer.toolbar.tools['hubble:togglelayer']
         toggle_tool.set_layer_to_toggle(class_layer)
-        layer_viewer.toolbar.set_tool_enabled('hubble:togglelayer', False)
+        layer_viewer.toolbar.set_tool_enabled('hubble:togglelayer', not self.stage_state.marker_before("tre_dat2"))
 
         # cosmicds PR157 - turn off fit line label for layer_viewer
         layer_viewer.toolbar.tools["hubble:linefit"].show_labels = False

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -117,6 +117,8 @@ class StageTwo(HubbleStage):
     show_team_interface = Bool(False).tag(sync=True)
     START_COORDINATES = SkyCoord(213 * u.deg, 61 * u.deg, frame='icrs')
 
+    _state_cls = StageState
+
     @default('template')
     def _default_template(self):
         return load_template("stage_two.vue", __file__)
@@ -136,7 +138,6 @@ class StageTwo(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_state = StageState()
         dosdonts_slideshow = DosDonts_SlideShow(self.stage_state)
         self.add_component(dosdonts_slideshow, label='c-dosdonts-slideshow')
 

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -16,7 +16,7 @@ from ..components import DistanceSidebar, DistanceTool, DistanceCalc, StageTwoCo
 from ..components.angsize_dosdonts_slideshow import DosDonts_SlideShow
 from ..data_management import STUDENT_MEASUREMENTS_LABEL
 from ..stage import HubbleStage
-from ..utils import GALAXY_FOV, DISTANCE_CONSTANT, IMAGE_BASE_URL, format_fov
+from ..utils import GALAXY_FOV, DISTANCE_CONSTANT, IMAGE_BASE_URL, distance_from_angular_size, format_fov
 
 log = logging.getLogger()
 
@@ -351,7 +351,7 @@ class StageTwo(HubbleStage):
         index = self.distance_table.index
         if index is None:
             return
-        distance = round(DISTANCE_CONSTANT / self.stage_state.meas_theta, 0)
+        distance = distance_from_angular_size(self.stage_state.meas_theta)
         self.update_data_value("student_measurements", "distance", distance,
                                index)
         if self.stage_state.distance_calc_count == 1:  # as long as at least one thing has been measured, tool is enabled. But if students want to loop through calculation by hand they can.

--- a/src/hubbleds/stages/stage_two_intro.py
+++ b/src/hubbleds/stages/stage_two_intro.py
@@ -18,6 +18,8 @@ class StageState(State):
 ])
 class StageTwoIntro(Stage):
 
+    _state_cls = StageState
+
     @default('template')
     def _default_template(self):
         return load_template("stage_two_intro.vue", __file__)
@@ -37,7 +39,6 @@ class StageTwoIntro(Stage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_state = StageState()
         two_intro_slideshow = TwoIntroSlideShow(self.stage_state,
                                                 self.app_state)
         self.add_component(two_intro_slideshow, label='c-two-intro-slideshow')

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -157,3 +157,9 @@ def vertical_line_mark(layer, x, color, label=None):
     viewer_state = layer.state.viewer_state
     return line_mark(layer, x, viewer_state.y_min, x, viewer_state.y_max,
                      color, label)
+
+def velocity_from_wavelengths(lamb_meas, lamb_rest):
+    return round((3 * (10 ** 5) * (lamb_meas / lamb_rest - 1)), 0)
+
+def distance_from_angular_size(theta):
+    return round(DISTANCE_CONSTANT / theta, 0)


### PR DESCRIPTION
This PR contains another batch of state testing updates. The changes here are:
* If a student has already found a value that is dependent on another one (i.e. velocity depends on rest wavelength), changing the independent value will also update the dependent one.
* Stage three setup is not deferred if stage three is the starting stage. I'll keep thinking of another way to do this, but this at least avoids the situation where the setup isn't triggered. Note that this depends on the index update from https://github.com/cosmicds/cosmicds/pull/162.