### PR TITLE
add angular size scale explainer guideline

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2.vue
@@ -4,7 +4,7 @@
     @back="
       state.marker = 'cho_row1';
     "
-    @next="() => { state.show_ruler = true; state.marker = 'ang_siz3'; console.log(state.show_ruler) }"
+    @next="() => { state.show_ruler = true; state.marker = 'ang_siz2b'; console.log(state.show_ruler) }"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2b.vue
+++ b/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2b.vue
@@ -10,10 +10,10 @@
       class="mb-4"
     >
     <p> 
-      The angular scale is measured in either in degrees (&#176;&thinsp;), arcminutes (&thinsp;'&thinsp;), or arcseconds (&thinsp;"&thinsp;) as you zoom in.  
+      The angular scale is measured in degrees (&#176;&thinsp;), arcminutes (&thinsp;'&thinsp;), or arcseconds (&thinsp;"&thinsp;) as you zoom in.  
     </p>
      <p> 
-      One <strong>arcminute</strong> is 1/60 of a degree, and one <strong>arcsecond</strong> is 1/60 of an arcminute 
+      There are 60 <strong>arcminutes</strong> in 1 degree, and 60 <strong>arcseconds</strong> in 1 arcminute.
     </p>
     <p> The data in your table will be measured in arcseconds.</p>
       

--- a/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2b.vue
+++ b/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas2b.vue
@@ -1,0 +1,22 @@
+<template>
+  <scaffold-alert
+    header-text="Angular Size Measurement"
+    @back="
+      state.marker = 'ang_siz2';
+    "
+    @next="state.marker = 'ang_siz3';"
+  >
+    <div
+      class="mb-4"
+    >
+    <p> 
+      The angular scale is measured in either in degrees (&#176;&thinsp;), arcminutes (&thinsp;'&thinsp;), or arcseconds (&thinsp;"&thinsp;) as you zoom in.  
+    </p>
+     <p> 
+      One <strong>arcminute</strong> is 1/60 of a degree, and one <strong>arcsecond</strong> is 1/60 of an arcminute 
+    </p>
+    <p> The data in your table will be measured in arcseconds.</p>
+      
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_two/guideline_angsize_meas3.vue
@@ -35,7 +35,7 @@
           color="accent"
           elevation="2"
           @click="
-            state.marker = 'ang_siz2'
+            state.marker = 'ang_siz2b'
           "
         >
           back

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -47,6 +47,7 @@ class StageState(CDSState):
         'ang_siz1',
         'cho_row1',
         'ang_siz2',
+        'ang_siz2b',
         'ang_siz3',
         'ang_siz4',
         'ang_siz5',
@@ -70,6 +71,7 @@ class StageState(CDSState):
     csv_highlights = CallbackProperty([
         'ang_siz1',
         'ang_siz2',
+        'ang_siz2b',
         'ang_siz3',
         'ang_siz4',
         'ang_siz5',
@@ -201,6 +203,7 @@ class StageTwo(HubbleStage):
             "guideline_angsize_meas1",
             "guideline_choose_row1",
             "guideline_angsize_meas2",
+            "guideline_angsize_meas2b",
             "guideline_angsize_meas3",
             "guideline_angsize_meas4",
             "guideline_angsize_meas5",

--- a/src/hubbleds/stages/stage_two.vue
+++ b/src/hubbleds/stages/stage_two.vue
@@ -28,6 +28,9 @@
         <c-guideline-angsize-meas2
           v-if="stage_state.marker == 'ang_siz2'"
           v-intersect.once="scrollIntoView" />
+        <c-guideline-angsize-meas2b
+          v-if="stage_state.marker == 'ang_siz2b'"
+          v-intersect.once="scrollIntoView" />
         <c-guideline-angsize-meas3
           v-if="stage_state.marker == 'ang_siz3'"
           v-intersect.once="scrollIntoView" />


### PR DESCRIPTION
Adds a new angular size  guideline after the 2<sup>nd</sup> angular measurements guideline `ang_size2` the text of it is

# Angular Size Measurement
`back = ang_siz2`, `next = ang_siz3`

The angular scale is measured in either in degrees (&#176;&thinsp;), arcminutes (&thinsp;'&thinsp;), or arcseconds (&thinsp;"&thinsp;) as you zoom in.  

One <strong>arcminute</strong> is 1/60 of a degree, and one <strong>arcsecond</strong> is 1/60 of an arcminute 

The data in your table will be measured in arcseconds.</p>