### PR TITLE
All stages ux updates 2

### DIFF
--- a/src/hubbleds/HubbleDS.ipynb
+++ b/src/hubbleds/HubbleDS.ipynb
@@ -17,10 +17,11 @@
     "\n",
     "from cosmicds.app import Application\n",
     "\n",
-    
-    "app = Application(story='hubbles_law', update_db=True, show_team_interface=True, allow_advancing=True, create_new_student=True)\n",
+    "import os\n",
+    "os.environ[\"JUPYTERHUB_USER\"] = \"dummy_student_2698\"\n",
+    "\n",
+    "app = Application(story='hubbles_law', update_db=False, show_team_interface=True, allow_advancing=True, create_new_student=False)\n",
     "# app = Application(story='hubbles_law', update_db=True, show_team_interface=True, allow_advancing=True, student_id=2250)\n",
-
     "\n",
     "app"
    ]

--- a/src/hubbleds/components/age_calc_components/guideline_class_age_range.vue
+++ b/src/hubbleds/components/age_calc_components/guideline_class_age_range.vue
@@ -70,7 +70,7 @@
           color="accent"
           elevation="2"
           @click="() => {
-            const expectedAnswers = [state.low_age, state.high_age];
+            const expectedAnswers = [state.stu_low_age, state.stu_high_age];
             state.marker = validateAnswersJS(['low_age', 'high_age'], expectedAnswers) ? 'cla_age2' : 'cla_age1';
           }"
         >

--- a/src/hubbleds/components/age_calc_components/guideline_class_age_range_c.vue
+++ b/src/hubbleds/components/age_calc_components/guideline_class_age_range_c.vue
@@ -70,7 +70,7 @@
           color="accent"
           elevation="2"
           @click="() => {
-            const expectedAnswers = [state.low_age, state.high_age];
+            const expectedAnswers = [state.cla_low_age, state.cla_high_age];
             state.marker = validateAnswersJS(['low_age', 'high_age'], expectedAnswers) ? 'age_dis1c' : 'cla_age1c';
           }"
         >

--- a/src/hubbleds/components/generic_state_components/stage_three/guideline_class_age_range2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_three/guideline_class_age_range2.vue
@@ -17,8 +17,8 @@
         color="info lighten-1"
         elevation="0"
       >        
-        $$ \text{Low age: } \textcolor{black}{\colorbox{#FFAB91}{ {{ (state.low_age).toFixed(0) }} } } \text{ Gyr} $$
-        $$ \text{High age: } \textcolor{black}{\colorbox{#FFAB91}{ {{ (state.high_age).toFixed(0) }} } } \text{ Gyr} $$
+        $$ \text{Low age: } \textcolor{black}{\colorbox{#FFAB91}{ {{ (state.stu_low_age).toFixed(0) }} } } \text{ Gyr} $$
+        $$ \text{High age: } \textcolor{black}{\colorbox{#FFAB91}{ {{ (state.stu_high_age).toFixed(0) }} } } \text{ Gyr} $$
       </v-card>
       <p class="mt-4">
         At first glance, this may seem like a large spread in possible age values for the universe. But if you think back to what astronomers knew in the 1920’s, the common scientific view was that the universe has always existed. So being able to measure any finite age for the universe was a BIG DEAL. 

--- a/src/hubbleds/components/id_slider/id_slider.py
+++ b/src/hubbleds/components/id_slider/id_slider.py
@@ -59,7 +59,7 @@ class IDSlider(VuetifyTemplate):
         self.selected_id = int(self.ids[self.selected])
         self.thumb_value = self.values[self.selected]
         self.highlighted = self.selected_id in self.highlight_ids
-        for cb in self._refresh_cbs():
+        for cb in self._refresh_cbs:
             cb(self)
 
     def _sort_key(self, id):

--- a/src/hubbleds/components/id_slider/id_slider.py
+++ b/src/hubbleds/components/id_slider/id_slider.py
@@ -18,14 +18,13 @@ class IDSlider(VuetifyTemplate):
     vmax = Int(1).tag(sync=True)
     vmin = Int(0).tag(sync=True)
     
-    def __init__(self, data, id_component, value_component, stage_state, *args, **kwargs):
+    def __init__(self, data, id_component, value_component, *args, **kwargs):
         # NB: We can't call this member value data
         # since VuetifyTemplate already has a data member
         # (that represents the typical Vue data)
         self.glue_data = data
         self.id_component = id_component
         self.value_component = value_component
-        self.state = stage_state
 
         self.default_color = kwargs.get("default_color", "#FF0000")
         self.highlight_ids = kwargs.get("highlight_ids", [])
@@ -34,6 +33,7 @@ class IDSlider(VuetifyTemplate):
         self.color = self.default_color
 
         self._id_change_cbs = CallbackContainer()
+        self._refresh_cbs = CallbackContainer()
 
         self.refresh()
         self._selected_changed({"new": self.selected})
@@ -49,8 +49,6 @@ class IDSlider(VuetifyTemplate):
     def refresh(self):
         self.ids = sorted(self.glue_data[self.id_component], key=self._sort_key)
         self.values = sorted(self.glue_data[self.value_component])
-        self.state.low_age = round(min(self.values))
-        self.state.high_age = round(max(self.values))
         self.vmax = len(self.values) - 1
         if(self.vmax % 2 == 0): # check if even
             self.halfvmax = self.vmax/2
@@ -61,6 +59,8 @@ class IDSlider(VuetifyTemplate):
         self.selected_id = int(self.ids[self.selected])
         self.thumb_value = self.values[self.selected]
         self.highlighted = self.selected_id in self.highlight_ids
+        for cb in self._refresh_cbs():
+            cb(self)
 
     def _sort_key(self, id):
         idx = where(self.glue_data[self.id_component] == id)[0][0]
@@ -73,6 +73,14 @@ class IDSlider(VuetifyTemplate):
 
     def remove_on_id_change(self, callback):
         self._id_change_cbs.remove(callback)
+
+    def on_refresh(self, callback, run=True):
+        self._refresh_cbs.append(callback)
+        if run:
+            callback(self)
+
+    def remove_on_refresh(self, callback):
+        self._refresh_cbs.remove(callback)
 
     @observe('selected')
     def _selected_changed(self, change):

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -189,6 +189,7 @@ class StageThree(HubbleStage):
 
         student_data = self.get_data(STUDENT_DATA_LABEL)
         class_meas_data = self.get_data(CLASS_DATA_LABEL)
+        all_data = self.get_data(ALL_DATA_LABEL)
 
         fit_table = Table(self.session,
                           data=student_data,
@@ -256,14 +257,10 @@ class StageThree(HubbleStage):
         
         self.add_component(hubble_slideshow, label='c-hubble-slideshow')
 
-# for the runner viewer
-# self.add_viewer(RunnerViewer)
-
         add_callback(self.stage_state, 'marker',
                      self._on_marker_update, echo_old=True)
         self.trigger_marker_update_cb = True
 
-        
         # Set up the generic state components
         state_components_dir = str(
             Path(
@@ -341,6 +338,7 @@ class StageThree(HubbleStage):
 
         # Grab data
         class_summ_data = self.get_data(CLASS_SUMMARY_LABEL)
+        classes_summary_data = self.get_data(ALL_CLASS_SUMMARIES_LABEL)
 
         # Set up the listener to sync the histogram <--> scatter viewers
 
@@ -374,6 +372,23 @@ class StageThree(HubbleStage):
             student_slider.update_data(self, msg.data)
         self.hub.subscribe(self, NumericalDataChangedMessage, filter=lambda d: d.label == CLASS_SUMMARY_LABEL, handler=update_student_slider)
 
+        # Create the class slider
+        class_slider_subset_label = "class_slider_subset"
+        self.class_slider_subset = all_data.new_subset(label=class_slider_subset_label)
+        class_slider = IDSlider(classes_summary_data, "class_id", "age", self.stage_state)
+        self.add_component(class_slider, "c-class-slider")
+        def class_slider_change(id, highlighted):
+            self.class_slider_subset.subset_state = all_data['class_id'] == id
+            color = class_slider.highlight_color if highlighted else class_slider.default_color
+            self.class_slider_subset.style.color = color
+
+        class_slider.on_id_change(class_slider_change)
+
+        def update_class_slider(msg):
+            class_slider.update_data(self, msg.data)
+        self.hub.subscribe(self, NumericalDataChangedMessage, filter=lambda d: d.label == ALL_CLASS_SUMMARIES_LABEL, handler=update_class_slider)    
+
+        classes_summary_data = self.get_data(ALL_CLASS_SUMMARIES_LABEL)
 
         not_ignore = {
             fit_table.subset_label: [layer_viewer],
@@ -404,7 +419,7 @@ class StageThree(HubbleStage):
 
         # set reasonable offset for y-axis labels
         # it would be better if axis labels were automatically well placed
-        velocity_viewers = [prodata_viewer, comparison_viewer, layer_viewer]
+        velocity_viewers = [prodata_viewer, comparison_viewer, layer_viewer, all_viewer]
         # velocity_viewers = [prodata_viewer, comparison_viewer, morphology_viewer, layer_viewer]
         for viewer in velocity_viewers:
             viewer.figure.axes[1].label_offset = "5em"
@@ -521,13 +536,15 @@ class StageThree(HubbleStage):
         student_layer.state.color = 'orange'
         student_layer.state.zorder = 3
         student_layer.state.size = 8
+        student_layer.state.visible = False
         all_viewer.add_data(class_meas_data)
-        class_layer = comparison_viewer.layers[-1]
+        class_layer = all_viewer.layers[-1]
         class_layer.state.zorder = 2
         class_layer.state.size = 5
         class_layer.state.color = 'red'
+        class_layer.state.visible = False
         all_viewer.add_data(all_data)
-        all_layer = comparison_viewer.layers[-1]
+        all_layer = all_viewer.layers[-2]
         all_layer.state.zorder = 1
         all_layer.state.visible = False
         all_viewer.state.x_att = all_data.id[dist_attr]

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -48,15 +48,11 @@ class StageState(CDSState):
     hypgal_distance = CallbackProperty(100)
     hypgal_velocity = CallbackProperty(8000)
 
-    # Jon - I'm having an issue where because we call the id_slider twice -once for the student values and once for the class values, the student high/low values are getting overwritten by the call for the class slider. I think we need to add an argument to the id_slider to specify which set of ages to store with each call, but I'm not sure the most efficient way to do this.
-    low_age = CallbackProperty(0)
-    high_age = CallbackProperty(0)
+    stu_low_age = CallbackProperty(0)
+    stu_high_age = CallbackProperty(0)
 
-    # stu_low_age = CallbackProperty(0)
-    # stu_high_age = CallbackProperty(0)
-
-    # cla_low_age = CallbackProperty(0)
-    # cla_high_age = CallbackProperty(0)
+    cla_low_age = CallbackProperty(0)
+    cla_high_age = CallbackProperty(0)
 
     markers = CallbackProperty([
         'exp_dat1',
@@ -366,14 +362,18 @@ class StageThree(HubbleStage):
         # Create the student slider
         student_slider_subset_label = "student_slider_subset"
         self.student_slider_subset = class_meas_data.new_subset(label=student_slider_subset_label)
-        student_slider = IDSlider(class_summ_data, "student_id", "age", self.stage_state, highlight_ids=[self.story_state.student_user["id"]])
+        student_slider = IDSlider(class_summ_data, "student_id", "age", highlight_ids=[self.story_state.student_user["id"]])
         self.add_component(student_slider, "c-student-slider")
         def student_slider_change(id, highlighted):
             self.student_slider_subset.subset_state = class_meas_data['student_id'] == id
             color = student_slider.highlight_color if highlighted else student_slider.default_color
             self.student_slider_subset.style.color = color
+        def student_slider_refresh(slider):
+            self.stage_state.stu_low_age = round(min(slider.values))
+            self.stage_state.stu_high_age = round(max(slider.values))
 
         student_slider.on_id_change(student_slider_change)
+        student_slider.on_refresh(student_slider_refresh)
 
         def update_student_slider(msg):
             student_slider.update_data(self, msg.data)
@@ -382,14 +382,18 @@ class StageThree(HubbleStage):
         # Create the class slider
         class_slider_subset_label = "class_slider_subset"
         self.class_slider_subset = all_data.new_subset(label=class_slider_subset_label)
-        class_slider = IDSlider(classes_summary_data, "class_id", "age", self.stage_state)
+        class_slider = IDSlider(classes_summary_data, "class_id", "age")
         self.add_component(class_slider, "c-class-slider")
         def class_slider_change(id, highlighted):
             self.class_slider_subset.subset_state = all_data['class_id'] == id
             color = class_slider.highlight_color if highlighted else class_slider.default_color
             self.class_slider_subset.style.color = color
+        def class_slider_refresh(slider):
+            self.stage_state.cla_low_age = round(min(slider.values))
+            self.stage_state.cla_high_age = round(max(slider.values))
 
         class_slider.on_id_change(class_slider_change)
+        class_slider.on_refresh(class_slider_refresh)
 
         def update_class_slider(msg):
             class_slider.update_data(self, msg.data)

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -395,6 +395,13 @@ class StageThree(HubbleStage):
         class_slider.on_id_change(class_slider_change)
         class_slider.on_refresh(class_slider_refresh)
 
+        self.hub.subscribe(self, NumericalDataChangedMessage,
+                           filter=lambda msg: msg.data.label == STUDENT_DATA_LABEL,
+                           handler=student_slider.refresh)
+        self.hub.subscribe(self, NumericalDataChangedMessage,
+                           filter=lambda msg: msg.data.label == CLASS_SUMMARY_LABEL,
+                           handler=class_slider.refresh)
+
         def update_class_slider(msg):
             class_slider.update_data(self, msg.data)
         self.hub.subscribe(self, NumericalDataChangedMessage, filter=lambda d: d.label == ALL_CLASS_SUMMARIES_LABEL, handler=update_class_slider)    

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -48,8 +48,15 @@ class StageState(CDSState):
     hypgal_distance = CallbackProperty(100)
     hypgal_velocity = CallbackProperty(8000)
 
+    # Jon - I'm having an issue where because we call the id_slider twice -once for the student values and once for the class values, the student high/low values are getting overwritten by the call for the class slider. I think we need to add an argument to the id_slider to specify which set of ages to store with each call, but I'm not sure the most efficient way to do this.
     low_age = CallbackProperty(0)
     high_age = CallbackProperty(0)
+
+    # stu_low_age = CallbackProperty(0)
+    # stu_high_age = CallbackProperty(0)
+
+    # cla_low_age = CallbackProperty(0)
+    # cla_high_age = CallbackProperty(0)
 
     markers = CallbackProperty([
         'exp_dat1',

--- a/src/hubbleds/stages/stage_three.vue
+++ b/src/hubbleds/stages/stage_three.vue
@@ -363,8 +363,9 @@
     <!--------------------- ALL DATA HUBBLE VIEWER ----------------------->
     <v-row
       class="d-flex align-stretch"
-          v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']"
     >
+          <!-- v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']" -->
+
       <v-col
         cols="12"
         lg="5"
@@ -383,6 +384,9 @@
           <v-lazy>
             <jupyter-widget :widget="viewers.all_viewer"/>
           </v-lazy>
+          <c-class-slider
+            class="slider_card"
+          />
         </v-card>
       </v-col>
     </v-row>

--- a/src/hubbleds/stages/stage_three.vue
+++ b/src/hubbleds/stages/stage_three.vue
@@ -48,7 +48,7 @@
 
     <v-row
       class="d-flex align-stretch"
-      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['exp_dat1'] && stage_state.indices[stage_state.marker] < stage_state.indices['cla_res1']"
+      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['exp_dat1'] && stage_state.indices[stage_state.marker] < stage_state.indices['cla_res1'] || stage_state.indices[stage_state.marker] > stage_state.indices['con_int2'] "
     >
       <v-col
         cols="12"
@@ -172,7 +172,7 @@
 
     <v-row
       class="d-flex align-stretch"
-      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['ran_var1']"
+      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['ran_var1'] && stage_state.indices[stage_state.marker] < stage_state.indices['age_uni1c']"
     > 
       <v-col
         cols="12"
@@ -200,12 +200,6 @@
         <c-guideline-confidence-interval
           v-if="stage_state.marker == 'con_int1'"
           v-intersect.once="scrollIntoView"/>
-        <c-guideline-classmates-results-c
-          v-if="stage_state.marker == 'cla_res1c'"
-          v-intersect.once="scrollIntoView" />
-        <c-guideline-class-age-range-c
-          v-if="stage_state.marker == 'cla_age1c'"
-          v-intersect.once="scrollIntoView"/>
       </v-col>
       <v-col
         cols="12"
@@ -232,10 +226,44 @@
       </v-col>
     </v-row>
 
+    <!--------------------- ALL DATA HUBBLE VIEWER - during class sequence ----------------------->
+    <v-row
+      class="d-flex align-stretch"
+      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['you_age1c']"
+    >
+      <v-col
+        cols="12"
+        lg="5"
+      >
+        <c-guideline-classmates-results-c
+          v-if="stage_state.marker == 'cla_res1c'"
+          v-intersect.once="scrollIntoView" />
+        <c-guideline-class-age-range-c
+          v-if="stage_state.marker == 'cla_age1c'"
+          v-intersect.once="scrollIntoView"/>
+      </v-col>
+      <v-col
+        cols="12"
+        lg="7"
+      >
+        <v-card
+          outlined
+        >
+          <v-lazy>
+            <jupyter-widget :widget="viewers.all_viewer"/>
+          </v-lazy>
+          <c-class-slider 
+            class="slider_card"
+            />
+        </v-card>
+      </v-col>
+    </v-row>
+
+
     <!--------------------- OUR CLASS HISTOGRAM VIEWER ----------------------->
     <v-row
       class="d-flex align-stretch"
-      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int1']"
+      v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int1'] && stage_state.indices[stage_state.marker] < stage_state.indices['age_uni1c']"
     >
       <v-col
         cols="12"
@@ -243,9 +271,6 @@
       >
         <c-guideline-class-age-distribution
           v-if="stage_state.marker == 'age_dis1'"
-          v-intersect.once="scrollIntoView"/>
-        <c-guideline-class-age-distribution-c
-          v-if="stage_state.marker == 'age_dis1c'"
           v-intersect.once="scrollIntoView"/>
       </v-col>
       <v-col
@@ -264,27 +289,18 @@
       </v-col>
     </v-row>
 
-    <c-guideline-confidence-interval-reflect2
-      v-if="stage_state.marker == 'con_int2'"
-      v-intersect.once="scrollIntoView"/>
-    <c-guideline-confidence-interval-reflect2-c
-      v-if="stage_state.marker == 'con_int2c'"
-      v-intersect.once="scrollIntoView"/>
-
-
-
     <!--------------------- ALL DATA HISTOGRAM VIEWER ----------------------->
     <v-row
       class="d-flex align-stretch"
-          v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']"
+          v-if="stage_state.indices[stage_state.marker] > stage_state.indices['cla_age1c']"
     >
       <v-col
         cols="12"
         lg="5"
       >
-        <v-btn
-          block
-        >PLACEHOLDER 5 {{ stage_state.marker }}</v-btn>
+        <c-guideline-class-age-distribution-c
+          v-if="stage_state.marker == 'age_dis1c'"
+          v-intersect.once="scrollIntoView"/>
       </v-col>
       <v-col
         cols="12"
@@ -302,8 +318,15 @@
       </v-col>
     </v-row>
 
+    <c-guideline-confidence-interval-reflect2
+      v-if="stage_state.marker == 'con_int2'"
+      v-intersect.once="scrollIntoView"/>
+    <c-guideline-confidence-interval-reflect2-c
+      v-if="stage_state.marker == 'con_int2c'"
+      v-intersect.once="scrollIntoView"/>
+
     <!--------------------- SANDBOX HISTOGRAM VIEWER ----------------------->
-    <v-row
+    <!-- <v-row
       class="d-flex align-stretch"
           v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']"
     >
@@ -329,14 +352,15 @@
           </v-lazy>
         </v-card>
       </v-col>
-    </v-row>
+    </v-row> -->
 
     <!--------------------- MORPHOLOGY HUBBLE VIEWER ----------------------->
     <!-- <v-row
       class="d-flex align-stretch"
-          v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']"
     >
-      <v-col
+          <!-- v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']" -->
+
+      <!-- <v-col
         cols="12"
         lg="5"
       >
@@ -356,40 +380,14 @@
           <v-lazy>
             <jupyter-widget :widget="viewers.morphology_viewer"/>
           </v-lazy>
-        </v-card>
-      </v-col>
-    </v-row> -->
-
-    <!--------------------- ALL DATA HUBBLE VIEWER ----------------------->
-    <v-row
-      class="d-flex align-stretch"
-    >
-          <!-- v-if="stage_state.indices[stage_state.marker] > stage_state.indices['con_int2']" -->
-
-      <v-col
-        cols="12"
-        lg="5"
-      >
-        <v-btn
-          block
-        >PLACEHOLDER 8 {{ stage_state.marker }}</v-btn>
-      </v-col>
-      <v-col
-        cols="12"
-        lg="7"
-      >
-        <v-card
-          outlined
-        >
-          <v-lazy>
-            <jupyter-widget :widget="viewers.all_viewer"/>
-          </v-lazy>
           <c-class-slider
             class="slider_card"
           />
         </v-card>
       </v-col>
-    </v-row>
+    </v-row> -->
+ -->
+
   </v-container>
 </template>
 

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -65,7 +65,6 @@ class StageState(CDSState):
 
     step_markers = CallbackProperty([
         'ang_siz1',
-        'ang_siz3',
         'est_dis1'
     ])
 
@@ -112,7 +111,6 @@ class StageState(CDSState):
 
 
 @register_stage(story="hubbles_law", index=3, steps=[
-    "ANGULAR SIZES",
     "MEASURE SIZE",
     "ESTIMATE DISTANCE"
 ])


### PR DESCRIPTION
- Set up all_viewer slider
- Fix Stage 2 steps that go with step indices
- @Carifio24, see commit 3a7a26b76b1f990a9451fc7b8b717e20ce5ef375. There is an issue here which I think has a fairly straightforward fix, but I wasn't sure of the right syntax to pass the relevant information with the separate student & class slider id calls. Please take a look when you get a chance.
- Put the Stage 3 repeated class guidelines in the right places with the correct viewers in Stage 3 vue layout.