### PR TITLE
Change stage three to use layer artist fetching method

### DIFF
--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -511,7 +511,8 @@ class StageThree(HubbleStage):
             layer_viewer.toolbar.set_tool_enabled('hubble:togglelayer', True)
         if advancing and new == "tre_lin1":
             layer_viewer = self.get_viewer("layer_viewer")
-            class_layer = layer_viewer.layers[-1]
+            class_meas_data = self.get_data(CLASS_DATA_LABEL)
+            class_layer = layer_viewer.layer_artist_for_data(class_meas_data)
             class_layer.state.visible = False
         if advancing and new == "you_age1":
             layer_viewer = self.get_viewer("layer_viewer")                
@@ -530,12 +531,12 @@ class StageThree(HubbleStage):
             self._update_hypgal_info()
         if advancing and new == "tre_lin2c":
             layer_viewer = self.get_viewer("layer_viewer")
-            print("tre_lin2c:", layer_viewer.layers)
-            best_fit_layer = layer_viewer.layers[-1]
+            best_fit_subset = self.get_data(STUDENT_DATA_LABEL).subsets[0]
+            best_fit_layer = layer_viewer.layer_artist_for_data(best_fit_subset)
             best_fit_layer.state.visible = False
-            class_layer = layer_viewer.layers[-2]
+            class_layer = layer_viewer.layer_artist_for_data(self.get_data(CLASS_DATA_LABEL))
             class_layer.state.visible = True
-            student_layer = layer_viewer.layers[-3]
+            student_layer = layer_viewer.layer_artist_for_data(self.get_data(STUDENT_DATA_LABEL))
             student_layer.state.visible = False    
             layer_viewer.toolbar.tools["hubble:linefit"].show_labels = True  
         if advancing and new == "age_uni1":
@@ -569,7 +570,7 @@ class StageThree(HubbleStage):
         # add class measurement data and hide by default
         layer_viewer.add_data(class_meas_data)
         layer_viewer.state.reset_limits()
-        class_layer = layer_viewer.layers[-1]
+        class_layer = layer_viewer.layer_artist_for_data(class_meas_data)
         class_layer.state.zorder = 1
         class_layer.state.color = "blue"
         class_layer.state.visible = False
@@ -591,16 +592,16 @@ class StageThree(HubbleStage):
         add_callback(toggle_tool, 'class_layer_toggled', self._on_class_layer_toggled) 
         add_callback(self.story_state, 'has_best_fit_galaxy', self._on_best_fit_galaxy_added)
 
-        student_layer_index = -2 if len(comparison_viewer.layers) == 2 else -1
-        student_layer = comparison_viewer.layers[student_layer_index]
+        student_layer = comparison_viewer.layer_artist_for_data(student_data)
         student_layer.state.color = 'orange'
         student_layer.state.zorder = 3
         student_layer.state.size = 8
         comparison_viewer.add_data(class_meas_data)
-        class_layer = comparison_viewer.layers[-2]
-        print(comparison_viewer.layers)
-        comparison_viewer.layers[-3].state.visible = False # Turn off student's own data on comparison viewer, layer -3 here.
-        comparison_viewer.layers[-4].state.visible = False # Turn off best fit subset view on comparison viewer
+        class_layer = comparison_viewer.layer_artist_for_data(class_meas_data)
+        comparison_viewer.layer_artist_for_data(student_data).state.visible = False # Turn off student's own data on comparison viewer, layer -3 here.
+        if len(student_data.subsets) > 0:
+            best_fit_subset = student_data.subsets[0]
+            comparison_viewer.layer_artist_for_data(best_fit_subset).state.visible = False # Turn off best fit subset view on comparison viewer
         class_layer.state.visible = False  # Turn off layer with the whole class
         class_layer.state.zorder = 2
         class_layer.state.color = 'red'
@@ -610,19 +611,19 @@ class StageThree(HubbleStage):
         comparison_viewer.state.reset_limits()
 
         all_data = self.get_data(ALL_DATA_LABEL)
-        student_layer = all_viewer.layers[-1]
+        student_layer = all_viewer.layer_artist_for_data(student_data)
         student_layer.state.color = 'orange'
         student_layer.state.zorder = 3
         student_layer.state.size = 8
         student_layer.state.visible = False
         all_viewer.add_data(class_meas_data)
-        class_layer = all_viewer.layers[-1]
+        class_layer = all_viewer.layer_artist_for_data(class_meas_data)
         class_layer.state.zorder = 2
         class_layer.state.size = 5
         class_layer.state.color = 'red'
         class_layer.state.visible = False
         all_viewer.add_data(all_data)
-        all_layer = all_viewer.layers[-2]
+        all_layer = all_viewer.layer_artist_for_data(all_data)
         all_layer.state.zorder = 1
         all_layer.state.visible = False
         all_viewer.state.x_att = all_data.id[dist_attr]
@@ -662,16 +663,16 @@ class StageThree(HubbleStage):
             viewer.figure.axes[1].num_ticks = 5
             if viewer != all_distr_viewer:
                 viewer.add_data(class_summ_data)
-                layer = viewer.layers[-1]
+                layer = viewer.layer_artist_for_data(class_summ_data)
                 layer.state.color = 'red'
                 layer.state.alpha = 0.5
             if viewer != class_distr_viewer:
                 viewer.add_data(students_summary_data)
-                layer = viewer.layers[-1]
+                layer = viewer.layer_artist_for_data(students_summary_data)
                 layer.state.color = 'blue'
                 layer.state.alpha = 0.5
                 viewer.add_data(classes_summary_data)
-                layer = viewer.layers[-1]
+                layer = viewer.layer_artist_for_data(classes_summary_data)
                 layer.state.color = '#f0c470'
                 layer.state.alpha = 0.5
                 viewer.state.normalize = True


### PR DESCRIPTION
This PR changes stage three to use the method added in https://github.com/cosmicds/cosmicds/pull/168, rather than relying on indices of layers in viewers, which is very fragile.

@patudom I don't remember exactly how the layers are supposed to look at this point, so let me know if anything looks off here.