### PR TITLE
center header on large screens

### DIFF
--- a/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
+++ b/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
@@ -260,11 +260,16 @@
             <v-row 
               justify="center"
             >
-              <h4
-                class="mb-2"
+              <div
+                class="text-center"
+                style="width: 100%;"
               >
-                One degree of angular size in the sky is a pinky's width at arm's length. 
-              </h4>
+                <h4
+                  class="mb-2"
+                >
+                  One degree XX of angular size in the sky is a pinky's width at arm's length. 
+                </h4>
+              </div>
               <v-img
                 class="mx-a"
                 contain

--- a/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
+++ b/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
@@ -267,7 +267,7 @@
                 <h4
                   class="mb-2"
                 >
-                  One degree XX of angular size in the sky is a pinky's width at arm's length. 
+                  One degree of angular size in the sky is a pinky's width at arm's length. 
                 </h4>
               </div>
               <v-img


### PR DESCRIPTION
Header had been spreading onto 2 columns when screen breakpoint is large enough. Adjusted such that header is forced to stay on its own line at all times.