### PR TITLE
Add index to keep track of progress with prodata components

### DIFF
--- a/src/hubbleds/components/prodata_components/guideline_professional_data0.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data0.vue
@@ -5,8 +5,7 @@
       state.marker = 'acc_unc1';
     "
     @next="
-      state.marker = 'pro_dat1';
-      state.prodata_response = false;
+      advance('pro_dat1');
     "
   >
     <div

--- a/src/hubbleds/components/prodata_components/guideline_professional_data1.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data1.vue
@@ -35,7 +35,7 @@
           :incorrect-answers="[0]"
           :correct-answers="[1]"
           :neutral-answers="[2]"
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat1"
         >
         </mc-radiogroup>
@@ -57,7 +57,7 @@
           elevation="2"
           @click="
               () => {
-                state.marker = 'pro_dat0'
+                state.marker = 'pro_dat0';
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data1.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data1.vue
@@ -35,7 +35,7 @@
           :incorrect-answers="[0]"
           :correct-answers="[1]"
           :neutral-answers="[2]"
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat1"
         >
         </mc-radiogroup>
@@ -67,7 +67,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -77,7 +77,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -85,9 +85,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat2';
-                
+               advance('pro_dat2');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data2.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data2.vue
@@ -29,7 +29,7 @@
           ]"
           :correct-answers="[0]"
           :neutral-answers='[1]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat2"
         >
         </mc-radiogroup>
@@ -61,7 +61,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -71,7 +71,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -79,8 +79,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat4';
+                advance('pro_dat4');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data2.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data2.vue
@@ -29,7 +29,7 @@
           ]"
           :correct-answers="[0]"
           :neutral-answers='[1]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat2"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/guideline_professional_data3.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data3.vue
@@ -35,7 +35,7 @@
           ]'
           :correct-answers="[0]"
           :neutral-answers='[1,2]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat3"
         >
         </mc-radiogroup>
@@ -67,7 +67,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -77,7 +77,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -85,8 +85,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat4';
+                advance('pro_dat4');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data3.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data3.vue
@@ -35,7 +35,7 @@
           ]'
           :correct-answers="[0]"
           :neutral-answers='[1,2]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat3"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
@@ -57,7 +57,7 @@
           elevation="2"
           @click="
               () => {
-                state.marker = 'pro_dat3';
+                state.marker = 'pro_dat2';
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
@@ -27,7 +27,7 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[0,1]"
           :neutral-answers='[]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat4"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data4.vue
@@ -27,7 +27,7 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[0,1]"
           :neutral-answers='[]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat4"
         >
         </mc-radiogroup>
@@ -38,7 +38,7 @@
         rows="2"
         label="Why?"
         tag="prodata-free-4"
-        v-if='state.prodata_response'
+        v-if='can_advance'
       ></free-response>
     </div>
     
@@ -67,7 +67,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -77,7 +77,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -85,8 +85,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat5';
+                advance('pro_dat5');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data5.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data5.vue
@@ -39,7 +39,7 @@
           ]"
           :correct-answers="[2]"
           :neutral-answers='[0,1]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat5"
         >
         </mc-radiogroup>
@@ -61,9 +61,7 @@
           elevation="2"
           @click="
               () => {
-                console.log('Back!');
                 state.marker = 'pro_dat4';
-                console.log(state.marker);
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data5.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data5.vue
@@ -39,7 +39,7 @@
           ]"
           :correct-answers="[2]"
           :neutral-answers='[0,1]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat5"
         >
         </mc-radiogroup>
@@ -61,7 +61,9 @@
           elevation="2"
           @click="
               () => {
+                console.log('Back!');
                 state.marker = 'pro_dat4';
+                console.log(state.marker);
               }
             "
         >
@@ -71,7 +73,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -81,7 +83,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -89,8 +91,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat6';
+                advance('pro_dat6');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data6.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data6.vue
@@ -29,7 +29,7 @@
   ['Try again! Compare the slope of best fit for our data to the slope for the HST data','Correct! The slope of best fit for our data is steeper than it is for the HST data', ]"
           :correct-answers="(parseFloat(state.hst_age) < parseFloat(Math.round(state.our_age).toFixed(0))) ? [0] : [1]"
           :neutral-answers="(parseFloat(state.hst_age) < parseFloat(Math.round(state.our_age).toFixed(0))) ? [1] : [0]"
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat6"
         >
         </mc-radiogroup>
@@ -66,7 +66,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -76,7 +76,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -84,8 +84,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat7';
+                advance('pro_dat7');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data6.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data6.vue
@@ -29,7 +29,7 @@
   ['Try again! Compare the slope of best fit for our data to the slope for the HST data','Correct! The slope of best fit for our data is steeper than it is for the HST data', ]"
           :correct-answers="(parseFloat(state.hst_age) < parseFloat(Math.round(state.our_age).toFixed(0))) ? [0] : [1]"
           :neutral-answers="(parseFloat(state.hst_age) < parseFloat(Math.round(state.our_age).toFixed(0))) ? [1] : [0]"
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat6"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/guideline_professional_data7.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data7.vue
@@ -24,7 +24,7 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[0,1]"
           :neutral-answers='[]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat7"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/guideline_professional_data7.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data7.vue
@@ -24,7 +24,7 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[0,1]"
           :neutral-answers='[]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat7"
         >
         </mc-radiogroup>
@@ -35,7 +35,7 @@
         rows="2"
         label="Why?"
         tag="prodata-free-7"
-        v-if='state.prodata_response'
+        v-if='can_advance'
       ></free-response>
     </div>
     
@@ -64,7 +64,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -74,7 +74,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -82,8 +82,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat8';
+                advance('pro_dat8');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data8.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data8.vue
@@ -93,8 +93,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'pro_dat9';
+                advance('pro_dat9');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data9.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data9.vue
@@ -34,7 +34,7 @@
           ]"
           :correct-answers="[2]"
           :neutral-answers='[0,1]'
-          :selected-callback="(state) => { $emit('ready'); }"
+          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
           score-tag="pro-dat9"
         >
         </mc-radiogroup>
@@ -66,7 +66,7 @@
       <v-col
         cols="6"
         class="shrink"
-        v-if="!state.prodata_response"
+        v-if="!can_advance"
       >
         <div
           style="font-size: 16px;"
@@ -76,7 +76,7 @@
       </v-col>
       <v-col
         class="shrink"
-        v-if="state.prodata_response"
+        v-if="can_advance"
       >
         <v-btn
           class="black--text"
@@ -84,8 +84,7 @@
           elevation="2"
           @click="
               () => {
-                state.prodata_response = false;
-                state.marker = 'sto_fin1';
+                advance('sto_fin1');
               }
             "
         >

--- a/src/hubbleds/components/prodata_components/guideline_professional_data9.vue
+++ b/src/hubbleds/components/prodata_components/guideline_professional_data9.vue
@@ -34,7 +34,7 @@
           ]"
           :correct-answers="[2]"
           :neutral-answers='[0,1]'
-          :selected-callback="(state) => { if (state.correct) { can_advance = true; } }"
+          :selected-callback="(status) => { if (status.correct) { can_advance = true; } }"
           score-tag="pro-dat9"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/prodata_components/prodata_components.py
+++ b/src/hubbleds/components/prodata_components/prodata_components.py
@@ -1,15 +1,31 @@
 import ipyvuetify as v
 from cosmicds.utils import load_template
 from glue_jupyter.state_traitlets_helpers import GlueState
-from traitlets import Bool, Unicode
+from traitlets import Bool, Unicode, observe
 
 
 class ProData(v.VuetifyTemplate):
     template = Unicode().tag(sync=True)
     state = GlueState().tag(sync=True)
     some_state_variable = Bool(False).tag(sync=True)
+    can_advance = Bool(False).tag(sync=True)
 
-    def __init__(self, filename, path, state, *args, **kwargs):
+    def __init__(self, filename, path, state, index, *args, **kwargs):
         self.state = state
         super().__init__(*args, **kwargs)
         self.template = load_template(filename, path)
+        self.index = index
+        self.can_advance = self.state.max_prodata_index > self.index
+
+    def _update_index(self):
+        self.state.max_prodata_index = max(self.state.max_prodata_index, self.index)
+
+    def vue_advance(self, marker):
+        print(f"Advancing to {marker}")
+        self.state.marker = marker
+        self._update_index()
+
+    @observe('can_advance')
+    def on_can_advance(self, change):
+        if change["new"]:
+            self._update_index()

--- a/src/hubbleds/components/prodata_components/prodata_components.py
+++ b/src/hubbleds/components/prodata_components/prodata_components.py
@@ -21,7 +21,6 @@ class ProData(v.VuetifyTemplate):
         self.state.max_prodata_index = max(self.state.max_prodata_index, self.index)
 
     def vue_advance(self, marker):
-        print(f"Advancing to {marker}")
         self.state.marker = marker
         self._update_index()
 

--- a/src/hubbleds/stages/stage_three.py
+++ b/src/hubbleds/stages/stage_three.py
@@ -62,6 +62,8 @@ class StageState(CDSState):
     cla_low_age = CallbackProperty(0)
     cla_high_age = CallbackProperty(0)
 
+    max_prodata_index = CallbackProperty(0)
+
     markers = CallbackProperty([
         'exp_dat1',
         'tre_dat1',
@@ -442,9 +444,9 @@ class StageThree(HubbleStage):
             "guideline_professional_data8",
             "guideline_professional_data9",
         ]
-        for comp in prodata_components:
+        for index, comp in enumerate(prodata_components):
             label = f"c-{comp}".replace("_", "-")
-            component = ProData(comp + ext, path, self.stage_state)
+            component = ProData(comp + ext, path, self.stage_state, index)
             self.add_component(component, label=label) 
 
         # Grab data
@@ -602,8 +604,8 @@ class StageThree(HubbleStage):
         self.story_state.on_class_data_update(self._on_class_data_update)
         self.story_state.on_student_data_update(self._on_student_data_update)
 
-        self.reset_limits_timer = RepeatedTimer(5, self.reset_viewer_limits)
-        self.reset_limits_timer.start()
+        # self.reset_limits_timer = RepeatedTimer(5, self.reset_viewer_limits)
+        # self.reset_limits_timer.start()
     
     def _on_marker_update(self, old, new):
         if not self.trigger_marker_update_cb:

--- a/src/hubbleds/stages/stage_three.vue
+++ b/src/hubbleds/stages/stage_three.vue
@@ -392,39 +392,31 @@
           v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data1
           v-if="stage_state.marker == 'pro_dat1'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data2
           v-if="stage_state.marker == 'pro_dat2'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data3
           v-if="stage_state.marker == 'pro_dat3'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data4
           v-if="stage_state.marker == 'pro_dat4'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data5
           v-if="stage_state.marker == 'pro_dat5'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data6
           v-if="stage_state.marker == 'pro_dat6'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data7
           v-if="stage_state.marker == 'pro_dat7'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data8
           v-if="stage_state.marker == 'pro_dat8'"
           v-intersect.once="scrollIntoView"/>
         <c-guideline-professional-data9
           v-if="stage_state.marker == 'pro_dat9'"
-          v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"/>
+          v-intersect.once="scrollIntoView"/>
         <c-guideline-story-finish
           v-if="stage_state.marker == 'sto_fin1'"
           v-intersect.once="scrollIntoView"/>


### PR DESCRIPTION
This PR looks to fix the issue where students could get stuck in the sequence of prodata components due to the reuse of the `prodata_response` variable in the stage state.

The approach used here is to have a `max_prodata_index` member of the stage state that keeps track of how far a student has advanced in the prodata sequence. Each component now has an internal `can_advance` flag as well as an index. The `can_advance` flag is set based on `max_prodata_index` and the component's index when it is created, and is now what controls the display of state in the template (rather than `state.prodata_response`).

I didn't look for any other places where the same issue could arise, but if there are, this can hopefully be a template for how to solve them.