### PR TITLE
Use visual attribute styling in new subset creation

### DIFF
--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -283,11 +283,11 @@ class HubblesLaw(Story):
             if subset is not None:
                 subset.subset_state = subset_state
             else:
-                # Once glue-core 1.6 is released, we can use color, alpha kwargs here
-                subset = student_data.new_subset(label=BEST_FIT_SUBSET_LABEL, subset=subset_state)
-                subset.style.color = "blue"
-                subset.style.alpha = 1
-                subset.style.markersize = 10
+                student_data.new_subset(label=BEST_FIT_SUBSET_LABEL,
+                                                 subset=subset_state,
+                                                 color="blue",
+                                                 alpha=1,
+                                                 markersize=10)
 
         for cb in self._on_student_data_update_cbs:
             cb()


### PR DESCRIPTION
This PR updates the Hubble story to use new functionality from `glue-core` 1.6 (and thus relies on https://github.com/cosmicds/cosmicds/pull/174). As far as I can tell this only affects one location, but we may as well stay up to date. There probably won't be any apparent change from this update, but the goal is similar to https://github.com/cosmicds/cosmicds/pull/147 - prevent any color-changing flashes when creating a new subset with a specific color.