### PR TITLE
Add guard against using beta test student ID

### DIFF
--- a/src/hubbleds/stage.py
+++ b/src/hubbleds/stage.py
@@ -35,9 +35,10 @@ class HubbleStage(Stage):
         return prepared
 
     def submit_measurement(self, measurement):
-        prepared = self._prepare_measurement(measurement)
-        requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/submit-measurement",
-                     json=prepared)
+        if self.app_state.update_db:
+            prepared = self._prepare_measurement(measurement)
+            requests.put(f"{API_URL}/{HUBBLE_ROUTE_PATH}/submit-measurement",
+                        json=prepared)
 
     def remove_measurement(self, galaxy_name):
         name = str(galaxy_name)
@@ -47,7 +48,7 @@ class HubbleStage(Stage):
         self.remove_data_values("student_measurements", "name", condition,
                                 single=True)
         user = self.app_state.student
-        if user.get("id", None) is not None:
+        if self.app_state.update_db and user.get("id", None) is not None:
             requests.delete(
                 f"{API_URL}/{HUBBLE_ROUTE_PATH}/measurement/{user['id']}/{galaxy_name}")
 

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -429,6 +429,6 @@ class HubblesLaw(Story):
         super().setup_for_student(app_state)
         if self.student_user["id"] in range(2989, 3018):
             print("Warning! You are using the ID of a beta test student.")
-        app_state.update_db = False
+            app_state.update_db = False
         self.fetch_student_data()
         self.fetch_class_data()

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -427,5 +427,8 @@ class HubblesLaw(Story):
 
     def setup_for_student(self, app_state):
         super().setup_for_student(app_state)
+        if self.student_user["id"] in range(2989, 3018):
+            print("Warning! You are using the ID of a beta test student.")
+        app_state.update_db = False
         self.fetch_student_data()
         self.fetch_class_data()


### PR DESCRIPTION
This PR adds some logic that throws a `ValueError` if the student ID is between 2989 and 3017, which is the range of IDs used for the beta test students.