### PR TITLE
Call galaxy selection logic during initialization

### DIFF
--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -310,6 +310,8 @@ class StageOne(HubbleStage):
         spec_toolbar.set_tool_enabled("hubble:restwave", self.stage_state.marker_reached("res_wav1"))
         spec_toolbar.set_tool_enabled("hubble:wavezoom", self.stage_state.marker_reached("obs_wav2"))
         spec_toolbar.set_tool_enabled("cds:home", self.stage_state.marker_reached("obs_wav2"))
+        if self.stage_state.galaxy:
+            self._on_galaxy_update(self.stage_state.galaxy)
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_update)
         
         


### PR DESCRIPTION
This PR fixes an issue with re-selecting the stored selected galaxy in the spectrum viewer. This originally worked, but the logic for this was broken when we moved to initializing the stage state before the stage itself - this means that the `galaxy` member doesn't get updated after the stage constructor and the callback isn't triggered. This PR adds an explicit call (if the selected galaxy isn't empty) that will make the galaxy actually be selected in the table/spectrum viewer.