### PR TITLE
Change from CDS to bqplot home tool

### DIFF
--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -295,7 +295,7 @@ class StageOne(HubbleStage):
         spec_toolbar.set_tool_enabled("hubble:wavezoom",
                                       self.stage_state.marker_reached(
                                           "obs_wav2"))
-        spec_toolbar.set_tool_enabled("cds:home",
+        spec_toolbar.set_tool_enabled("bqplot:home",
                                       self.stage_state.marker_reached(
                                           "obs_wav2"))
         if self.stage_state.galaxy:
@@ -330,7 +330,7 @@ class StageOne(HubbleStage):
 
         if self.stage_state.marker_reached("obs_wav2"):
             spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
-            spectrum_viewer.toolbar.set_tool_enabled("cds:home", True)
+            spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
         # Uncomment this to pre-fill galaxy data for convenience when testing later stages
         # self.vue_fill_data()        
@@ -393,7 +393,7 @@ class StageOne(HubbleStage):
         if advancing and new == "obs_wav2":
             spectrum_viewer = self.get_viewer("spectrum_viewer")
             spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
-            spectrum_viewer.toolbar.set_tool_enabled("cds:home", True)
+            spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
     def _on_step_index_update(self, index):
         # If we aren't on this stage, ignore

--- a/src/hubbleds/viewers/spectrum_view.py
+++ b/src/hubbleds/viewers/spectrum_view.py
@@ -52,7 +52,7 @@ class SpecView(BqplotScatterView):
     _subset_artist_cls = SpectrumViewLayerArtist
 
     inherit_tools = False
-    tools = ['cds:home', 'hubble:wavezoom', 'hubble:restwave','cds:info']
+    tools = ['bqplot:home', 'hubble:wavezoom', 'hubble:restwave','cds:info']
     _state_cls = SpectrumViewerState
     show_line = Bool(True)
     LABEL = "Spectrum Viewer"

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -32,7 +32,7 @@ HubbleFitView = cds_viewer(
     BqplotScatterView,
     name="HubbleFitView",
     viewer_tools=[
-        "cds:home",
+        "bqplot:home",
         "bqplot:rectzoom",
         "bqplot:rectangle",
         "cds:linedraw",
@@ -46,7 +46,7 @@ HubbleFitLayerView = cds_viewer(
     BqplotScatterView,
     name="HubbleFitLayerView",
     viewer_tools=[
-        # "cds:home",
+        # "bqplot:home",
         # 'bqplot:rectangle',
         "hubble:linefit",
         "hubble:linedraw",
@@ -60,7 +60,7 @@ HubbleScatterView = cds_viewer(
     BqplotScatterView,
     name="HubbleScatterView",
     viewer_tools=[
-        'cds:home',
+        'bqplot:home',
         'bqplot:rectzoom',
         'hubble:linefit'
     ],
@@ -72,7 +72,7 @@ HubbleHistogramView = cds_viewer(
     BqplotHistogramView,
     name="HubbleHistogramView",
     viewer_tools=[
-        "cds:home",
+        "bqplot:home",
         "bqplot:xzoom",
     ],
     label="Class Histogram"
@@ -82,7 +82,7 @@ HubbleClassHistogramView = cds_viewer(
     BqplotHistogramView,
     name="HubbleClassHistogramView",
     viewer_tools=[
-        "cds:home",
+        "bqplot:home",
         "bqplot:xzoom",
         "bqplot:xrange"
     ],


### PR DESCRIPTION
This PR changes any uses of the `cds:home` tool to uses the glue-jupyter `bqplot:home` tool (see https://github.com/cosmicds/cosmicds/pull/183). This should fix any issues with the home tool (we have it using the reset icon) not working. 