### PR TITLE
Using generic guideline in stage 1

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
@@ -5,10 +5,10 @@
     max-width="800"
     elevation="6"
     header-text="Choose a Row"
-    @back="() => state.marker = 'sel_gal3'"
-    @next="() => state.marker = 'mee_spe1'"
-    next-text="Select a galaxy from your table."
-    :can-advance="() => state.spec_viewer_reached"
+    @back="() => { state.marker = 'sel_gal3'; }"
+    @next="() => { state.marker = 'mee_spe1'; }"
+    next-content="Select a galaxy from your table."
+    :can-advance="(state) => state.spec_viewer_reached"
     :state="state"
   >
     <div class="mb-4">

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
@@ -1,15 +1,16 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Choose a Row"
+    @back="() => state.marker = 'sel_gal3'"
+    @next="() => state.marker = 'mee_spe1'"
+    next-text="Select a galaxy from your table."
+    :can-advance="() => state.spec_viewer_reached"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Choose a Row
-    </h3>
     <div class="mb-4">
       <p>
       Let's look at the light spectrum for one of your galaxies.
@@ -18,56 +19,7 @@
       Click on a row in your table to choose that galaxy.
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal3';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        cols="6"
-        class="shrink"
-        v-if="!state.spec_viewer_reached"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Select a galaxy from your table.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.spec_viewer_reached"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'mee_spe1';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Select a Galaxy"
+    @back="() => { state.marker = 'dop_cal2'; }"
+    @next="() => { state.marker = 'dop_cal4'; }"
+    :can-advance="(state) => state.doppler_calc_reached"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Select a Galaxy
-    </h3>
+    <template #next-content>
+      Select a galaxy from your table.
+    </template>
+    
     <div class="mb-4">
       <p>
         Click on a row in your table to select one of the galaxies.
@@ -18,56 +22,7 @@
         You will calculate the velocity for this galaxy using the Doppler equation.
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'dop_cal2';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        cols="6"
-        class="shrink"
-        v-if="!state.doppler_calc_reached"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Select a galaxy from your table.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.doppler_calc_reached"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'dop_cal4';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
@@ -10,7 +10,7 @@
     :can-advance="(state) => state.doppler_calc_reached"
     :state="state"
   >
-    <template #next-content>
+    <template #before-next>
       Select a galaxy from your table.
     </template>
     

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_4.vue
@@ -1,16 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
       class="mb-4 mx-auto doppler_alert"
       color="info"
       elevation="6"
       max-width="800"
+      header-text="Input Wavelengths"
+      @back="() => { state.marker = 'dop_cal3'; }"
+      :state="state"
+      @next="() => 
+        {
+          const expectedAnswers = [state.lambda_obs, state.lambda_rest];
+          state.marker = validateAnswersJS(['lam_obs', 'lam_rest'], expectedAnswers) ? 'dop_cal5' : 'dop_cal4';
+          state.doppler_calc_dialog = !!validateAnswersJS(['lam_obs', 'lam_rest'], expectedAnswers);
+        }"
   >
-    <h3
-        class="mb-4"
-    >
-      Input Wavelengths
-    </h3>
-
     <div
         v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
         class="mb-4"
@@ -117,47 +120,7 @@
     >
       Not quite. Make sure you haven't reversed the rest and observed wavelength values.
     </v-alert>
-    <v-divider
-        class="my-4"
-    >
-    </v-divider>
-    <v-row
-        align="center"
-        no-gutters
-    >
-      <v-col>
-        <v-btn
-            class="black--text"
-            color="accent"
-            elevation="2"
-            @click="
-            state.marker = 'dop_cal3';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-          class="shrink"
-      >
-        <v-btn
-            class="black--text"
-            color="accent"
-            elevation="2"
-            @click="() => {
-            const expectedAnswers = [state.lambda_obs, state.lambda_rest];
-            state.marker = validateAnswersJS(['lam_obs', 'lam_rest'], expectedAnswers) ? 'dop_cal5' : 'dop_cal4';
-            state.doppler_calc_dialog = !!validateAnswersJS(['lam_obs', 'lam_rest'], expectedAnswers);
-          }"
-        >
-          next
-        </v-btn>
-      </v-col>
-
-    </v-row>
-
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
@@ -11,7 +11,7 @@
       @back="() => { state.marker = 'dop_cal3'; }"
       @next="() => { state.completed = true; }"
   >
-    <template #next-content>
+    <template #before-next>
       Click the <v-icon>mdi-run-fast</v-icon> icon.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
@@ -1,15 +1,20 @@
 <template>
-  <v-alert
+  <scaffold-alert
       class="mb-4 mx-auto"
       color="info"
       elevation="6"
       max-width="800"
+      header-text="Velocity Calculation"
+      :can-advance="(state) => state.velocities_total === 5"
+      next-text="stage 2"
+      :state="state"
+      @back="() => { state.marker = 'dop_cal3'; }"
+      @next="() => { state.completed = true; }"
   >
-    <h3
-        class="mb-4"
-    >
-      Velocity Calculation
-    </h3>
+    <template #next-content>
+      Click the <v-icon>mdi-run-fast</v-icon> icon.
+    </template>
+
     <div
         v-if="state.velocities_total < 5"
         v-intersect="(entries, _observer, intersecting) => {
@@ -37,59 +42,9 @@
         v-if="state.velocities_total === 5"
         class="mb-4"
     >
-      Great work! You have completed Stage 1. Proceed to Stage 2.
+      <p>Great work! You have completed Stage 1. Proceed to Stage 2.</p>
     </div>
-    <v-divider
-        class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-        align="center"
-        no-gutters
-    >
-      <v-col>
-        <v-btn
-            class="black--text"
-            color="accent"
-            elevation="2"
-            @click="
-            state.marker = 'dop_cal3';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-
-      <v-col
-          v-if="state.velocities_total < 5"
-          class="shrink"
-          cols="4"
-      >
-        <div
-            style="font-size: 16px;"
-        >
-          Click the
-          <v-icon>mdi-run-fast</v-icon>
-          icon.
-        </div>
-      </v-col>
-      <v-col
-          v-if="state.velocities_total === 5"
-          class="shrink"
-      >
-        <v-btn
-            class="black--text"
-            color="accent"
-            elevation="2"
-            @click="state.completed = true"
-        >
-          stage 2
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
@@ -1,15 +1,16 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Introducing the Guidelines"
+    @next="state.marker = 'sel_gal1'"
+    :allow-back="false"
   >
-    <h3
-      class="mb-4"
-    >
-      Introducing the Guidelines
-    </h3>
+    <template #back-content>
+      <span>Use left menu to return to Introduction.<br>(Press <v-icon>mdi-menu</v-icon> in upper left if menu is not open)</span>
+    </template>
     <div
       class="mb-4"
     >
@@ -20,47 +21,11 @@
         The information in the guideline boxes will suggest what you should focus on, or what you should do next.  
       </p>
       <p>
-        The images, tables, or graph where the guideline suggests action will also be highlighted with an <b> orange outline </b>
+        The images, tables, or graph where the guideline suggests action will also be highlighted with an <b> orange outline.</b>
       </p>
     </div>
     
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col
-        class="shrink"
-        cols="7"
-        >
-        <span style="font-size: 16px;">Use left menu to return to Introduction.<br>(Press <v-icon>mdi-menu</v-icon> in upper left if menu is not open)</span>
-        
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        class="shrink"
-      ></v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal1'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
@@ -8,7 +8,7 @@
     @next="state.marker = 'sel_gal1'"
     :allow-back="false"
   >
-    <template #back-content>
+    <template #before-back>
       <span>Use left menu to return to Introduction.<br>(Press <v-icon>mdi-menu</v-icon> in upper left if menu is not open)</span>
     </template>
     <div

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
@@ -8,7 +8,7 @@
     @next="state.marker = 'sel_gal1'"
     :allow-back="false"
   >
-    <template #before-back>
+    <template #back-content>
       <span>Use left menu to return to Introduction.<br>(Press <v-icon>mdi-menu</v-icon> in upper left if menu is not open)</span>
     </template>
     <div

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
@@ -1,15 +1,13 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Table Data"
+    @back="() => { state.marker = 'sel_gal1'; }"
+    @next="() => { state.marker = 'sel_gal3'; }"
   >
-    <h3
-      class="mb-4"
-    >
-      Table Data
-    </h3>
     <div
       class="mb-4"
     >
@@ -17,45 +15,7 @@
         Notice that your My Galaxies table now has a row for your selected galaxy, and the marker on your galaxy has changed from green to yellow.
       </p>
     </div>
-    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal1'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal3'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Observed Wavelength"
+    :can-advance="(state) => state.obswaves_total >= 1"
+    @back="() => { state.marker = 'res_wav1'; }"
+    @next="() => { state.marker = 'obs_wav2'; }"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Observed Wavelength
-    </h3>
+    <template #next-content>
+      Measure the observed wavelength.
+    </template>
+
     <div
       class="mb-4"
     >
@@ -20,57 +24,7 @@
         Align the measuring tool to the <strong>{{ state.galaxy.element }} (observed)</strong> marker and click. This records the <strong>observed wavelength</strong> in your table.
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'res_wav1';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      
-      <v-col
-        cols="6"
-        class="shrink"
-        v-if="state.obswaves_total < 1"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Measure the observed wavelength.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.obswaves_total >= 1"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'obs_wav2';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
@@ -10,7 +10,7 @@
     @next="() => { state.marker = 'obs_wav2'; }"
     :state="state"
   >
-    <template #next-content>
+    <template #before-next>
       Measure the observed wavelength.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Observed Wavelength"
+    @back="() => { state.marker = 'obs_wav1'; }"
+    @next="() => { state.marker = 'rep_rem1'; }"
+    :can-advance="(state) => state.zoom_tool_activated"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Observed Wavelength
-    </h3>
+  <template #next-content>
+    Click <v-icon>mdi-select-search</v-icon> to activate tool. Click and drag across the red <strong>{{ state.galaxy.element }} </strong> marker to zoom in.
+  </template>
+
     <div
       class="mb-4"
     >
@@ -25,57 +29,7 @@
         <strong>Tip:</strong> You can re-measure the wavelength as many times as you like. 
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'obs_wav1';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      
-      <v-col
-        cols="6"
-        class="shrink"
-        v-if="!state.zoom_tool_activated"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click <v-icon>mdi-select-search</v-icon> to activate tool. Click and drag across the red <strong>{{ state.galaxy.element }} </strong> marker to zoom in.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.zoom_tool_activated"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'rep_rem1';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
@@ -10,9 +10,9 @@
     :can-advance="(state) => state.zoom_tool_activated"
     :state="state"
   >
-  <template #next-content>
-    Click <v-icon>mdi-select-search</v-icon> to activate tool. Click and drag across the red <strong>{{ state.galaxy.element }} </strong> marker to zoom in.
-  </template>
+    <template #next-content>
+      Click <v-icon>mdi-select-search</v-icon> to activate tool. Click and drag across the red <strong>{{ state.galaxy.element }} </strong> marker to zoom in.
+    </template>
 
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
@@ -10,7 +10,7 @@
     :can-advance="(state) => state.zoom_tool_activated"
     :state="state"
   >
-    <template #next-content>
+    <template #before-next>
       Click <v-icon>mdi-select-search</v-icon> to activate tool. Click and drag across the red <strong>{{ state.galaxy.element }} </strong> marker to zoom in.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Reflect on Your Data"
+    :can-advance="(state) => state.reflection_complete"
+    :state="state"
+    @back="() => { state.marker = 'rep_rem1'; }"
+    @next="() => { state.marker = 'dop_cal0'; }"
   >
-    <h3
-      class="mb-4"
-    >
-      Reflect on Your Data
-    </h3>
+
+    <template #next-content>
+      Click the <strong>REFLECT</strong> button.
+    </template>
 
     <div
       class="mb-4"
@@ -21,57 +25,7 @@
         Click the <strong>REFLECT</strong> button to complete the reflection sequence before moving on.
       </p>
     </div>
-    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'rep_rem1'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        v-if="!state.reflection_complete"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click the <strong>REFLECT</strong> button.
-        </div>
-      </v-col>
-      <v-col
-        v-if="state.reflection_complete"
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'dop_cal0'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
@@ -11,7 +11,7 @@
     @next="() => { state.marker = 'dop_cal0'; }"
   >
 
-    <template #next-content>
+    <template #before-next>
       Click the <strong>REFLECT</strong> button.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
@@ -12,7 +12,7 @@
     "
     :state="state"
   >
-    <template #next-content>
+    <template #before-next>
       Measure wavelength<span v-if="state.obswaves_total < 4">s</span> for {{ 5 - state.obswaves_total }} more <span v-if="state.obswaves_total < 4">galaxies</span><span v-if="state.obswaves_total == 4">galaxy</span>.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
@@ -1,22 +1,21 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    @back="() => { state.marker = 'obs_wav2'; }"
+    @next="() => { state.marker = 'ref_dat1'; }"
+    :can-advance="(state) => state.obswaves_total >= 5"
+    :header-text="() => 
+      state.obswaves_total < 5 ? 'Repeat for Remaining Galaxies' : 'Nice Work'
+    "
+    :state="state"
   >
-    <h3
-      class="mb-4"
-      v-if="state.obswaves_total < 5"
-    >
-      Repeat for Remaining Galaxies
-    </h3>
-    <h3
-      class="mb-4"
-      v-if="state.obswaves_total >= 5"
-    >
-      Nice Work
-    </h3>
+    <template #next-content>
+      Measure wavelength<span v-if="state.obswaves_total < 4">s</span> for {{ 5 - state.obswaves_total }} more <span v-if="state.obswaves_total < 4">galaxies</span><span v-if="state.obswaves_total == 4">galaxy</span>.
+    </template>
+
     <div
       class="mb-4"
       v-if="state.obswaves_total < 5"
@@ -39,57 +38,7 @@
         You can continue to refine your measurements, or, if you are satisfied with your measurements, you can move on.
       </p>
     </div>
-    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'obs_wav2'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        v-if="state.obswaves_total < 5"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Measure wavelength<span v-if="state.obswaves_total < 4">s</span> for {{ 5 - state.obswaves_total }} more <span v-if="state.obswaves_total < 4">galaxies</span><span v-if="state.obswaves_total == 4">galaxy</span>.
-        </div>
-      </v-col>
-      <v-col
-        v-if="state.obswaves_total >= 5"
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'ref_dat1'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
@@ -8,9 +8,10 @@
     :state="state"
     @back="() => { state.marker = 'mee_spe1'; }"
     @next="() => { state.marker = 'obs_wav1'; }"
+    :can-advance="(state) => state.lambda_used"
   >
 
-    <template #next-content>
+    <template #before-next>
       Click the <v-icon>mdi-lambda</v-icon> button.
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Rest Wavelength"
+    :state="state"
+    @back="() => { state.marker = 'mee_spe1'; }"
+    @next="() => { state.marker = 'obs_wav1'; }"
   >
-    <h3
-      class="mb-4"
-    >
-      Rest Wavelength
-    </h3>
+
+    <template #next-content>
+      Click the <v-icon>mdi-lambda</v-icon> button.
+    </template>
+
     <div
       class="mb-4"
     >
@@ -39,57 +43,7 @@
         You can click the <v-icon>mdi-lambda</v-icon> icon again to toggle the rest wavelength back off.
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'mee_spe1';
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      
-      <v-col
-        cols="6"
-        class="shrink"
-        v-if="!state.lambda_used"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click the <v-icon>mdi-lambda</v-icon> button.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.lambda_used"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'obs_wav1';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Select Your Galaxies"
+    @back="() => { state.marker = 'mee_gui1'; }"
+    @next="() => {
+      if (state.gals_total == 0) {
+        state.marker = 'sel_gal2';
+      } else if (state.gals_total > 0) {
+        state.marker = 'sel_gal3';
+      } 
+    }"
   >
-    <h3
-      class="mb-4"
-    >
-      Select Your Galaxies
-    </h3>
     <div
       class="mb-4"
     >
@@ -20,61 +24,7 @@
         This Data Story will focus on a nearby subset of spiral galaxies.
       </p>
     </div>
-    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'mee_gui1'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        v-if="state.gals_total == 0"
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal2'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-      <v-col
-        v-if="state.gals_total > 0"
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal3'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
@@ -10,7 +10,7 @@
     :state="state"
   >
 
-    <template #next-content>
+    <template #before-next>
       <div>
         <div
           v-if="state.gals_total < 5 && state.gals_total > 0"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
@@ -1,15 +1,53 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Select Your Galaxies"
+    @back="() => { state.marker = 'sel_gal1'; }"
+    :can-advance="(_state) => false"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Select Your Galaxies
-    </h3>
+
+    <template #next-content>
+      <div>
+        <v-col
+          v-if="state.gals_total < 5 && state.gals_total > 0"
+          cols="6"
+          class="shrink"
+        >
+          <div
+            style="font-size: 16px;"
+          >
+            Select {{ 5 - state.gals_total }} <span v-if="state.gals_total > 0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
+          </div>
+        </v-col>
+        <v-col
+          v-if="state.gals_total == 0 && !state.gal_selected"
+          cols="6"
+          class="shrink"
+        >
+          <div
+            style="font-size: 16px;"
+          >
+            Click on any green dot.
+          </div>
+        </v-col>
+        <v-col
+          v-if="state.gals_total == 0 && state.gal_selected"
+          cols="6"
+          class="shrink"
+        >
+          <div
+            style="font-size: 16px;"
+          >
+            Click <v-icon>mdi-plus</v-icon> to add galaxy or <v-icon>mdi-cached</v-icon> to choose another
+          </div>
+        </v-col>
+      </div>
+    </template>
+
     <div
       v-if="state.gals_total == 0 && !state.gal_selected"
       class="mb-4"
@@ -34,64 +72,7 @@
         If you’d rather look for another galaxy, click the <v-icon>mdi-cached</v-icon> button to reset the view and choose a different green dot.
       </p>
     </div>
-    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal1'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        v-if="state.gals_total < 5 && state.gals_total > 0"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Select {{ 5 - state.gals_total }} <span v-if="state.gals_total > 0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
-        </div>
-      </v-col>
-      <v-col
-        v-if="state.gals_total == 0 && !state.gal_selected"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click on any green dot.
-        </div>
-      </v-col>
-      <v-col
-        v-if="state.gals_total == 0 && state.gal_selected"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click <v-icon>mdi-plus</v-icon> to add galaxy or <v-icon>mdi-cached</v-icon> to choose another
-        </div>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
@@ -12,39 +12,24 @@
 
     <template #next-content>
       <div>
-        <v-col
+        <div
           v-if="state.gals_total < 5 && state.gals_total > 0"
-          cols="6"
-          class="shrink"
+          style="font-size: 16px;"
         >
-          <div
-            style="font-size: 16px;"
-          >
-            Select {{ 5 - state.gals_total }} <span v-if="state.gals_total > 0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
-          </div>
-        </v-col>
-        <v-col
+          Select {{ 5 - state.gals_total }} <span v-if="state.gals_total > 0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
+        </div>
+        <div
           v-if="state.gals_total == 0 && !state.gal_selected"
-          cols="6"
-          class="shrink"
+          style="font-size: 16px;"
         >
-          <div
-            style="font-size: 16px;"
-          >
-            Click on any green dot.
-          </div>
-        </v-col>
-        <v-col
+          Click on any green dot.
+        </div>
+        <div
           v-if="state.gals_total == 0 && state.gal_selected"
-          cols="6"
-          class="shrink"
+          style="font-size: 16px;"
         >
-          <div
-            style="font-size: 16px;"
-          >
-            Click <v-icon>mdi-plus</v-icon> to add galaxy or <v-icon>mdi-cached</v-icon> to choose another
-          </div>
-        </v-col>
+          Click <v-icon>mdi-plus</v-icon> to add galaxy or <v-icon>mdi-cached</v-icon> to choose another
+        </div>
       </div>
     </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
@@ -11,7 +11,7 @@
     :state="state"
   >
 
-  <template #next-content>
+  <template #before-next>
     Select {{ 5 - state.gals_total }} <span v-if="state.gals_total>0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
   </template>
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Select your Galaxies"
+    @back="() => { state.marker = 'sel_gal1'; }"
+    @next="() => { state.marker = 'cho_row1'; }"
+    :can-advance="(state) => state.gals_total === 5"
+    :state="state"
   >
-    <h3
-      class="mb-4"
-    >
-      Select Your Galaxies
-    </h3>
+
+  <template #next-content>
+    Select {{ 5 - state.gals_total }} <span v-if="state.gals_total>0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
+  </template>
 
     <div
       v-if="state.gals_total == 0 & !state.gal_selected"
@@ -65,56 +69,7 @@
         Let's turn to your table of galaxies.
       </p>
     </div>    
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'sel_gal1'
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      <v-col
-        v-if="state.gals_total < 5"
-        cols="6"
-        class="shrink"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Select {{ 5 - state.gals_total }} <span v-if="state.gals_total>0">more</span> <span v-if="state.gals_total < 4">galaxies</span><span v-if="state.gals_total == 4">galaxy</span>.
-        </div>
-      </v-col>
-      <v-col
-        v-if="state.gals_total >= 5"
-        class="shrink"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'cho_row1'
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 <script>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
@@ -1,15 +1,23 @@
 <template>
-  <v-alert
+  <scaffold-alert
     color="info"
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
+    header-text="Meet the Spectrum Viewer"
+    :can-advance="(state) => state.spec_tutorial_opened"
+    :state="state"
+    @back="() => {
+      state.marker = 'cho_row1';
+      state.spectrum_tool_visible = 0;
+    }"
+    @next="() => { state.marker = 'res_wav1'; }"
   >
-    <h3
-      class="mb-4"
-    >
-      Meet the Spectrum Viewer
-    </h3>
+
+    <template #next-content>
+      Click the <strong>SPECTRUM TUTORIAL</strong> button.
+    </template>
+
     <div
       class="mb-4"
     >
@@ -35,58 +43,7 @@
         You can reopen the <strong>SPECTRUM TUTORIAL</strong> any time you need a refresher about spectra.
       </p>
     </div>
-    <v-divider
-      class="my-4"
-    >
-    </v-divider>
-
-    <v-row
-      align="center"
-      no-gutters
-    >
-      <v-col>
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'cho_row1';
-            state.spectrum_tool_visible = 0;
-          "
-        >
-          back
-        </v-btn>
-      </v-col>
-      <v-spacer></v-spacer>
-      
-      <v-col
-        cols="7"
-        class="shrink"
-        v-if="!state.spec_tutorial_opened"
-      >
-        <div
-          style="font-size: 16px;"
-        >
-          Click the <strong>SPECTRUM TUTORIAL</strong> button.
-        </div>
-      </v-col>
-      <v-col
-        class="shrink"
-        v-if="state.spec_tutorial_opened"
-      >
-        <v-btn
-          class="black--text"
-          color="accent"
-          elevation="2"
-          @click="
-            state.marker = 'res_wav1';
-          "
-        >
-          next
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-alert>
+  </scaffold-alert>
 </template>
 
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
@@ -14,7 +14,7 @@
     @next="() => { state.marker = 'res_wav1'; }"
   >
 
-    <template #next-content>
+    <template #before-next>
       Click the <strong>SPECTRUM TUTORIAL</strong> button.
     </template>
 

--- a/src/hubbleds/components/spectrum_slideshow/spectrum_slideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/spectrum_slideshow.vue
@@ -1,696 +1,715 @@
 <template>
-  <v-btn
-    block
-    color="secondary"
-    elevation="2"
-    @click.stop="() => { dialog = true; opened = true; marker = 'spe_tut1' }"
+  <v-dialog
+      v-model="dialog"
+      persistent
+      max-width="1000px"
+      ref="dialog"
   >
-    Spectrum tutorial
-
-    <v-dialog
-        v-model="dialog"
-        persistent
-        max-width="1000px"
-    >
-      <v-card
-        class="mx-auto"
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        v-bind="attrs"
+        v-on="on"
+        block
+        color="secondary"
+        elevation="2"
+        @click.stop="() => { opened = true; marker = 'spe_tut1' }"
       >
-        <v-toolbar
-          color="secondary"
-          dense
-          dark
+      Spectrum tutorial
+      </v-btn>
+    </template>
+    <v-card
+      class="mx-auto"
+    >
+      <v-toolbar
+        color="secondary"
+        dense
+        dark
+      >
+        <v-toolbar-title
+          class="text-h6 text-uppercase font-weight-regular"
         >
-          <v-toolbar-title
-            class="text-h6 text-uppercase font-weight-regular"
-          >
-            Light and Spectra
-          </v-toolbar-title>
-          <v-spacer></v-spacer>
-          <span
-            @click="
-              () => {
-                $emit('close');
-                dialog = false;
-                if (step === 8) {
-                  step = 0;
-                }
+          Light and Spectra
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <speech-synthesizer
+          :root="() => this.$refs.dialog.$children[1].$el"
+          :selectors="['div.v-toolbar__title', 'div.v-card__text.black--text', 'h3', 'p']"
+          />
+        <span
+          @click="
+            () => {
+              $emit('close');
+              dialog = false;
+              if (step === 8) {
+                step = 0;
               }
-            "
-          >
-            <v-btn icon>
-              <v-icon> mdi-close </v-icon>
-            </v-btn>
-          </span>
-        </v-toolbar>
-
-        <v-window
-          v-model="step"
-          style="height: 70vh;"
-          class="overflow-auto"
+            }
+          "
         >
-          <v-window-item :value="0" 
-            class="no-transition"
-          >
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                    class="d-flex flex-column"
-                    height="100%"
-                    flat
-                    tile
-                  >
-                    <h3
-                      class="mb-4"
-                    >
-                      Refraction and diffraction
-                    </h3>
-                    <div>
-                      <v-card
-                        class="mt-auto mb-4"
-                        flat
-                        color="secondary lighten-3"
-                        light
-                      >                  
-                        <v-card-text
-                          class="black--text"
-                        >
-                          A <strong>spectrum</strong> is created when you pass light from a source through a spectrograph. A <strong>spectrograph</strong> separates the light into its different colors (like a rainbow) and measures how much light there is at each color (i.e. wavelength).
-                        </v-card-text>
-                      </v-card>
-                      <p>
-                        Diffraction gratings and prisms &#8212; and raindrops, bubbles, and oil slicks &#8212; create spectra because they bend light of different colors by different amounts.
-                      </p>     
-                      <p>
-                        The figure illustrates light passing through a diffraction grating (1) and a prism (2).
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col
-                    cols="4"
-                    offset="1"
-                  >
-                    <v-img
-                      id="grating_and_prism"
-                      class="mb-4 mx-a mt-n3"
-                      contain
-                      :src="`${image_location}/refraction_diffraction_spectra.png`"
-                    ></v-img>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
+          <v-btn icon>
+            <v-icon> mdi-close </v-icon>
+          </v-btn>
+        </span>
+      </v-toolbar>
 
-          <v-window-item :value="1" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                    class="d-flex flex-column"
-                    height="100%"
-                    flat
-                    tile
+      <v-window
+        v-model="step"
+        style="height: 70vh;"
+        class="overflow-auto"
+      >
+        <v-window-item :value="0" 
+          class="no-transition"
+        >
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                  class="d-flex flex-column"
+                  height="100%"
+                  flat
+                  tile
+                >
+                  <h3
+                    class="mb-4"
                   >
-                    <h3
-                      class="mb-4"
-                    >
-                      Spectrum images and graphs
-                    </h3>
-                    <div>
-                      <p>
-                        The graphics to the right show sample spectra for two different types of light bulbs.
-                      </p>
-                      <p>
-                        The spectrum images (i.e. the wide bar above the blue data points in each graphic) show what the light from each bulb looks like when it is separated into its colors by the spectrograph. 
-                      </p>
-                      <p>
-                        The spectrum graphs (i.e. the blue data points in each graphic) represent how bright the light is at each specific wavelength.
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col cols="6">
+                    Refraction and diffraction
+                  </h3>
+                  <div>
                     <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>Light spectrum for LED bulb</h4>
-                      <v-img
-                        class="mb-4 mx-a"
-                        contain
-                        :src="`${image_location}/LED_White_spectool.png`"
-                      ></v-img>
-                      <h4>Light spectrum for sodium vapor bulb</h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/Sodium_Vapor_spectool.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="2" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                    class="d-flex flex-column"
-                    height="100%"
-                    flat
-                    tile
-                  >
-                    <h3 class="mb-4">Interpreting spectrum graphs</h3>
-                    <div>
-                      <p>
-                        Examine the highlighted regions in the graphics to the right.
-                      </p>
-                      <p>
-                        At wavelengths where the spectrum graph has a
-                        <strong>high brightness</strong> value, the spectrum
-                        image is <strong>brightly lit</strong> at the
-                        corresponding wavelengths.
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col cols="6">
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>Light spectrum for LED bulb</h4>
-                      <v-img
-                        class="mb-4 mx-a"
-                        contain
-                        :src="`${image_location}/LED_White_w_highlight_spectool.png`"
-                      ></v-img>
-                      <h4>Light spectrum for sodium vapor bulb</h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/Sodium_Vapor_w_highlight_spectool.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="3" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                    class="d-flex flex-column"
-                    height="100%"
-                    flat
-                    tile
-                  >
-                    <h3 class="mb-4">Interpreting spectrum graphs</h3>
-                    <div>
-                      <p>
-                        Examine the highlighted regions in the graphics to the right.
-                      </p>
-                      <p>
-                        At wavelengths where the spectrum graph has a
-                        <strong>low brightness</strong> value, the spectrum
-                        image is <strong>dim</strong> or
-                        <strong>dark</strong> at the corresponding wavelengths.
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col cols="6">
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>Light spectrum for LED bulb</h4>
-                      <v-img
-                        class="mb-4 mx-a"
-                        contain
-                        :src="`${image_location}/LED_White_w_neghighlight_spectool.png`"
-                      ></v-img>
-                      <h4>Light spectrum for sodium vapor bulb</h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/Sodium_Vapor_w_neghighlight_spectool.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="4" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                  >
-                    <h3
-                      class="mb-4"
-                    >
-                      How do spectra indicate a source's motion?
-                    </h3>
-                    <div>
-                      <p>
-                        Think about a firetruck racing down the street. Have you noticed how the pitch of the siren changes depending whether the truck is moving toward or away from you? When the truck is moving toward you, the siren’s pitch is higher. When the truck is moving away from you, the siren’s pitch is lower. The faster the truck is moving, the bigger the change in pitch.
-                      </p>
-                      <p>
-                        This pitch change is due to a phenomenon called the <strong>Doppler shift</strong>, where the observed properties of a sound wave change due to the motion of the object emitting the sound.
-                      </p>
-                      <p>
-                        So what does this have to do with light waves and spectra?
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col cols="6">
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>
-                        Doppler shift
-                      </h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/siren_moving_white.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="5" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                  >
-                    <h3
-                      class="mb-4"
-                    >
-                      How do spectra indicate a source's motion?
-                    </h3>
-                    <div>
-                      <p>
-                        The same <strong>Doppler shift</strong> happens with <strong>light waves</strong> (and all other wave phenomena). But a light source has to be moving very fast for you to notice these changes!
-                      </p>
-                      <p>
-                        When a light source moves <strong>away from you</strong>, you observe the light to have a <strong>longer (redder)</strong> wavelength than you would if the object were not moving. This effect is called <strong>redshift</strong>.
-                      </p>
-                      <p>
-                        When a light source moves <strong>toward you</strong>, you observe the light to have a <strong>shorter (bluer)</strong> wavelength than you would if the object were not moving. This effect is called <strong>blueshift</strong>.
-                      </p>
-                    </div>
-                  </v-col>
-                  <v-col cols="6">
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>
-                        Doppler shift
-                      </h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/doppler_shift_light_white.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="6" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col>
-                    <h3
-                      class="mb-4"
-                    >
-                      How do we know the rest wavelength of the light?
-                    </h3>
-                    <div>
-                      <p>
-                        A key to using the Doppler shift to determine the velocity of an astronomical source is to know the wavelength of its light when it is <strong>not moving</strong>. (This is called the <strong>rest wavelength</strong> of light).
-                      </p>
-                      <p>
-                        Luckily, elements emit and absorb light at specific wavelengths that are unique to those elements. These unique patterns provide “chemical fingerprints” that we can use to identify the presence of an element in an astronomical source (like a star or a gas cloud). 
-                      </p>
-                      <p>
-                        The spectrum images below show the pattern of emission lines that are produced by four different elements. The emission line patterns are unique to each element.
-                      </p>
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-row>
-                  <v-col
-                    offset="1"
-                    cols="10"
-                  >
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="px-3"
-                    >
-                      <v-row>
-                        <v-col
-                          cols="2"
-                          class="d-flex flex-column"
-                          height="100%"
-                        >
-                          <v-img
-                            class="mx-a"
-                            contain
-                            :src="`${image_location}/carbon_atom_model.png`"
-                          ></v-img>
-                          <v-img
-                            class="mt-auto mx-a"
-                            contain
-                            :src="`${image_location}/nitrogen_atom_model.png`"
-                          ></v-img>
-                        </v-col>
-                        <v-col cols="8">
-                          <v-img
-                            class="mx-a"
-                            contain
-                            :src="`${image_location}/stsci_spectrum_element_montage.jpg`"
-                          ></v-img>
-                        </v-col>
-                        <v-col cols="2" class="d-flex flex-column" height="100%">
-                          <v-row>
-                            <v-col>
-                              <v-img
-                                class="mx-a"
-                                contain
-                                :src="`${image_location}/oxygen_atom_model.png`"
-                              ></v-img>
-                            </v-col>
-                          </v-row>
-                          <v-row>
-                            <v-col>
-                              <v-img
-                                class="mt-auto mx-a"
-                                contain
-                                :src="`${image_location}/iron_atom_model.png`"
-                              ></v-img>
-                            </v-col>
-                          </v-row>
-                        </v-col>
-                      </v-row>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="7" class="no-transition">
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="6"
-                    class="d-flex flex-column"
-                    height="100%"
-                    flat
-                    tile
-                  >
-                    <h3 class="mb-4">
-                      Emission and absorption lines in spectra
-                    </h3>
-                    <div>
-                      <p>
-                        The top spectrum shows <strong>emission lines</strong> from a source containing hydrogen.
-                      </p>
-                      <p>
-                        The bottom spectrum shows <strong>absorption lines</strong> due to hydrogen.
-                      </p>
-                      <p>
-                        Notice that in both spectra, the emission and absorption lines are present at the same combination of wavelengths (i.e. hydrogen’s “chemical fingerprint”).
-                      </p>
-                    </div>
-                    <v-card
-                      class="mt-auto"
+                      class="mt-auto mb-4"
                       flat
                       color="secondary lighten-3"
                       light
-                    > 
+                    >                  
                       <v-card-text
                         class="black--text"
                       >
-                        Elements emit light at specific wavelengths, and they can also absorb light at the same wavelengths, depending on the conditions associated with a light source.
+                        A <strong>spectrum</strong> is created when you pass light from a source through a spectrograph. A <strong>spectrograph</strong> separates the light into its different colors (like a rainbow) and measures how much light there is at each color (i.e. wavelength).
                       </v-card-text>
                     </v-card>
-                  </v-col>
-                  <v-col cols="6">
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <h4>Hydrogen emission spectrum</h4>
-                      <v-img
-                        class="mb-4 mx-a"
-                        contain
-                        :src="`${image_location}/hydrogen_emission_spectool.png`"
-                      ></v-img>
-                      <h4>Hydrogen absorption spectrum</h4>
-                      <v-img
-                        class="mx-a"
-                        contain
-                        :src="`${image_location}/hydrogen_absorption_spectool.png`"
-                      ></v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="8" 
-            class="no-transition"
-          >
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="12"
-                  >
-                    <h3 class="mb-4">
-                      Rest vs. Observed Wavelengths
-                    </h3>
                     <p>
-                      Since we know the wavelengths emitted or absorbed by an element when it is not moving, we can use these <strong>rest wavelengths</strong> as a reference to compare against the <strong>observed wavelengths</strong> of the light when an object <em>is</em> moving.
-                    </p>
-                </v-row>
-                <v-row>
-                  <v-col
-                    cols="12"
-                    lg="10"
-                    offset-lg="1"
-                  >
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <div
-                        class="pa-3"
-                      >
-                        <h4>
-                          Looking for the H-&alpha; emission line
-                        </h4>
-                        <p>
-                          The dotted line shows the rest wavelength of a hydrogen line known as <strong>H-&alpha;</strong> (pronounced "H alpha"). The solid line shows the observed wavelength of the H-&alpha; line.
-                        </p>
-                      </div>
-                      <v-img
-                        contain
-                        :src="`${image_location}/restobs1_dotted.png`"
-                      >
-                      </v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-
-          <v-window-item :value="9" 
-            class="no-transition"
-          >
-            <v-card-text>
-              <v-container>
-                <v-row>
-                  <v-col
-                    cols="12"
-                  >
-                    <h3 class="mb-4">
-                      Rest vs. Observed Wavelengths
-                    </h3>
+                      Diffraction gratings and prisms &#8212; and raindrops, bubbles, and oil slicks &#8212; create spectra because they bend light of different colors by different amounts.
+                    </p>     
                     <p>
-                      Since we know the wavelengths emitted or absorbed by an element when it is not moving, we can use these <strong>rest wavelengths</strong> as a reference to compare against the <strong>observed wavelengths</strong> of the light when an object <em>is</em> moving.
+                      The figure illustrates light passing through a diffraction grating (1) and a prism (2).
                     </p>
-                </v-row>
-                <v-row>
-                  <v-col
-                    cols="12"
-                    lg="10"
-                    offset-lg="1"
-                  >
-                    <v-card
-                      color="white"
-                      light
-                      outlined
-                      class="mt-n3 pa-3"
-                    >
-                      <div
-                        class="pa-3"
-                      >
-                        <h4>
-                          Looking for the Mg I absorption line
-                        </h4>
-                        <p>
-                          The dotted line shows the rest wavelength of a magnesium line known as <strong>Mg I</strong> (pronounced "magnesium one"). The solid line shows the observed wavelength of the Mg I line.
-                        </p>
-                      </div>
-                      <v-img
-                        contain
-                        :src="`${image_location}/restobs2_dotted.png`"
-                      >
-                      </v-img>
-                    </v-card>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
+                  </div>
+                </v-col>
+                <v-col
+                  cols="4"
+                  offset="1"
+                >
+                  <v-img
+                    id="grating_and_prism"
+                    class="mb-4 mx-a mt-n3"
+                    contain
+                    :src="`${image_location}/refraction_diffraction_spectra.png`"
+                  ></v-img>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
 
-          <v-window-item :value="10" 
-            class="no-transition"
+        <v-window-item :value="1" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                  class="d-flex flex-column"
+                  height="100%"
+                  flat
+                  tile
+                >
+                  <h3
+                    class="mb-4"
+                  >
+                    Spectrum images and graphs
+                  </h3>
+                  <div>
+                    <p>
+                      The graphics to the right show sample spectra for two different types of light bulbs.
+                    </p>
+                    <p>
+                      The spectrum images (i.e. the wide bar above the blue data points in each graphic) show what the light from each bulb looks like when it is separated into its colors by the spectrograph. 
+                    </p>
+                    <p>
+                      The spectrum graphs (i.e. the blue data points in each graphic) represent how bright the light is at each specific wavelength.
+                    </p>
+                  </div>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>Light spectrum for LED bulb</h4>
+                    <v-img
+                      class="mb-4 mx-a"
+                      contain
+                      :src="`${image_location}/LED_White_spectool.png`"
+                    ></v-img>
+                    <h4>Light spectrum for sodium vapor bulb</h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/Sodium_Vapor_spectool.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="2" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                  class="d-flex flex-column"
+                  height="100%"
+                  flat
+                  tile
+                >
+                  <h3 class="mb-4">Interpreting spectrum graphs</h3>
+                  <div>
+                    <p>
+                      Examine the highlighted regions in the graphics to the right.
+                    </p>
+                    <p>
+                      At wavelengths where the spectrum graph has a
+                      <strong>high brightness</strong> value, the spectrum
+                      image is <strong>brightly lit</strong> at the
+                      corresponding wavelengths.
+                    </p>
+                  </div>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>Light spectrum for LED bulb</h4>
+                    <v-img
+                      class="mb-4 mx-a"
+                      contain
+                      :src="`${image_location}/LED_White_w_highlight_spectool.png`"
+                    ></v-img>
+                    <h4>Light spectrum for sodium vapor bulb</h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/Sodium_Vapor_w_highlight_spectool.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="3" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                  class="d-flex flex-column"
+                  height="100%"
+                  flat
+                  tile
+                >
+                  <h3 class="mb-4">Interpreting spectrum graphs</h3>
+                  <div>
+                    <p>
+                      Examine the highlighted regions in the graphics to the right.
+                    </p>
+                    <p>
+                      At wavelengths where the spectrum graph has a
+                      <strong>low brightness</strong> value, the spectrum
+                      image is <strong>dim</strong> or
+                      <strong>dark</strong> at the corresponding wavelengths.
+                    </p>
+                  </div>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>Light spectrum for LED bulb</h4>
+                    <v-img
+                      class="mb-4 mx-a"
+                      contain
+                      :src="`${image_location}/LED_White_w_neghighlight_spectool.png`"
+                    ></v-img>
+                    <h4>Light spectrum for sodium vapor bulb</h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/Sodium_Vapor_w_neghighlight_spectool.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="4" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                >
+                  <h3
+                    class="mb-4"
+                  >
+                    How do spectra indicate a source's motion?
+                  </h3>
+                  <div>
+                    <p>
+                      Think about a firetruck racing down the street. Have you noticed how the pitch of the siren changes depending whether the truck is moving toward or away from you? When the truck is moving toward you, the siren’s pitch is higher. When the truck is moving away from you, the siren’s pitch is lower. The faster the truck is moving, the bigger the change in pitch.
+                    </p>
+                    <p>
+                      This pitch change is due to a phenomenon called the <strong>Doppler shift</strong>, where the observed properties of a sound wave change due to the motion of the object emitting the sound.
+                    </p>
+                    <p>
+                      So what does this have to do with light waves and spectra?
+                    </p>
+                  </div>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>
+                      Doppler shift
+                    </h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/siren_moving_white.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="5" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                >
+                  <h3
+                    class="mb-4"
+                  >
+                    How do spectra indicate a source's motion?
+                  </h3>
+                  <div>
+                    <p>
+                      The same <strong>Doppler shift</strong> happens with <strong>light waves</strong> (and all other wave phenomena). But a light source has to be moving very fast for you to notice these changes!
+                    </p>
+                    <p>
+                      When a light source moves <strong>away from you</strong>, you observe the light to have a <strong>longer (redder)</strong> wavelength than you would if the object were not moving. This effect is called <strong>redshift</strong>.
+                    </p>
+                    <p>
+                      When a light source moves <strong>toward you</strong>, you observe the light to have a <strong>shorter (bluer)</strong> wavelength than you would if the object were not moving. This effect is called <strong>blueshift</strong>.
+                    </p>
+                  </div>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>
+                      Doppler shift
+                    </h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/doppler_shift_light_white.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="6" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col>
+                  <h3
+                    class="mb-4"
+                  >
+                    How do we know the rest wavelength of the light?
+                  </h3>
+                  <div>
+                    <p>
+                      A key to using the Doppler shift to determine the velocity of an astronomical source is to know the wavelength of its light when it is <strong>not moving</strong>. (This is called the <strong>rest wavelength</strong> of light).
+                    </p>
+                    <p>
+                      Luckily, elements emit and absorb light at specific wavelengths that are unique to those elements. These unique patterns provide “chemical fingerprints” that we can use to identify the presence of an element in an astronomical source (like a star or a gas cloud). 
+                    </p>
+                    <p>
+                      The spectrum images below show the pattern of emission lines that are produced by four different elements. The emission line patterns are unique to each element.
+                    </p>
+                  </div>
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col
+                  offset="1"
+                  cols="10"
+                >
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="px-3"
+                  >
+                    <v-row>
+                      <v-col
+                        cols="2"
+                        class="d-flex flex-column"
+                        height="100%"
+                      >
+                        <v-img
+                          class="mx-a"
+                          contain
+                          :src="`${image_location}/carbon_atom_model.png`"
+                        ></v-img>
+                        <v-img
+                          class="mt-auto mx-a"
+                          contain
+                          :src="`${image_location}/nitrogen_atom_model.png`"
+                        ></v-img>
+                      </v-col>
+                      <v-col cols="8">
+                        <v-img
+                          class="mx-a"
+                          contain
+                          :src="`${image_location}/stsci_spectrum_element_montage.jpg`"
+                        ></v-img>
+                      </v-col>
+                      <v-col cols="2" class="d-flex flex-column" height="100%">
+                        <v-row>
+                          <v-col>
+                            <v-img
+                              class="mx-a"
+                              contain
+                              :src="`${image_location}/oxygen_atom_model.png`"
+                            ></v-img>
+                          </v-col>
+                        </v-row>
+                        <v-row>
+                          <v-col>
+                            <v-img
+                              class="mt-auto mx-a"
+                              contain
+                              :src="`${image_location}/iron_atom_model.png`"
+                            ></v-img>
+                          </v-col>
+                        </v-row>
+                      </v-col>
+                    </v-row>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="7" class="no-transition">
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="6"
+                  class="d-flex flex-column"
+                  height="100%"
+                  flat
+                  tile
+                >
+                  <h3 class="mb-4">
+                    Emission and absorption lines in spectra
+                  </h3>
+                  <div>
+                    <p>
+                      The top spectrum shows <strong>emission lines</strong> from a source containing hydrogen.
+                    </p>
+                    <p>
+                      The bottom spectrum shows <strong>absorption lines</strong> due to hydrogen.
+                    </p>
+                    <p>
+                      Notice that in both spectra, the emission and absorption lines are present at the same combination of wavelengths (i.e. hydrogen’s “chemical fingerprint”).
+                    </p>
+                  </div>
+                  <v-card
+                    class="mt-auto"
+                    flat
+                    color="secondary lighten-3"
+                    light
+                  > 
+                    <v-card-text
+                      class="black--text"
+                    >
+                      Elements emit light at specific wavelengths, and they can also absorb light at the same wavelengths, depending on the conditions associated with a light source.
+                    </v-card-text>
+                  </v-card>
+                </v-col>
+                <v-col cols="6">
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <h4>Hydrogen emission spectrum</h4>
+                    <v-img
+                      class="mb-4 mx-a"
+                      contain
+                      :src="`${image_location}/hydrogen_emission_spectool.png`"
+                    ></v-img>
+                    <h4>Hydrogen absorption spectrum</h4>
+                    <v-img
+                      class="mx-a"
+                      contain
+                      :src="`${image_location}/hydrogen_absorption_spectool.png`"
+                    ></v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="8" 
+          class="no-transition"
+        >
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="12"
+                >
+                  <h3 class="mb-4">
+                    Rest vs. Observed Wavelengths
+                  </h3>
+                  <p>
+                    Since we know the wavelengths emitted or absorbed by an element when it is not moving, we can use these <strong>rest wavelengths</strong> as a reference to compare against the <strong>observed wavelengths</strong> of the light when an object <em>is</em> moving.
+                  </p>
+              </v-row>
+              <v-row>
+                <v-col
+                  cols="12"
+                  lg="10"
+                  offset-lg="1"
+                >
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <div
+                      class="pa-3"
+                    >
+                      <h4>
+                        Looking for the H-&alpha; emission line
+                      </h4>
+                      <p>
+                        The dotted line shows the rest wavelength of a hydrogen line known as <strong>H-&alpha;</strong> (pronounced "H alpha"). The solid line shows the observed wavelength of the H-&alpha; line.
+                      </p>
+                    </div>
+                    <v-img
+                      contain
+                      :src="`${image_location}/restobs1_dotted.png`"
+                    >
+                    </v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="9" 
+          class="no-transition"
+        >
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="12"
+                >
+                  <h3 class="mb-4">
+                    Rest vs. Observed Wavelengths
+                  </h3>
+                  <p>
+                    Since we know the wavelengths emitted or absorbed by an element when it is not moving, we can use these <strong>rest wavelengths</strong> as a reference to compare against the <strong>observed wavelengths</strong> of the light when an object <em>is</em> moving.
+                  </p>
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col
+                  cols="12"
+                  lg="10"
+                  offset-lg="1"
+                >
+                  <v-card
+                    color="white"
+                    light
+                    outlined
+                    class="mt-n3 pa-3"
+                  >
+                    <div
+                      class="pa-3"
+                    >
+                      <h4>
+                        Looking for the Mg I absorption line
+                      </h4>
+                      <p>
+                        The dotted line shows the rest wavelength of a magnesium line known as <strong>Mg I</strong> (pronounced "magnesium one"). The solid line shows the observed wavelength of the Mg I line.
+                      </p>
+                    </div>
+                    <v-img
+                      contain
+                      :src="`${image_location}/restobs2_dotted.png`"
+                    >
+                    </v-img>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+
+        <v-window-item :value="10" 
+          class="no-transition"
+          style="height: 100%;"
+        >
+          <v-card-text
             style="height: 100%;"
           >
-            <v-card-text
+            <v-container
               style="height: 100%;"
             >
-              <v-container
+              <v-row
                 style="height: 100%;"
+                align="center"
               >
-                <v-row
-                  style="height: 100%;"
-                  align="center"
+                <v-col
+                  class="pa-4 text-center my-auto"
                 >
-                  <v-col
-                    class="pa-4 text-center my-auto"
-                  >
-                    <v-img
-                      class="mb-4"
-                      contain
-                      height="128"
-                      src="https://www.pngrepo.com/png/211744/512/rocket-ship-launch-missile.png"
-                    ></v-img>
-                    <h3 class="text-h6 font-weight-light mb-2">
-                      You're ready to start measuring galaxy velocities now.
-                    </h3>
-                    <span class="text-caption grey--text">Click the <strong>SPECTRUM TUTORIAL</strong> button again if you'd like to come back for a refresher.</span>
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card-text>
-          </v-window-item>
-        </v-window>
+                  <v-img
+                    class="mb-4"
+                    contain
+                    height="128"
+                    src="https://www.pngrepo.com/png/211744/512/rocket-ship-launch-missile.png"
+                  ></v-img>
+                  <h3 class="text-h6 font-weight-light mb-2">
+                    You're ready to start measuring galaxy velocities now.
+                  </h3>
+                  <span class="text-caption grey--text">Click the <strong>SPECTRUM TUTORIAL</strong> button again if you'd like to come back for a refresher.</span>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-window-item>
+      </v-window>
 
-        <v-divider></v-divider>
+      <v-divider></v-divider>
 
-        <v-card-actions>
-          <v-btn
-            :disabled="step === 0"
-            class="black--text"
-            color="accent"
-            depressed
-            @click="step--"
+      <v-card-actions>
+        <v-btn
+          :disabled="step === 0"
+          class="black--text"
+          color="accent"
+          depressed
+          @click="step--"
+        >
+          back
+        </v-btn>
+        <v-spacer></v-spacer>
+        <v-item-group v-model="step" class="text-center" mandatory>
+          <v-item
+            v-for="n in length"
+            :key="`btn-${n}`"
+            v-slot="{ active, toggle }"
           >
-            back
-          </v-btn>
-          <v-spacer></v-spacer>
-          <v-item-group v-model="step" class="text-center" mandatory>
-            <v-item
-              v-for="n in length"
-              :key="`btn-${n}`"
-              v-slot="{ active, toggle }"
-            >
-              <v-btn :input-value="active" icon @click="toggle">
-                <v-icon
-                  color="secondary"
-                >
-                  mdi-record
-                </v-icon>
-              </v-btn>
-            </v-item>
-          </v-item-group>
-          <v-spacer></v-spacer>
-          <v-btn
-            v-if="step < 10"
-            class="black--text"
-            color="accent"
-            depressed
-            @click="step++;"
-          >
-            next
-          </v-btn>
-          <v-btn
-            v-if="step >= 10"
-            color="accent"
-            class="black--text"
-            depressed
-            @click="
-              () => {
-                $emit('close');
-                dialog = false;
-                step = 0;
-              }
-            "
-          >
-            done
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </v-btn>
+            <v-btn :input-value="active" icon @click="toggle">
+              <v-icon
+                color="secondary"
+              >
+                mdi-record
+              </v-icon>
+            </v-btn>
+          </v-item>
+        </v-item-group>
+        <v-spacer></v-spacer>
+        <v-btn
+          v-if="step < 10"
+          class="black--text"
+          color="accent"
+          depressed
+          @click="step++;"
+        >
+          next
+        </v-btn>
+        <v-btn
+          v-if="step >= 10"
+          color="accent"
+          class="black--text"
+          depressed
+          @click="
+            () => {
+              $emit('close');
+              dialog = false;
+              step = 0;
+            }
+          "
+        >
+          done
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
+
+<script>
+module.exports = {
+  mounted() {
+    console.log(this);
+    console.log(this.$refs.dialog);
+  }
+}
+</script>
+
 
 
 <style>

--- a/src/hubbleds/components/spectrum_slideshow/spectrum_slideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/spectrum_slideshow.vue
@@ -3,7 +3,6 @@
       v-model="dialog"
       persistent
       max-width="1000px"
-      ref="dialog"
   >
     <template v-slot:activator="{ on, attrs }">
       <v-btn
@@ -19,6 +18,7 @@
     </template>
     <v-card
       class="mx-auto"
+      ref="content"
     >
       <v-toolbar
         color="secondary"
@@ -32,7 +32,7 @@
         </v-toolbar-title>
         <v-spacer></v-spacer>
         <speech-synthesizer
-          :root="() => this.$refs.dialog.$children[1].$el"
+          :root="() => this.$refs.content.$el"
           :selectors="['div.v-toolbar__title', 'div.v-card__text.black--text', 'h3', 'p']"
           />
         <span
@@ -705,7 +705,7 @@
 module.exports = {
   mounted() {
     console.log(this);
-    console.log(this.$refs.dialog);
+    console.log(this.$refs.content);
   }
 }
 </script>


### PR DESCRIPTION
This PR updates the guidelines in stage one to use the updated `scaffold-alert` component from https://github.com/cosmicds/cosmicds/pull/185. This trims considerably trims down boilerplate for these guidelines, as well as gives access to the new speech synthesis functionality from that PR. When a user advances to the next guideline, speech from the current guideline will be stopped.

This PR also adds the speech synthesis component to the spectrum slideshow, to serve as an example of how to do this for dialogs. In order to facilitate this, I've also modified the spectrum slideshow to use the v-dialog's activator slot, rather than having the button be the root element of the template. The main issue with the dialog was that the root element is only created when the dialog is opened. Thus, in order to let the speech synthesizer know what root element to use, we use a [template ref](https://vuejs.org/guide/essentials/template-refs.html) on the main dialog content, and reference this in the function that we pass to the speech component. (This can be done without template refs, but it depends on the particular child structure of the v-dialog component, so I think this is a more robust method).

Known issue (to be fixed in a future PR):
* The speech doesn't stop when a dialog window is closed, or the slide changes