### PR TITLE
Generic marker movement for stage 1

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_choose_row.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Choose a Row"
-    @back="() => { state.marker = 'sel_gal3'; }"
-    @next="() => { state.marker = 'mee_spe1'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.spec_viewer_reached"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_0.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_0.vue
@@ -1,12 +1,8 @@
 <template>
   <scaffold-alert
     title-text="Velocity Calculation"
-    @back="
-      state.marker = 'ref_dat1';
-    "
-    @next="
-      state.marker = 'dop_cal1';
-    "
+    @back="state.marker_backward = 1"
+    @next="state.marker_forward = 1"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_1.vue
@@ -1,12 +1,8 @@
 <template>
   <scaffold-alert
     title-text="Velocity Calculation"
-    @back="
-      state.marker = 'dop_cal0';
-    "
-    @next="
-      state.marker = 'dop_cal2';
-    "
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_2.vue
@@ -1,12 +1,8 @@
 <template>
   <scaffold-alert
     title-text="The Doppler Equation"
-    @back="
-      state.marker = 'dop_cal1';
-    "
-    @next="
-      state.marker = 'dop_cal3';
-    "
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_3.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Select a Galaxy"
-    @back="() => { state.marker = 'dop_cal2'; }"
-    @next="() => { state.marker = 'dop_cal4'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.doppler_calc_reached"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_4.vue
@@ -5,7 +5,7 @@
       elevation="6"
       max-width="800"
       title-text="Input Wavelengths"
-      @back="() => { state.marker = 'dop_cal3'; }"
+      @back="() => { state.marker_backward = 1; }"
       :state="state"
       @next="() => 
         {

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_doppler_calc_6.vue
@@ -8,7 +8,7 @@
       :can-advance="(state) => state.velocities_total === 5"
       next-text="stage 2"
       :state="state"
-      @back="() => { state.marker = 'dop_cal3'; }"
+      @back="() => { state.marker_backward = 1; }"
       @next="() => { state.completed = true; }"
   >
     <template #before-next>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_intro_guidelines.vue
@@ -5,7 +5,7 @@
     max-width="800"
     elevation="6"
     title-text="Introducing the Guidelines"
-    @next="state.marker = 'sel_gal1'"
+    @next="state.marker_forward = 1"
     :allow-back="false"
   >
     <template #back-content>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_notice_galaxy_table.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Table Data"
-    @back="() => { state.marker = 'sel_gal1'; }"
-    @next="() => { state.marker = 'sel_gal3'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_1.vue
@@ -6,8 +6,8 @@
     elevation="6"
     title-text="Observed Wavelength"
     :can-advance="(state) => state.obswaves_total >= 1"
-    @back="() => { state.marker = 'res_wav1'; }"
-    @next="() => { state.marker = 'obs_wav2'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :state="state"
   >
     <template #before-next>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_obswave_2.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Observed Wavelength"
-    @back="() => { state.marker = 'obs_wav1'; }"
-    @next="() => { state.marker = 'rep_rem1'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.zoom_tool_activated"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_reflect_on_data.vue
@@ -7,8 +7,8 @@
     title-text="Reflect on Your Data"
     :can-advance="(state) => state.reflection_complete"
     :state="state"
-    @back="() => { state.marker = 'rep_rem1'; }"
-    @next="() => { state.marker = 'dop_cal0'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
   >
 
     <template #before-next>

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_remaining_gals.vue
@@ -4,8 +4,8 @@
     class="mb-4 mx-auto"
     max-width="800"
     elevation="6"
-    @back="() => { state.marker = 'obs_wav2'; }"
-    @next="() => { state.marker = 'ref_dat1'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.obswaves_total >= 5"
     :title-text="state.obswaves_total < 5 ? 'Repeat for Remaining Galaxies' : 'Nice Work'
     "

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_restwave.vue
@@ -6,8 +6,8 @@
     elevation="6"
     title-text="Rest Wavelength"
     :state="state"
-    @back="() => { state.marker = 'mee_spe1'; }"
-    @next="() => { state.marker = 'obs_wav1'; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.lambda_used"
   >
 

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
@@ -5,7 +5,7 @@
     max-width="800"
     elevation="6"
     title-text="Select Your Galaxies"
-    @back="() => { state.marker_forward = 1; }"
+    @back="() => { state.marker_backward = 1; }"
     @next="() => {
       if (state.gals_total == 0) {
         state.marker = 'sel_gal2';

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_1.vue
@@ -5,7 +5,7 @@
     max-width="800"
     elevation="6"
     title-text="Select Your Galaxies"
-    @back="() => { state.marker = 'mee_gui1'; }"
+    @back="() => { state.marker_forward = 1; }"
     @next="() => {
       if (state.gals_total == 0) {
         state.marker = 'sel_gal2';

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
@@ -5,7 +5,7 @@
     max-width="800"
     elevation="6"
     title-text="Select Your Galaxies"
-    @back="() => { state.marker = 'sel_gal1'; }"
+    @back="() => { state.move_backward = 1; }"
     :can-advance="(_state) => false"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_2.vue
@@ -5,7 +5,7 @@
     max-width="800"
     elevation="6"
     title-text="Select Your Galaxies"
-    @back="() => { state.move_backward = 1; }"
+    @back="() => { state.marker_backward = 1; }"
     :can-advance="(_state) => false"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Select your Galaxies"
-    @back="() => { state.marker = 'sel_gal1'; }"
-    @next="() => { state.marker = 'cho_row1'; }"
+    @back="() => { state.move_backward = 1; }"
+    @next="() => { state.move_forward = 1; }"
     :can-advance="(state) => state.gals_total === 5"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
@@ -5,7 +5,13 @@
     max-width="800"
     elevation="6"
     title-text="Select your Galaxies"
-    @back="() => { state.marker_backward = 1; }"
+    @back="() => {
+      if (state.gals_total == 0) {
+        state.marker = 'sel_gal2';
+      } else {
+        state.marker = 'sel_gal1';
+      }
+    }"
     @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.gals_total === 5"
     :state="state"

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_select_galaxies_3.vue
@@ -5,8 +5,8 @@
     max-width="800"
     elevation="6"
     title-text="Select your Galaxies"
-    @back="() => { state.move_backward = 1; }"
-    @next="() => { state.move_forward = 1; }"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
     :can-advance="(state) => state.gals_total === 5"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/guideline_spectrum.vue
@@ -8,10 +8,10 @@
     :can-advance="(state) => state.spec_tutorial_opened"
     :state="state"
     @back="() => {
-      state.marker = 'cho_row1';
+      state.marker_backward = 1;
       state.spectrum_tool_visible = 0;
     }"
-    @next="() => { state.marker = 'res_wav1'; }"
+    @next="() => { state.marker_forward = 1; }"
   >
 
     <template #before-next>

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -162,7 +162,7 @@ class StageState(CDSState):
     @marker_forward.setter
     def marker_forward(self, value):
         index = self.indices[self.marker]
-        new_index = min(max(index - value, 0), len(self.markers) - 1)
+        new_index = min(max(index + value, 0), len(self.markers) - 1)
         self.marker = self.markers[new_index]
 
     def marker_before(self, marker):

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -12,9 +12,8 @@ from echo import add_callback, ignore_callback, CallbackProperty, \
     callback_property
 from glue.core import Data
 from glue.core.message import NumericalDataChangedMessage
-from glue_jupyter.link import link
 from numpy import isin
-from traitlets import default, Bool
+from traitlets import Bool, default, validate
 
 from ..components import SpectrumSlideshow, SelectionTool
 from ..data.styles import load_style
@@ -157,13 +156,13 @@ class StageState(CDSState):
     @marker_backward.setter
     def marker_backward(self, value):
         index = self.indices[self.marker]
-        new_index = max(index - value, 0)
+        new_index = min(max(index - value, 0), len(self.markers) - 1)
         self.marker = self.markers[new_index]
 
     @marker_forward.setter
     def marker_forward(self, value):
         index = self.indices[self.marker]
-        new_index = max(index + value, 0)
+        new_index = min(max(index - value, 0), len(self.markers) - 1)
         self.marker = self.markers[new_index]
 
     def marker_before(self, marker):

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -174,7 +174,7 @@ class StageState(CDSState):
     def marker_reached(self, marker):
         return self.indices[self.marker] >= self.indices[marker]
 
-    def _marker_index(self, marker):
+    def marker_index(self, marker):
         return self.indices[marker]
 
 

--- a/src/hubbleds/stages/stage_one.vue
+++ b/src/hubbleds/stages/stage_one.vue
@@ -13,8 +13,7 @@
           @click="() => {
             console.log('stage state:', stage_state);
             console.log('story state:', story_state);
-            console.log('markers:', stage_state.marker, stage_state.marker_index);
-            }"
+          }"
         >
           State
         </v-btn>

--- a/src/hubbleds/stages/stage_one.vue
+++ b/src/hubbleds/stages/stage_one.vue
@@ -13,6 +13,7 @@
           @click="() => {
             console.log('stage state:', stage_state);
             console.log('story state:', story_state);
+            console.log('markers:', stage_state.marker, stage_state.marker_index);
             }"
         >
           State


### PR DESCRIPTION
This PR introduces a mechanism for moving the marker forward or backward without needing to reference the particular markers involved. Here this is done only for stage one, but there's nothing stage one-specific here. This is done by using  `marker_backward` and `marker_forward` callback properties which don't store a value but have custom setter logic.

I wanted to have a `marker_index` callback property that was synced with the `marker`  - similar to the examples in [this gist](https://gist.github.com/Carifio24/8716d4cd7470c088517989358138b714). This works perfectly in Python, but setting the marker directly in our application often led to an extra triggering of the index-setting callback with an incorrect index. I assume keeping two values in sync both on the Python side and with JavaScript is just a bit too much to manage.

Rather than attempt to keep two values in sync, this approach uses the setters of `marker_backward` and `marker_forward` to move backward or forward a set number in the list of markers. `marker` itself hasn't changed, so we can still explicitly set the marker if we want to.

Some of the guidelines in stages 2+ are significantly changed in #117, so once that PR is resolved I'll handle the rest of the stages.