### PR TITLE
Add additional team interface functionality

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_one/reflect_velocity_windows.vue
+++ b/src/hubbleds/components/generic_state_components/stage_one/reflect_velocity_windows.vue
@@ -336,7 +336,7 @@
             >
             <!-- vue's v-for with a range starts the count at 1, so we have to add 2 in the disabled step instead of 1 to account for the fact that we are otherwise counting the windows from 0 https://v2.vuejs.org/v2/guide/list.html?redirect=true#v-for-with-a-Range-->
               <v-btn
-                :disabled="n > max_step_completed + 2"
+                :disabled="requireResponses && n > max_step_completed + 2"
                 :input-value="active"
                 icon
                 @click="toggle"
@@ -352,7 +352,7 @@
           <v-spacer></v-spacer>
           <v-btn
             v-if="step < 7"
-            :disabled="step > max_step_completed"
+            :disabled="requireResponses && step > max_step_completed"
             class="black--text"
             color="accent"
             depressed
@@ -385,7 +385,28 @@
 
 <script>
 module.exports = {
-  props: ["state", "buttonText", "titleText", "closeText"],
+  props: {
+    state: {
+      type: Object,
+      required: true
+    },
+    buttonText: {
+      type: String,
+      required: true
+    },
+    titleText: {
+      type: String,
+      required: true
+    },
+    closeText: {
+      type: String,
+      required: true
+    },
+    requireResponses: {
+      type: Boolean,
+      default: true
+    }
+  },
   data: function () {
     return {
       step: 0,
@@ -415,7 +436,7 @@ module.exports = {
     closeDialog(force = false) {
     // component does not have show_team_interface or allow_advancing variable available, so it can't be bypassed
       reachedEnd = this.max_step_completed >= this.interact_steps[this.interact_steps.length - 1];
-      if (reachedEnd || force) {
+      if (reachedEnd || force || !this.requireResponses) {
         console.log('closing doppler reflection sequence');
         this.$emit('submit');
         this.dialog = false;
@@ -424,7 +445,7 @@ module.exports = {
         console.log('user has not reached end of sequence')
         this.dialog = false;
       }
-      }
+    }
   },
 
   watch: {

--- a/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
+++ b/src/hubbleds/components/two_intro_slideshow/two_intro_slideshow.vue
@@ -779,7 +779,7 @@
       <v-spacer></v-spacer>
 
       <v-btn
-        :disabled="step > max_step_completed"
+        :disabled="!show_team_interface && step > max_step_completed"
         v-if="step < length-1"
         class="black--text"
         color="accent"

--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -664,7 +664,7 @@ class StageOne(HubbleStage):
             with ignore_callback(sf_tool, "flagged"):
                 sf_tool.flagged = False
 
-    def update_velocities(self, table, tool):
+    def update_velocities(self, table, tool=None):
         data = table.glue_data
         for item in table.items:
             index = table.indices_from_items([item])[0]
@@ -677,7 +677,12 @@ class StageOne(HubbleStage):
                 self.update_data_value(STUDENT_MEASUREMENTS_LABEL, "velocity",
                                        velocity, index)
         self.story_state.update_student_data()
-        table.update_tool(tool)
+
+        if tool is not None:
+            table.update_tool(tool)
+
+    def vue_update_velocities(self, _args):
+        self.update_velocities(self.galaxy_table)
 
     def enable_velocity_tool(self, enable):
         if enable:

--- a/src/hubbleds/stages/stage_one.vue
+++ b/src/hubbleds/stages/stage_one.vue
@@ -209,6 +209,7 @@
               button-text="reflect"
               close-text="submit"
               :state="stage_state"
+              :require-responses="!show_team_interface"
               @submit="
                 stage_state.reflection_complete = true;
                 console.log('Submit button was clicked.');

--- a/src/hubbleds/stages/stage_one.vue
+++ b/src/hubbleds/stages/stage_one.vue
@@ -234,6 +234,22 @@
               </v-icon>
             </v-btn>
           </v-col>
+          <v-col
+            v-if="show_team_interface"
+            cols="4"
+          >
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-btn
+              color="error"
+              class="black--text"
+              @click="update_velocities()"
+            >
+              calculate velocities
+            </v-btn>
+          </v-col>
         </v-row>
       </v-col>
     </v-row>

--- a/src/hubbleds/stages/stage_two.py
+++ b/src/hubbleds/stages/stage_two.py
@@ -366,7 +366,7 @@ class StageTwo(HubbleStage):
             self.enable_distance_tool(True)
         self.get_distance_count()
 
-    def update_distances(self, table, tool):
+    def update_distances(self, table, tool=None):
         data = table.glue_data
         for item in table.items:
             index = table.indices_from_items([item])[0]
@@ -378,8 +378,12 @@ class StageTwo(HubbleStage):
                 self.update_data_value("student_measurements", "distance",
                                        distance, index)
         self.story_state.update_student_data()
-        table.update_tool(tool)
+        if tool is not None:
+            table.update_tool(tool)
         self.get_distance_count()
+
+    def vue_update_distances(self, _args):
+        self.update_distances(self.distance_table)
 
     def vue_add_distance_data_point(self, _args=None):
         self.stage_state.make_measurement = True

--- a/src/hubbleds/stages/stage_two.vue
+++ b/src/hubbleds/stages/stage_two.vue
@@ -143,8 +143,16 @@
           :class="stage_state.table_highlights.includes(stage_state.marker) ? 'pa-1 my-n1' : 'pa-0'"
           outlined
         >
-          <jupyter-widget :widget="widgets.distance_table" />
+          <jupyter-widget :widget="widgets.distance_table" />        
         </v-card>
+        <v-btn
+          v-if="show_team_interface"
+          color="error"
+          class="black--text"
+          @click="update_distances()"
+        >
+          calculate distances
+        </v-btn>
       </v-col>
     </v-row>
   </v-container>


### PR DESCRIPTION
This PR adds some additional functionality when in the "team interface" mode:

* The reflection questions in stage one can be bypassed
* The entire stage two intro is accessible to begin
* In stage one, a red "Calculate Velocities" button has been added to allow filling in velocities without going through the first calculation
* Similarly, in stage two, a red "Calculate Distances" button has been added

If there are other reflection questions past stage one, I can make another PR to deal with those once #117 has been resolved, since that PR makes significant changes to many of the later guidelines.