### PR TITLE
Update setup.cfg to accommodate `packaging`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,7 @@ package_dir =
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    importlib-metadata
-    python_version>="3.7"
+    importlib-metadata; python_version>="3.7"
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
 
 


### PR DESCRIPTION
This PR updates our `setup.cfg` file to account for changes to `setuptools`. In particular, `setuptools` updated its bundled version of `packaging` in [v67.0.0](https://setuptools.pypa.io/en/stable/history.html#v67-0-0), which led to stricter formatting for markers; see [here](https://github.com/pypa/setuptools/blob/main/docs/userguide/declarative_config.rst#opt-2).