### PR TITLE
Add scroll-into-view for expanding guideline

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect2.vue
@@ -1,10 +1,11 @@
 <template>
   <scaffold-alert
     title-text="Identify Your Confidence Interval"
+    ref="scaffold"
     @back="state.marker_backward = 1"
     @next="() => {
-      if (state.reveal_iter < 3) {
-        state.reveal_iter = state.reveal_iter + 1;
+      if (revealIter < 3) {
+        revealIter = revealIter + 1;
       }
       else {
         state.marker_forward = 1;
@@ -88,7 +89,7 @@
       </v-row>
 
       <v-row
-        v-if="state.reveal_iter >= 1"
+        v-if="revealIter >= 1"
       >
         <v-col
           cols="12"
@@ -151,7 +152,7 @@
         </v-col>
       </v-row>
       <v-row
-        v-if="state.reveal_iter >= 1"
+        v-if="revealIter >= 1"
       >
         <v-col
           cols="12"
@@ -184,14 +185,14 @@
       </v-row>
 
       <v-row
-        v-if="state.reveal_iter >= 2"
+        v-if="revealIter >= 2"
       >
         <v-col>
           3. Explain why you chose your values using information from the scatterplot and/or the histogram:
         </v-col>
       </v-row>
       <v-row
-        v-if="state.reveal_iter >= 2"
+        v-if="revealIter >= 2"
       >
         <v-col>
           <free-response
@@ -205,7 +206,7 @@
       </v-row>
 
       <v-row
-        v-if="state.reveal_iter >= 3"
+        v-if="revealIter >= 3"
       >
         <v-col
           cols="12"
@@ -264,7 +265,7 @@
         </v-col>
       </v-row>
       <v-row
-        v-if="state.reveal_iter >= 3"
+        v-if="revealIter >= 3"
       >
         <v-col>
           <free-response
@@ -282,7 +283,23 @@
 
 <script>
 module.exports = {
-  props: ['state']
+  props: ['state'],
+  data() {
+    return {
+      revealIter: 0
+    }
+  },
+  watch: {
+    revealIter(_value) {
+      const scaffold = this.$refs.scaffold;
+      this.$nextTick(() => {
+        scaffold.$refs.next.$el.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        });
+      });
+    }
+  }
 }
 </script>
 

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -65,8 +65,6 @@ class StageState(CDSState):
     cla_low_age = CallbackProperty(0)
     cla_high_age = CallbackProperty(0)
 
-    reveal_iter = CallbackProperty(0)
-
     age_calc_state = DictCallbackProperty({
         'hint1_dialog': False,
         'hint2_dialog': False,


### PR DESCRIPTION
This PR adds functionality to the stage 5 `con_int2` guideline to scroll down to the new location of the next button each time the guideline expands. Additionally, this moves keeping track of the guideline expansion from the stage state into the component state, since the rest of the stage doesn't use it at all.

This relies on https://github.com/cosmicds/cosmicds/pull/209, as it uses one of the template refs introduced there to access the next button.