### PR TITLE
Clear and re-render MathJax in stage 4 guideline

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_4/guideline_age_universe_estimate4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4/guideline_age_universe_estimate4.vue
@@ -20,15 +20,15 @@
         color="info lighten-1"
         elevation="0"
       >
-        {{ youEnteredMJax }}
+        {{ youEnteredMJax(state.hypgal_distance, state.hypgal_velocity) }}
       </v-card>    
       <p class="mt-4">
         Dividing through gives an estimated age of the universe from your dataset:
       </p>
       <div
-        class="JaxEquation my-8"
+        class="JaxEquation my-8 est-age"
       >
-        $$ D = {{ (Math.round(state.age_const * state.hypgal_distance/state.hypgal_velocity).toFixed(0) ) }} \text{ Gyr} $$
+        {{ estAgeMJax(state.hypgal_distance, state.hypgal_velocity) }}
       </div>
       <v-divider role="presentation" class="mt-3"></v-divider>
       <v-card
@@ -138,30 +138,42 @@ module.exports = {
   props: ['state'],
   data() {
     return {
-      youEnteredMJax: this.enteredMJax(this.state.hypgal_distance, this.state.hypgal_velocity)
-    };
+      enteredJax: this.youEnteredMJax(this.state.hypgal_distance, this.state.hypgal_velocity),
+      ageJax: this.estAgeMJax(this.state.hypgal_distance, this.state.hypgal_velocity)
+    }
   },
   methods: {
-    enteredMJax(distance, velocity) {
+    youEnteredMJax(distance, velocity) {
       return `$$ t = ${Math.round(this.state.age_const)}  \\times \\frac{\\textcolor{black}{\\colorbox{#FFAB91}{ ${distance.toFixed(0)} } } \\text{ Mpc} } { \\textcolor{black}{\\colorbox{#FFAB91}{ ${velocity.toFixed(0)} } }  \\text{ km/s} }  \\text{   Gyr}$$`
     },
-    resetEnteredMJax(distance, velocity) {
-      const youEnteredCard = this.$el.querySelector(".entered-card");
-        this.youEnteredMJax = this.enteredMJax(distance, velocity);
-        youEnteredCard.textContent = this.youEnteredMJax;
-        youEnteredCard.querySelectorAll("mjx-container").forEach(el => youEnteredCard.remove(el));
-        MathJax.typesetPromise([youEnteredCard]);
+    estAgeMJax(distance, velocity) {
+      return `$$ D = ${Math.round(this.state.age_const * distance / velocity).toFixed(0)} \\text{ Gyr} $$`;
+    },
+    removeMathJax(container) {
+      container.querySelectorAll("mjx-container").forEach(el => container.remove(el));
+    },
+    resetMathJax(containers, newJax) {
+      containers.forEach((container, index) => {
+        container.textContent = newJax[index];
+        this.removeMathJax(container);
+      });
+      MathJax.typesetPromise(containers);
+    },
+    resetAllMathJax(distance, velocity) {
+      const containers = [".entered-card", ".est-age"].map(sel => this.$el.querySelector(sel));
+      const newJax = [this.youEnteredMJax(distance, velocity), this.estAgeMJax(distance, velocity)];
+      this.resetMathJax(containers, newJax);
     }
   },
   watch: {
     'state.hypgal_distance': {
       handler(distance) {
-        this.resetEnteredMJax(distance, this.state.hypgal_velocity);
+        this.resetAllMathJax(distance, this.state.hypgal_velocity);
       }
     },
     'state.hypgal_velocity': {
       handler(velocity) {
-        this.resetEnteredMJax(this.state.hypgal_distance, velocity);
+        this.resetAllMathJax(this.state.hypgal_distance, velocity);
       }
     }
   }

--- a/src/hubbleds/components/generic_state_components/stage_4/guideline_age_universe_estimate4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4/guideline_age_universe_estimate4.vue
@@ -16,11 +16,11 @@
         You entered:
       </p>
       <v-card
-        class="JaxEquation pa-3"
+        class="JaxEquation pa-3 entered-card"
         color="info lighten-1"
         elevation="0"
       >
-        $$ t = {{ Math.round(state.age_const) }}  \times \frac{\textcolor{black}{\colorbox{#FFAB91}{ {{ (state.hypgal_distance).toFixed(0) }} } } \text{ Mpc} } { \textcolor{black}{\colorbox{#FFAB91}{ {{ (state.hypgal_velocity).toFixed(0) }} } }  \text{ km/s} }  \text{   Gyr}$$
+        {{ youEnteredMJax }}
       </v-card>    
       <p class="mt-4">
         Dividing through gives an estimated age of the universe from your dataset:
@@ -54,7 +54,6 @@
             class="my-1"
           >
             <v-col
-              
             >
               \(t\)
             </v-col>
@@ -136,6 +135,35 @@ mjx-mstyle {
 
 <script>
 module.exports = {
-  props: ['state']
+  props: ['state'],
+  data() {
+    return {
+      youEnteredMJax: this.enteredMJax(this.state.hypgal_distance, this.state.hypgal_velocity)
+    };
+  },
+  methods: {
+    enteredMJax(distance, velocity) {
+      return `$$ t = ${Math.round(this.state.age_const)}  \\times \\frac{\\textcolor{black}{\\colorbox{#FFAB91}{ ${distance.toFixed(0)} } } \\text{ Mpc} } { \\textcolor{black}{\\colorbox{#FFAB91}{ ${velocity.toFixed(0)} } }  \\text{ km/s} }  \\text{   Gyr}$$`
+    },
+    resetEnteredMJax(distance, velocity) {
+      const youEnteredCard = this.$el.querySelector(".entered-card");
+        this.youEnteredMJax = this.enteredMJax(distance, velocity);
+        youEnteredCard.textContent = this.youEnteredMJax;
+        youEnteredCard.querySelectorAll("mjx-container").forEach(el => youEnteredCard.remove(el));
+        MathJax.typesetPromise([youEnteredCard]);
+    }
+  },
+  watch: {
+    'state.hypgal_distance': {
+      handler(distance) {
+        this.resetEnteredMJax(distance, this.state.hypgal_velocity);
+      }
+    },
+    'state.hypgal_velocity': {
+      handler(velocity) {
+        this.resetEnteredMJax(this.state.hypgal_distance, velocity);
+      }
+    }
+  }
 }
 </script>

--- a/src/hubbleds/data_management.py
+++ b/src/hubbleds/data_management.py
@@ -97,6 +97,9 @@ DB_SUMMARY_FIELDS = [
     DB_AGE_FIELD
 ]
 
+# Misc
+SPECTRUM_EXTENSION = ".fits"
+
 def reverse(d):
     return { v : k for k, v in d.items() }
 

--- a/src/hubbleds/stage.py
+++ b/src/hubbleds/stage.py
@@ -7,7 +7,7 @@ from cosmicds.phases import Stage
 from cosmicds.utils import API_URL, CDSJSONEncoder
 from echo import add_callback
 
-from .data_management import MEAS_TO_STATE, STUDENT_MEASUREMENTS_LABEL, UNITS_TO_STATE
+from .data_management import *
 from .utils import HUBBLE_ROUTE_PATH, distance_from_angular_size, velocity_from_wavelengths
 
 
@@ -27,10 +27,9 @@ class HubbleStage(Stage):
         prepared = {HubbleStage._map_key(k): measurement.get(k, None) for k in
                     MEAS_TO_STATE.keys()}
         prepared.update(UNITS_TO_STATE)
-        prepared["student_id"] = self.app_state.student["id"]
-        ext = ".fits"
-        if not prepared["galaxy_name"].endswith(ext):
-            prepared["galaxy_name"] += ext
+        prepared[DB_STUDENT_ID_FIELD] = self.app_state.student["id"]
+        if not prepared[DB_GALNAME_FIELD].endswith(SPECTRUM_EXTENSION):
+            prepared[DB_GALNAME_FIELD] += SPECTRUM_EXTENSION
         prepared = json.loads(json.dumps(prepared, cls=CDSJSONEncoder))
         return prepared
     
@@ -39,10 +38,9 @@ class HubbleStage(Stage):
         prepared = {HubbleStage._map_key(k): measurement.get(k, None) for k in
                     MEAS_TO_STATE.keys()}
         prepared.update(UNITS_TO_STATE)
-        prepared["student_id"] = self.app_state.student["id"]
-        ext = ".fits"
-        if not prepared["galaxy_name"].endswith(ext):
-            prepared["galaxy_name"] += ext
+        prepared[DB_STUDENT_ID_FIELD] = self.app_state.student["id"]
+        if not prepared[DB_GALNAME_FIELD].endswith(SPECTRUM_EXTENSION):
+            prepared[DB_GALNAME_FIELD] += SPECTRUM_EXTENSION
         prepared = json.loads(json.dumps(prepared, cls=CDSJSONEncoder))
         return prepared
 
@@ -65,9 +63,9 @@ class HubbleStage(Stage):
     def remove_measurement(self, galaxy_name):
         name = str(galaxy_name)
         condition = lambda x: x == name
-        if not galaxy_name.endswith(".fits"):
-            galaxy_name += ".fits"
-        self.remove_data_values("student_measurements", "name", condition,
+        if not galaxy_name.endswith(SPECTRUM_EXTENSION):
+            galaxy_name += SPECTRUM_EXTENSION
+        self.remove_data_values(STUDENT_MEASUREMENTS_LABEL, NAME_COMPONENT, condition,
                                 single=True)
         user = self.app_state.student
         if self.app_state.update_db and user.get("id", None) is not None:
@@ -83,18 +81,18 @@ class HubbleStage(Stage):
         # Update dependent values, if the student has already has a value for them
         # We block submission to avoid sending unnecessary requests
         data = self.data_collection[dc_name]
-        if comp_name == "measwave":
-            velocity = data["velocity"][index]
+        if comp_name == MEASWAVE_COMPONENT:
+            velocity = data[VELOCITY_COMPONENT][index]
             if velocity is not None:
-                rest = data["restwave"][index]
+                rest = data[RESTWAVE_COMPONENT][index]
                 new_velocity = velocity_from_wavelengths(value, rest)
-                self.update_data_value(dc_name, "velocity", new_velocity, index, block_submit=True)
+                self.update_data_value(dc_name, VELOCITY_COMPONENT, new_velocity, index, block_submit=True)
 
-        if comp_name == "angular_size":
-            distance = data["distance"][index]
+        if comp_name == ANGULAR_SIZE_COMPONENT:
+            distance = data[DISTANCE_COMPONENT][index]
             if distance is not None:
                 new_distance = distance_from_angular_size(value)
-                self.update_data_value(dc_name, "distance", new_distance, index, block_submit=True)
+                self.update_data_value(dc_name, DISTANCE_COMPONENT, new_distance, index, block_submit=True)
 
         # Submit a measurement, if necessary
         if self.app_state.update_db \


### PR DESCRIPTION
There is currently an issue with the stage 4 `age_uni4` guideline where, if the student changes their measurements and the best-fit galaxy is updated, the MathJax is re-rendered without clearing the old MathJax (leading to two copies of each of the two items in the guideline). This PR adds watchers that will clear out the old MathJax and render updated content when the best-fit galaxies are modified.