### PR TITLE
Update viewers to inherit new limit-reset behavior

### DIFF
--- a/src/hubbleds/viewers/spectrum_view.py
+++ b/src/hubbleds/viewers/spectrum_view.py
@@ -9,7 +9,7 @@ from glue_jupyter.bqplot.scatter import BqplotScatterView, \
     BqplotScatterLayerArtist
 
 from cosmicds.mixins import LineHoverStateMixin, LineHoverViewerMixin
-from cosmicds.viewers.cds_viewers import cds_viewer
+from cosmicds.viewers.cds_viewer import cds_viewer
 from ..utils import H_ALPHA_REST_LAMBDA, MG_REST_LAMBDA
 
 __all__ = ['SpectrumView', 'SpectrumViewLayerArtist', 'SpectrumViewerState']

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -2,6 +2,7 @@ from echo import delay_callback
 from glue.viewers.scatter.state import ScatterViewerState
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from glue_jupyter.bqplot.scatter import BqplotScatterView
+from cosmicds.viewers.cds_viewer import CDSHistogramViewerState, CDSScatterViewerState
 from cosmicds.viewers.cds_viewer import cds_viewer
 from cosmicds.viewers.dotplot.viewer import BqplotDotPlotView
 
@@ -13,7 +14,7 @@ __all__ = [
 ]
 
 
-class HubbleScatterViewerState(ScatterViewerState):
+class HubbleScatterViewerState(CDSScatterViewerState):
 
     def reset_limits(self):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
@@ -73,6 +74,7 @@ HubbleScatterView = cds_viewer(
 
 HubbleHistogramView = cds_viewer(
     BqplotHistogramView,
+    state_cls=CDSHistogramViewerState,
     name="HubbleHistogramView",
     viewer_tools=[
         "bqplot:home",
@@ -83,6 +85,7 @@ HubbleHistogramView = cds_viewer(
 
 HubbleClassHistogramView = cds_viewer(
     BqplotHistogramView,
+    state_cls=CDSHistogramViewerState,
     name="HubbleClassHistogramView",
     viewer_tools=[
         "bqplot:home",

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -2,7 +2,7 @@ from echo import delay_callback
 from glue.viewers.scatter.state import ScatterViewerState
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
 from glue_jupyter.bqplot.scatter import BqplotScatterView
-from cosmicds.viewers import cds_viewer
+from cosmicds.viewers.cds_viewer import cds_viewer
 from cosmicds.viewers.dotplot.viewer import BqplotDotPlotView
 
 


### PR DESCRIPTION
This PR updates our viewers to use the behavior introduced in https://github.com/cosmicds/cosmicds/pull/213. I didn't add any additional calls to `reset_limits` - I think adding those calls into the sequencing can be its own PR. In my testing this seems to work well - see e.g. the video below.

https://user-images.githubusercontent.com/14281631/232160320-bb29b925-1f09-4484-8ade-3ee57da0c364.mp4