### PR TITLE
"Waiting screen" for stage 4

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
@@ -12,7 +12,7 @@
       <v-toolbar-title
         class="text-h6 text-uppercase font-weight-regular"
       >
-        Waiting Screen
+        Take a quick break
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <speech-synthesizer
@@ -24,8 +24,9 @@
     <v-card-text>
       <v-container>
         <v-row>
-          <p>Very few of your classmates have finished taking their data, so let's wait for them to catch up.</p>
-          <p>While you do, feel free to explore the sky using WorldWide Telescope!</p>
+          <p>You and your classmates will be comparing your measurements in the next section, but we need to wait a few moments for more of them to catch up.</p>
+          <p>While you wait, you can explore the same sky viewer you saw in the introduction.</p>
+          <p>This screen will autoadvance when enough classmates are ready to proceed.</p>
           <iframe
             allowfullscreen
             allow="accelerometer; clipboard-write; gyroscope"

--- a/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
@@ -30,6 +30,7 @@
             allowfullscreen
             allow="accelerometer; clipboard-write; gyroscope"
             class="wwt-iframe"
+            title="WorldWide Telescope"
             :src="`https://web.wwtassets.org/research/latest/?origin=${window.location.origin}`"
           >
             <p>ERROR: cannot display AAS WorldWide Telescope research app!</p>
@@ -45,6 +46,13 @@ module.exports = {
   mounted() {
     const iframe = this.$el.querySelector(".wwt-iframe");
 
+    /**
+     * For now, I'm using the research app because we can't include script tags
+     * in templates, and requirejs was giving some issues when I tried loading
+     * the WWT SDK programmatically.
+     * TODO: Figure this out!
+     */
+
     // The app needs some time to be ready to accept messages
     setTimeout(() => {
       console.log("About to post!");
@@ -58,3 +66,9 @@ module.exports = {
 }
 </script>
 
+<style scoped>
+.wwt-iframe {
+  width: 100% !important;
+  height: 500px !important;
+}
+</style>

--- a/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4_waiting_screen.vue
@@ -55,7 +55,6 @@ module.exports = {
 
     // The app needs some time to be ready to accept messages
     setTimeout(() => {
-      console.log("About to post!");
       iframe.contentWindow.postMessage({
         event: "modify_settings",
         target: "app",

--- a/src/hubbleds/components/generic_state_components/waiting_screen.vue
+++ b/src/hubbleds/components/generic_state_components/waiting_screen.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-card
+    id="waiting-screen"
+    elevation="6"
+  >
+    <v-toolbar
+      ref="toolbar"
+      color="warning"
+      dense
+      dark
+    >
+      <v-toolbar-title
+        class="text-h6 text-uppercase font-weight-regular"
+      >
+        Waiting Screen
+      </v-toolbar-title>
+      <v-spacer></v-spacer>
+      <speech-synthesizer
+        ref="synth"
+        :root="$el"
+        :selectors="['div.v-toolbar__title.text-h6', 'div.v-card__text.black--text', 'h3', 'p']"
+      />
+    </v-toolbar>
+    <v-card-text>
+      <v-container>
+        <v-row>
+          <p>Very few of your classmates have finished taking their data, so let's wait for them to catch up.</p>
+          <p>While you do, feel free to explore the sky using WorldWide Telescope!</p>
+          <iframe
+            allowfullscreen
+            allow="accelerometer; clipboard-write; gyroscope"
+            class="wwt-iframe"
+            :src="`https://web.wwtassets.org/research/latest/?origin=${window.location.origin}`"
+          >
+            <p>ERROR: cannot display AAS WorldWide Telescope research app!</p>
+          </iframe>
+        </v-row>
+      </v-container>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+module.exports = {
+  mounted() {
+    const iframe = this.$el.querySelector(".wwt-iframe");
+
+    // The app needs some time to be ready to accept messages
+    setTimeout(() => {
+      console.log("About to post!");
+      iframe.contentWindow.postMessage({
+        event: "modify_settings",
+        target: "app",
+        settings: [["hideAllChrome", true]]
+      }, "https://web.wwtassets.org/");
+    }, 1000);
+  }
+}
+</script>
+

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.py
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.py
@@ -1,6 +1,5 @@
 import ipyvuetify as v
 from cosmicds.utils import load_template
-from glue_jupyter.state_traitlets_helpers import GlueState
 from traitlets import Int, Bool, Unicode, List, Float
 
 from ...utils import DISTANCE_CONSTANT

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -8,9 +8,10 @@ from cosmicds.components.table import Table
 from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
 from cosmicds.utils import extend_tool, load_template, update_figure_css
-from echo import CallbackProperty, add_callback, keep_in_sync, remove_callback, DictCallbackProperty
+from echo import CallbackProperty, add_callback, remove_callback, DictCallbackProperty
 from glue.core.message import NumericalDataChangedMessage
 from glue.core.data import Data
+from glue_jupyter.link import link
 from hubbleds.utils import IMAGE_BASE_URL, AGE_CONSTANT
 from traitlets import default, Bool
 from ..data.styles import load_style
@@ -163,7 +164,8 @@ class StageThree(HubbleStage):
         add_callback(self.stage_state, 'stage_4_complete',
                      self._on_stage_4_complete)
 
-        self._waiting_sync = keep_in_sync(self.story_state, 'enough_students_ready', self.stage_state, 'stage_ready')
+
+        link((self.story_state, 'enough_students_ready'), (self.stage_state, 'stage_ready'))
 
         self.show_team_interface = self.app_state.show_team_interface
 

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -8,7 +8,7 @@ from cosmicds.components.table import Table
 from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
 from cosmicds.utils import extend_tool, load_template, update_figure_css
-from echo import CallbackProperty, add_callback, remove_callback, DictCallbackProperty
+from echo import CallbackProperty, add_callback, keep_in_sync, remove_callback, DictCallbackProperty
 from glue.core.message import NumericalDataChangedMessage
 from glue.core.data import Data
 from hubbleds.utils import IMAGE_BASE_URL, AGE_CONSTANT
@@ -32,6 +32,7 @@ class StageState(CDSState):
     trend_line_drawn = CallbackProperty(False)
     best_fit_clicked = CallbackProperty(False)
     stage_4_complete = CallbackProperty(False)
+    stage_ready = CallbackProperty(False)
 
     marker = CallbackProperty("")
     indices = CallbackProperty({})
@@ -161,6 +162,8 @@ class StageThree(HubbleStage):
         
         add_callback(self.stage_state, 'stage_4_complete',
                      self._on_stage_4_complete)
+
+        self._waiting_sync = keep_in_sync(self.story_state, 'enough_students_ready', self.stage_state, 'stage_ready')
 
         self.show_team_interface = self.app_state.show_team_interface
 

--- a/src/hubbleds/stages/stage_4.vue
+++ b/src/hubbleds/stages/stage_4.vue
@@ -1,30 +1,33 @@
 <template>
-  <v-container>
-    <v-row v-if="show_team_interface">
-      <v-col>
-        <v-btn
-          color="error"
-          class="black--text"
-          @click="() => {
-            console.log('stage state:', stage_state);
-            console.log('story state:', story_state);
-          }"
-        >
-          State
-        </v-btn>
-        <v-btn
-          color="error"
-          class="black--text"
-          @click="() => {
-            stage_state.marker = 'sho_est1';
-          }"
-        >
-          jump
-        </v-btn>
-        Marker: {{ stage_state.marker }}
-      </v-col>
-    </v-row>
-
+<v-container>
+  <v-row v-if="stage_state.show_team_interface">
+    <v-col>
+      <v-btn
+        color="error"
+        class="black--text"
+        @click="() => {
+          console.log('stage state:', stage_state);
+          console.log('story state:', story_state);
+        }"
+      >
+        State
+      </v-btn>
+      <v-btn
+        color="error"
+        class="black--text"
+        @click="() => {
+          stage_state.marker = 'sho_est1';
+        }"
+      >
+        jump
+      </v-btn>
+      Marker: {{ stage_state.marker }}
+    </v-col>
+  </v-row>
+  <v-container v-if="!stage_state.stage_ready">
+    <stage-4-waiting-screen/>
+  </v-container>
+  <v-container v-else>
     <!--------------------- TABLE ROW ----------------------->
     <v-row
       class="d-flex align-stretch"
@@ -187,6 +190,7 @@
       </v-col>
     </v-row>
   </v-container>
+</v-container>
 </template>
 
 

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, Counter
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -15,6 +15,7 @@ from echo.callback_container import CallbackContainer
 from glue.core import Data
 from glue.core.component import CategoricalComponent, Component
 from glue.core.data_factories.fits import fits_reader
+from glue.core.message import NumericalDataChangedMessage
 from glue.core.subset import CategorySubsetState
 
 from .data_management import *
@@ -27,6 +28,7 @@ class HubblesLaw(Story):
     calculations = DictCallbackProperty({})
     validation_failure_counts = DictCallbackProperty({})
     has_best_fit_galaxy = CallbackProperty(False)
+    enough_students_ready = CallbackProperty(False)
 
     name_ext = ".fits"
 
@@ -38,6 +40,10 @@ class HubblesLaw(Story):
         self._on_timer_cbs = CallbackContainer()
 
         self.add_callback('has_best_fit_galaxy', self.update_student_data)
+
+        self.hub.subscribe(self, NumericalDataChangedMessage,
+                           filter=lambda msg: msg.data.label == CLASS_DATA_LABEL,
+                           handler=self._on_class_data_updated)
 
         # Load data needed for Hubble's Law
         data_dir = Path(__file__).parent / "data"
@@ -446,6 +452,14 @@ class HubblesLaw(Story):
 
     def on_timer(self, cb):
         self._on_timer_cbs.append(cb)
+
+    def _on_class_data_updated(self, _message):
+        if not self.enough_students_ready:
+            class_data = self.data_collection[CLASS_DATA_LABEL]
+            counter = Counter(class_data[STUDENT_ID_COMPONENT])
+            students_ready = len([k for k, v in counter.items() if v >= 5])
+            if students_ready >= 6:
+                self.enough_students_ready = True
 
     def fetch_class_data(self):
         def check_update(measurements):


### PR DESCRIPTION
This PR adds a "waiting screen" for students who reach stage four before "enough" of their classmates finish collecting their data. Currently, the waiting screen allows them to use a WWT window until things are ready for them to proceed. The condition for this is connected to the class data - when enough students have finished taking measurements (that is, they have 5 data points), the waiting screen is taken away. Currently, I've defined "enough" students to be 6. We can easily change that - it's set on line 461 in `story.py`.

To test this, it's easiest to turn off the automatic class data updating to have some good control over what the class data actually is. Here's what I did:

* Comment out lines 144-145 and 483 in `story.py` (where the repeated timer is created, and where we initially fetch the class data).
* Manually set the class data to include data from 5 students via:
```
import requests

from cosmicds.utils import API_URL
from hubbleds.utils import HUBBLE_ROUTE_PATH

story = app.story_state
n_students = 5
n_measurements = 5 * n_students
url = f"{API_URL}/{HUBBLE_ROUTE_PATH}/stage-3-data/3005/178"
res = requests.get(url).json()
measurements = res["measurements"]
measurements = measurements[:n_measurements]
data = story.data_from_measurements(measurements)
data.label = "class_data"
app.data_collection["class_data"].update_values_from_data(data)
```

You should see the loading screen. Re-running the above block with `n_students = 6` should update the stage to show the regular content.