### PR TITLE
Fix total score in final guideline

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_story_finish.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_story_finish.vue
@@ -13,7 +13,7 @@
       class="mb-4"
     >
     <p>
-      You have completed the Hubble Data Story with {{ story_state.total_score}} <v-icon>mdi-piggy-bank</v-icon> points. Nice work!
+      You have completed the Hubble Data Story with {{ state.total_score }} <v-icon>mdi-piggy-bank</v-icon> points. Nice work!
     </p>
     <p>
       You may be wondering "So what's the <strong>right</strong> answer?"
@@ -29,6 +29,6 @@
 
 <script>
 module.exports = {
- props: ['state', 'story_state']
+ props: ['state'] 
 }
 </script>

--- a/src/hubbleds/stages/stage_6.py
+++ b/src/hubbleds/stages/stage_6.py
@@ -1,7 +1,7 @@
 from os.path import join
 from pathlib import Path
 
-from echo import CallbackProperty, add_callback, callback_property
+from echo import CallbackProperty, add_callback, callback_property, keep_in_sync
 from glue.core.message import NumericalDataChangedMessage
 from glue.core import Subset
 from traitlets import Bool, default
@@ -28,6 +28,8 @@ class StageState(CDSState):
     our_age = CallbackProperty(0)
 
     max_prodata_index = CallbackProperty(0)
+
+    total_score = CallbackProperty(0)
     
     markers = [
         'pro_dat0',
@@ -125,6 +127,7 @@ class StageFive(HubbleStage):
         # self.stage_state.marker = self.stage_state.markers[0]
         
         add_callback(self.stage_state, 'marker', self._on_marker_update, echo_old=True)
+        self._score_sync = keep_in_sync(self.story_state, 'total_score', self.stage_state, 'total_score');
         
         prodata_viewer = self.add_viewer(HubbleScatterView, "prodata_viewer",
                                          "Professional Data")

--- a/src/hubbleds/stages/stage_6.vue
+++ b/src/hubbleds/stages/stage_6.vue
@@ -76,8 +76,7 @@
         <guideline-story-finish
           v-if="stage_state.marker == 'sto_fin1'"
           v-intersect.once="scrollIntoView"
-          :state="stage_state"
-          :story_state="story_state"/>
+          :state="stage_state"/> 
 
       </v-col>
       <v-col


### PR DESCRIPTION
This PR fixes the display of the total score in the final guideline. The issue is that the story state doesn't get updated in the frontend - I'm thinking this may be related to the issues we were seeing in https://github.com/cosmicds/cosmicds/issues/176. This hadn't surfaced before because this is actually the only place that we've tried to use the story state in the frontend, at least in the stages.

This PR provides a fix by adding a `total_score` member to the stage 6 state which is synced to the story state value.

Fixes #145.