### PR TITLE
Remove debugging statements

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_angsize_meas3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_angsize_meas3.vue
@@ -33,10 +33,6 @@
 
 <script>
 module.exports = {
-  props: ['state'],
-  created() {
-    console.log(this);
-    console.log(this.state.ruler_clicked_total);
-  }
+  props: ['state']
 }
 </script>


### PR DESCRIPTION
This is a tiny PR to remove `console.log` statements left over from debugging #160.