### PR TITLE
Markers align to binning

### DIFF
--- a/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
+++ b/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
@@ -441,17 +441,19 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate,HubListener):
             self.dotplot_viewer_2.line_label.x = [new_x]
             self.dotplot_viewer_2.line_label.text = [self.dotplot_viewer_2._label_text(new_x)]
 
-
-
+    @staticmethod
+    def get_bin(bins, x):
+        bin_width = bins[1] - bins[0]
+        index = int((x - bins[0])/bin_width)
+        return bins[0] + bin_width * (index + 1/2)
+    
     def plot_measurements(self, data):
         """ data should be a glue data"""
         vel = data.to_dataframe()[VELOCITY_COMPONENT]
         
         if self.show_first_measurment:
             viewer = self.dotplot_viewer
-            bins = viewer.state.bins
-            index = self.search_sorted(bins, vel[0])
-            x = (bins[index] + bins[index-1]) / 2
+            x = self.get_bin(viewer.state.bins, vel[0])
             self.first_meas_line.x = [x,x]
             self.first_meas_plotted = True
         else:
@@ -460,8 +462,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate,HubListener):
         if self.show_second_measurment:
             viewer = self.dotplot_viewer_2
             bins = viewer.state.bins
-            index = self.search_sorted(bins, vel[1])
-            x = (bins[index] + bins[index-1]) / 2
+            x = self.get_bin(viewer.state.bins, vel[1])
             self.second_meas_line.x = [x,x]
             self.second_meas_plotted = True
         else:

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -482,8 +482,11 @@ class StageTwo(HubbleStage):
         
     @staticmethod  
     def binned_x(bins, x):
-        index = searchsorted(bins, x, side='right')
-        return (bins[index] + bins[index-1]) / 2
+        # index = searchsorted(bins, x, side='right')
+        # return (bins[index] + bins[index-1]) / 2
+        bin_width = bins[1] - bins[0]
+        index = int((x - bins[0])/bin_width)
+        return bins[0] + bin_width * (index + 1/2)
     
     def plot_measurement(self, viewer, x, color, label = None):
         # x needs to be in a bin

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -424,17 +424,16 @@ class StageTwo(HubbleStage):
             # previous line shows up when you click on the figure
             v1.show_previous_line(show = True, show_label = True)
             v2.show_previous_line(show = True, show_label = True)
-            def _on_dotplot_click(plot, event):
+
+            def _on_dotplot_click(plot, event = None):
                 # it doesn't matter which plot we get the event from
                 # because d = C / \theta and \theta = C / d
-                event['domain']['x'] = round(DISTANCE_CONSTANT / event['domain']['x'], 0)
                 if event is None:
-                    print("No event")
                     return
-                if plot is v1:
-                    v2._on_click(event)
-                else:
-                    v1._on_click(event)
+                the_other_plot = v2 if plot is v1 else v1
+                event['domain']['x'] = self.binned_x(the_other_plot.state.bins, DISTANCE_CONSTANT / event['domain']['x'])
+                the_other_plot._on_click(event)
+
             v1.add_event_callback(lambda event:_on_dotplot_click(v1,event), events=['click'])
             v2.add_event_callback(lambda event:_on_dotplot_click(v2,event), events=['click'])
             


### PR DESCRIPTION
Make a change in stage 3, so that when clicking in one plot and placing a marker, the corresponding marker in the other plot goes to the nearest bin. 

This builds off of PR #163 

https://user-images.githubusercontent.com/7862929/234689649-49974cb9-bab1-4d51-98b6-e969da0fa019.mov

