### PR TITLE
Create front end for simplified dot sequence in Stage 1

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_check_measurement.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_check_measurement.vue
@@ -1,0 +1,24 @@
+<template>
+  <scaffold-alert
+    title-text="Check Measurement"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Now that you have measured the velocity of the example galaxy, we need a way to check your result.
+      </p>
+      <p>
+        In science, you can't always look up the "right answer," so we have to use the information available. This doesn't work 100% of the time, but one method is to follow the <strong>wisdom of crowds</strong> and see what others have measured.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_01.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_01.vue
@@ -1,0 +1,27 @@
+<template>
+  <scaffold-alert
+    title-text="Consensus"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        The first thing to check is whether there is <strong>consensus</strong> in everyone's measurements.
+      </p>
+      <p>
+        If there is consensus, the measurements will tend to cluster around a single value.
+      </p>
+      <p>
+        If there is not consensus, the measurements will be scattered across a range of values or clustered around more than one value.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_02.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_02.vue
@@ -1,0 +1,41 @@
+<template>
+  <scaffold-alert
+    title-text="Check Measurement"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :can-advance="(state) => state.dot_seq2_q"
+    :state="state"
+  >
+    <template #before-next>
+      Choose a response
+    </template>
+    <div>
+      <p>
+        Based on this graph do you think there is <it>concensus</it> on the velocity of this galaxy?
+      </p>
+      <mc-radiogroup 
+          :radio-options="[
+            'Yes',
+            'No',
+            'I am not sure',
+            ]"
+            :feedbacks="[
+            'Yes, most of the measurements appear in a cluster towards the right of the graph. Note, though, that they span a large range in velocity values.',
+            'This case could go either way. Most of the measurements appear in a cluster towards the right of the graph, but they span a very large range in velocity values.',
+            'Yeah, sometimes it is hard to tell. Most of the measurements appear in a cluster towards the right of the graph, but they span a large range in velocity values.'
+            ]" 
+          :neutral-answers="[0,1,2]"
+          @select="(opt) => { if (opt.correct || opt.neutral) { console.log('correct'); $emit('ready'); } }"
+          score-tag="vel_meas_concensus">
+            >
+          </mc-radiogroup>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_03.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_03.vue
@@ -1,0 +1,24 @@
+<template>
+  <scaffold-alert
+    title-text="Your measurement vs Others'"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Another thing to check is whether your measurement is close or far away from other values.
+      </p>
+      <p>
+        If your measurement is very far from others, that makes it an <strong>outlier</strong> and you may need to adjust how you made your measurement.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_04.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_04.vue
@@ -1,0 +1,21 @@
+<template>
+  <scaffold-alert
+    title-text="Velocity and Wavelength"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Whether or not your point is an outlier, it can be helpful to know how the measured velocities correspond to the measured wavelengths in the spectrum.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_05.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_05.vue
@@ -1,0 +1,24 @@
+<template>
+  <scaffold-alert
+    title-text="Velocity and Wavelength"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Your measured wavelength is marked in orange-red on the spectrum viewer.
+      </p>
+      <span style="color:#1DE9B6!important">
+        <strong>This guidline is where wavelength marker should turn on in viewer.</strong>
+      </span>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_06.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_06.vue
@@ -1,0 +1,27 @@
+<template>
+  <scaffold-alert
+    title-text="Velocity and Wavelength"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Move your mouse left and right in the velocity dot plot. 
+      </p>
+      <p>
+        Click on a velocity to mark the corresponding wavelength in the spectrum viewer below.
+      </p>
+      <p>
+        See if you can identify features in the spectrum viewer that correspond to outliers or to the larger cluster of velocity measurements.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_07.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_07.vue
@@ -1,0 +1,25 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :can-advance="(state) => state.dot_zoom_activated"
+    :state="state"
+  >
+    <template #before-next>
+      Click <span style="color:#1DE9B6!important">magnifying glass icon</span>
+    </template>
+    <div>
+      <p>
+        Let's take a closer look at the cluster of measurements to the right of the graph. Click <span style="color:#1DE9B6!important">insert magnifying glass icon here</span> to activate the zoom tool.
+      </p>
+      <span style="color:#1DE9B6!important">After zoom tool is activated, autoadvance to next guideline</span>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_08.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_08.vue
@@ -1,0 +1,25 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :can-advance="(state) => state.dot_zoomed"
+    :state="state"
+  >
+    <template #before-next>
+      Zoom in
+    </template>
+    <div>
+      <p>
+        Click and drag across the cluster of velocity measurements to zoom in.
+      </p>
+      <span style="color:#1DE9B6!important">After user zooms in, autoadvance to next guideline</span>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_09.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_09.vue
@@ -1,0 +1,21 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        You should see that the tall towers of dots have split into smaller towers across smaller velocity bins. If not, zoom in closer by clicking and dragging again, or click <span style="color:#1DE9B6!important">reset icon</span> to reset the view and try again.
+      </p>
+      <span style="color:#1DE9B6!important">After zoom tool is activated, autoadvance to next guideline</span>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_10.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_10.vue
@@ -1,0 +1,23 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        Earlier, it might have seemed like there was consensus in our measurements, but now that we are zoomed in, notice that the velocities are actually clustered around multiple values.
+      </p>
+      <p>
+        Click on different velocity values to see which features in the spectrum viewer they are connected to.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_11.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_11.vue
@@ -1,0 +1,46 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        We have zoomed in to the corresponding range of the spectrum viewer.
+      </p>
+      <p>
+        When you measured the line earlier, you may have noticed that there is actually a trio of lines here. And you might have wondered which of them is the one you should have measured. The tallest one? The middle one?
+      </p>
+
+      <v-btn
+      block
+      color="deep-orange darken-2"
+      @click="
+        learn_more = !learn_more
+      "
+      >
+        What causes these lines?
+      </v-btn>
+      <v-alert
+        class="mt-4 trend-alert"
+        v-if="learn_more"
+        dense
+        color="info darken-1"
+      >
+        Many galaxies have this trio of lines. The H-alpha line is the one in the middle that corresponds to the marker. The emission lines to the left and right are cause by nitrogen in the galaxy.
+      </v-alert>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+
+<script>
+module.exports = {
+  props: ['state'],
+
+  data: () => ({
+      learn_more: false,
+  })
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_12.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_12.vue
@@ -1,0 +1,22 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <p>
+        The H-alpha line is the one in the middle that corresponds to the marker. It may have been tempting to choose the tallest line present, but you should always choose the line that aligns with the marker.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_13.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_13.vue
@@ -1,0 +1,18 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div>
+      <span style="color:#1DE9B6!important">Create same choice card and parallel behavior from Stage 3 tutorial to end</span>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_intro_dotplot.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_intro_dotplot.vue
@@ -1,0 +1,32 @@
+<template>
+  <scaffold-alert
+    title-text="Dot plots"
+    :can-advance="(state) => state.dotplot_tutorial_opened"
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <template #before-next>
+      Click <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">DOT PLOT TUTORIAL</span> button.
+    </template>
+
+    <div>
+      <p>
+        This is a <strong>dot plot</strong> of velocity measurements for you and a randomly chosen subset of others who have completed the Hubble Data Story.
+      </p>
+      <p>
+        Your measurement is shown as an orange-red dot.
+      </p>
+      <p>
+        Click the <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">DOT PLOT TUTORIAL</span> button to learn about interpreting dot plots.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_note_to_team.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_note_to_team.vue
@@ -1,0 +1,27 @@
+<template>
+  <scaffold-alert
+    @back="() => { state.marker_backward = 1; }"
+    @next="() => { state.marker_forward = 1; }"
+    :state="state"
+  >
+    <div style="color:#1DE9B6!important">
+      <p>
+        Implement same slideshow functionality as the Hubble runners slideshow. (text on left, dot plot viewer on right)
+      </p>
+      <ul>
+        <li> Explain how each dot represents a measurement. You can see how many measured values are in a bin
+        <li> Zooming in breaks up measurements into smaller bins, to tall dot towers split into smaller towers.
+      </ul>
+      <p>
+        Check what else is in existing tutorial that we should keep
+      </p>
+    </div>
+  </scaffold-alert>
+</template>
+
+
+<script>
+module.exports = {
+ props: ['state']
+}
+</script>

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -57,6 +57,10 @@ class StageState(CDSState):
     gal_selected = CallbackProperty(False)
     spec_viewer_reached = CallbackProperty(False)
     spec_tutorial_opened = CallbackProperty(False)
+    dotplot_tutorial_opened = CallbackProperty(True) # Need to initialize as false later
+    dot_zoom_activated = CallbackProperty(True) # Need to initialize as false later
+    dot_zoomed = CallbackProperty(True) # Need to initialize as false later
+    dot_seq2_q = CallbackProperty(False)
     lambda_used = CallbackProperty(False)
     lambda_on = CallbackProperty(False)
     waveline_set = CallbackProperty(False)
@@ -148,6 +152,22 @@ class StageState(CDSState):
         # 'dop_cal3',
         'dop_cal4',
         'dop_cal5',
+        'che_mea1',
+        'int_dot1',
+        'not_tea1', #this will get taken out once implemented
+        'dot_seq1',
+        'dot_seq2',
+        'dot_seq3',
+        'dot_seq4',
+        'dot_seq5',
+        'dot_seq6',
+        'dot_seq7',
+        'dot_seq8',
+        'dot_seq9',
+        'dot_seq10',
+        'dot_seq11',
+        'dot_seq12',
+        'dot_seq13',
         'osm_tut',
         'smt_tut',
         'rem_gal1',
@@ -1008,8 +1028,8 @@ class StageOne(HubbleStage):
 
     def fill_table(self, table, tool=None):
         print("in fill_table")
-        self.update_data_value(table._glue_data.label, MEASWAVE_COMPONENT, 6811, 0) 
-        self.update_data_value(table._glue_data.label, VELOCITY_COMPONENT, 11241, 0)
+        self.update_data_value(table._glue_data.label, MEASWAVE_COMPONENT, 6830, 0) 
+        self.update_data_value(table._glue_data.label, VELOCITY_COMPONENT, 12130, 0)
 
     def vue_fill_table(self, _args):
         print("in vue_fill_table")

--- a/src/hubbleds/stages/stage_1.vue
+++ b/src/hubbleds/stages/stage_1.vue
@@ -21,7 +21,8 @@
           color="error"
           class="black--text"
           @click="() => {
-            stage_state.marker = 'smt_tut';
+            stage_state.marker = 'che_mea1';
+            stage_state.spec_viewer_reached = true;
             fill_table();
           }"
         >
@@ -123,6 +124,16 @@
           v-intersect.once="scrollIntoView"
           :state="stage_state"
         />
+        <guideline-check-measurement
+          v-if="stage_state.marker === 'che_mea1'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-13
+          v-if="stage_state.marker === 'dot_seq13'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
       </v-col>
       <v-col
         cols="12"
@@ -153,6 +164,93 @@
           />
       </v-col>
     </v-row>
+
+<!-- Row for Velocity Dot Plot -->
+    <v-row>
+      <v-col
+        cols="12"
+        lg="4"
+      >
+        <guideline-intro-dotplot
+          v-if="stage_state.marker === 'int_dot1'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-note-to-team
+          v-if="stage_state.marker === 'not_tea1'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-01
+          v-if="stage_state.marker === 'dot_seq1'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-02
+          v-if="stage_state.marker === 'dot_seq2'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+          @ready="stage_state.dot_seq2_q = true"
+        />
+        <guideline-dot-sequence-03
+          v-if="stage_state.marker === 'dot_seq3'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-04
+          v-if="stage_state.marker === 'dot_seq4'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-06
+          v-if="stage_state.marker === 'dot_seq6'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-07
+          v-if="stage_state.marker === 'dot_seq7'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-08
+          v-if="stage_state.marker === 'dot_seq8'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-09
+          v-if="stage_state.marker === 'dot_seq9'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-10
+          v-if="stage_state.marker === 'dot_seq10'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        lg="8"
+      >
+        <v-row
+          v-if = "stage_state.indices[stage_state.marker] >= stage_state.indices['int_dot1']"
+        >
+          <v-col
+            class="py-0"
+          >
+            <v-card
+              :color="stage_state.spec_highlights.includes(stage_state.marker) ? 'info' : 'black'"
+              :class="stage_state.spec_highlights.includes(stage_state.marker) ? 'pa-1 my-n1' : 'pa-0'"
+              outlined
+            >
+              This is where velocity measurement dot plot goes
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+
+<!-- Row for Spectrum Viewer -->
     <v-row>
       <v-col
         cols="12"
@@ -205,6 +303,21 @@
         />
         <guideline-doppler-calc-2
           v-if="stage_state.marker === 'dop_cal2'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-05
+          v-if="stage_state.marker === 'dot_seq5'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-11
+          v-if="stage_state.marker === 'dot_seq11'"
+          v-intersect.once="scrollIntoView"
+          :state="stage_state"
+        />
+        <guideline-dot-sequence-12
+          v-if="stage_state.marker === 'dot_seq12'"
           v-intersect.once="scrollIntoView"
           :state="stage_state"
         />
@@ -284,6 +397,7 @@
             >
               calculate velocities
             </v-btn>
+          Marker: {{ stage_state.marker }}
           </v-col>
         </v-row>
       </v-col>


### PR DESCRIPTION
- This creates the guidelines for a simplified tutorial sequence in Stage 1
- Back end actions or front end slideshows that still need to be created are noted direction on the guidelines in light green. We will need to remove those once the back end content is complete.
- I realized that the guideline text I wrote describing consensus only applies if students don't measure a far to the right outlier, so I will need to modify the text to be more general. I'll do that on a future pass.

@johnarban, let me know if this looks ok to you, and if so, you can start hooking up the back end functionality and I can create the shorter tutorial slideshow.