### PR TITLE
Update y limits on spectrum viewer zoom

### DIFF
--- a/src/hubbleds/tools/wavelength_zoom.py
+++ b/src/hubbleds/tools/wavelength_zoom.py
@@ -22,6 +22,8 @@ class WavelengthZoom(BqplotXZoom):
             return
         super().update_selection(*args)
 
+        state._reset_y_limits()
+
         if self.on_zoom is not None:
             xbounds_new = [state.x_min, state.x_max]
             self.on_zoom(xbounds_old, xbounds_new)

--- a/src/hubbleds/viewers/spectrum_view.py
+++ b/src/hubbleds/viewers/spectrum_view.py
@@ -28,6 +28,13 @@ class SpectrumViewerState(LineHoverStateMixin, ScatterViewerState):
     def ymax_factor(self):
         return self._YMAX_FACTOR
 
+    def _reset_y_limits(self):
+        with delay_callback(self, 'y_min', 'y_max'):
+            ymin, ymax = self.y_min, self.y_max
+            super()._reset_y_limits()
+            self.y_max = self._YMAX_FACTOR * self.y_max
+            self.resolution_y *= (self.y_max - self.y_min) / (ymax - ymin)
+
     def reset_limits(self):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             xmin, xmax = self.x_min, self.x_max


### PR DESCRIPTION
This PR aims to resolve #183 by resetting the y-limits of the spectrum viewer when the speczoom tool is used.