### PR TITLE
Make wavelength zoom aware of x-axis bounds

### DIFF
--- a/src/hubbleds/tools/wavelength_zoom.py
+++ b/src/hubbleds/tools/wavelength_zoom.py
@@ -22,7 +22,7 @@ class WavelengthZoom(BqplotXZoom):
             return
         super().update_selection(*args)
 
-        state._reset_y_limits()
+        state.reset_y_limits_for_view()
 
         if self.on_zoom is not None:
             xbounds_new = [state.x_min, state.x_max]


### PR DESCRIPTION
I realized that #194 didn't actually solve the main issue of #183, since the `_reset_y_limits` method called there isn't zoom-aware. This PR updates the wavelength zoom tool to reset the y limits based on the x-axis bounds. @patudom let me know what you think about the behavior of this.