### PR TITLE
Finish new stage 1 tutorial 2

### DIFF
--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -13,44 +13,22 @@ from functools import partial
 class DotplotTutorialSlideshow(v.VuetifyTemplate):
     template = load_template("dotplot_tutorial_slideshow.vue", __file__, traitlet=True).tag(sync=True)
     step = Int(0).tag(sync=True)
-    length = Int(5).tag(sync=True)
+    length = Int(4).tag(sync=True)
     dialog = Bool(False).tag(sync=True)
-    opened = Bool(False).tag(sync=True)
+    finished = Bool(False).tag(sync=True)
     currentTitle = Unicode("").tag(sync=True)
     maxStepCompleted = Int(0).tag(sync=True)
-    interactSteps = List([]).tag(sync=True)
-    image_location = Unicode().tag(sync=True)
-    # layer_viewer = Instance(DOMWidget).tag(sync=True, **widget_serialization)
     dotplot_viewer = Instance(DOMWidget).tag(sync=True, **widget_serialization)
 
-    _titles = [
-        "Title 1",
-        "Title 2",
-        "Title 3",
-        "Title 4",
-        "Title 5",
-
-    ]
     _default_title = "Dot Plot Tutorial"
 
     def __init__(self, viewers, *args, **kwargs):
         self.currentTitle = self._default_title
         self.dotplot_viewer = viewers[0]
         self.dotplot_viewer_viewer = viewers[0].viewer
-        # self.layer_viewer = viewers[1]
         self.dotplot_viewer_viewer.add_lines_to_figure()
         
         extend_tool(self.dotplot_viewer_viewer, "bqplot:xzoom", activate_cb=self.on_zoom_active, deactivate_cb=self.on_zoom_deactive)        
-
-        def update_title(change):
-            index = change["new"]
-            print("step:", index)
-            if index in range(len(self._titles)):
-                self.currentTitle = self._titles[index]
-            else:
-                self.currentTitle = self._default_title
-
-        self.observe(update_title, names=["step"])
 
         super().__init__(*args, **kwargs)
         
@@ -60,7 +38,6 @@ class DotplotTutorialSlideshow(v.VuetifyTemplate):
     def vue_home_add_previous_line(self, _data = None):
         f = partial(self.dotplot_viewer_viewer.add_lines_to_figure, add_line = False, add_previous_line = True)
         extend_tool(self.dotplot_viewer_viewer, "bqplot:home", activate_cb=f, activate_before_tool=False)
-        
     
     def vue_activate_zoom_tool(self, _data = None):
         self.dotplot_viewer_viewer.toolbar.set_tool_enabled("bqplot:xzoom", True)
@@ -80,7 +57,6 @@ class DotplotTutorialSlideshow(v.VuetifyTemplate):
             pass
         self.dotplot_viewer_viewer.show_previous_line(False, False)
         self.dotplot_viewer_viewer.show_line(False, False)
-    
     
     def on_zoom_active(self, *args, **kwargs):
         self.vue_removeMeasuringTool()

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -35,13 +35,15 @@ class DotplotTutorialSlideshow(v.VuetifyTemplate):
     def vue_home_add_line(self, _data = None):
         f = partial(self.dotplot_viewer_viewer.add_lines_to_figure, add_line = True, add_previous_line = False)
         extend_tool(self.dotplot_viewer_viewer, "bqplot:home", activate_cb=f, activate_before_tool=False)
+
     def vue_home_add_previous_line(self, _data = None):
         f = partial(self.dotplot_viewer_viewer.add_lines_to_figure, add_line = False, add_previous_line = True)
         extend_tool(self.dotplot_viewer_viewer, "bqplot:home", activate_cb=f, activate_before_tool=False)
     
     def vue_activate_zoom_tool(self, _data = None):
         self.dotplot_viewer_viewer.toolbar.set_tool_enabled("bqplot:xzoom", True)
-    
+        self.dotplot_viewer_viewer.toolbar.set_tool_enabled("bqplot:home", True)
+
     def vue_activate_selector(self, _data = None):
         self.dotplot_viewer_viewer.show_previous_line(False, False)
         self.dotplot_viewer_viewer.add_event_callback(self.dotplot_viewer_viewer._on_click, events = ['click'])

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -28,7 +28,7 @@ class DotplotTutorialSlideshow(v.VuetifyTemplate):
         self.dotplot_viewer_viewer = viewers[0].viewer
         self.dotplot_viewer_viewer.add_lines_to_figure()
         
-        extend_tool(self.dotplot_viewer_viewer, "bqplot:xzoom", activate_cb=self.on_zoom_active, deactivate_cb=self.on_zoom_deactive)        
+        extend_tool(self.dotplot_viewer_viewer, "hubble:wavezoom", activate_cb=self.on_zoom_active, deactivate_cb=self.on_zoom_deactive)        
 
         super().__init__(*args, **kwargs)
         
@@ -41,7 +41,7 @@ class DotplotTutorialSlideshow(v.VuetifyTemplate):
         extend_tool(self.dotplot_viewer_viewer, "bqplot:home", activate_cb=f, activate_before_tool=False)
     
     def vue_activate_zoom_tool(self, _data = None):
-        self.dotplot_viewer_viewer.toolbar.set_tool_enabled("bqplot:xzoom", True)
+        self.dotplot_viewer_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
         self.dotplot_viewer_viewer.toolbar.set_tool_enabled("bqplot:home", True)
 
     def vue_activate_selector(self, _data = None):

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
@@ -11,7 +11,7 @@
         color="secondary"
         elevation="2"
         id="slideshow-button"
-        @click.stop="() => { dialog = true; opened = true }"
+        @click.stop="() => { dialog = true; }"
       >
         Dot Plot Tutorial
       </v-btn>
@@ -40,7 +40,6 @@
         <v-btn
           icon
           @click="closeDialog()"
-          :disabled="maxStepCompleted < length - 1"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -51,17 +50,15 @@
           style="height: 70vh;"
           class="overflow-auto"
         >
-        
         <v-row>
-          
           <v-col
             cols="12"
             lg="5"
             >
             
-        <v-window-item :value="0" class="no-transition">
-          <v-card-text>
-            <v-container>
+            <v-window-item :value="0" class="no-transition">
+              <v-card-text>
+                <v-container>
                   <p>
                     This <strong>dot plot</strong> displays&#8212;as a dot&#8212;every velocity measurement in our sample.
                   </p>
@@ -77,26 +74,26 @@
                   <div style="color:#1DE9B6!important">
                     Tools off on this slide
                   </div>
-            </v-container>
-          </v-card-text>
-        </v-window-item>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
 
-        <v-window-item :value="1" class="no-transition">
-          <v-card-text>
-            <v-container>
+            <v-window-item :value="1" class="no-transition">
+              <v-card-text>
+                <v-container>
                   <p>
                     As with the spectrum viewer, if you move your mouse left and right within the dot plot, the vertical marker will display the velocity value for the center of each bin.
                   </p>
                   <div style="color:#1DE9B6!important">
                     Activate measuring tool
                   </div>
-            </v-container>
-          </v-card-text>
-        </v-window-item>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
 
-        <v-window-item :value="2" class="no-transition">
-          <v-card-text>
-            <v-container>
+            <v-window-item :value="2" class="no-transition">
+              <v-card-text>
+                <v-container>
                   <p>
                     Our data sample includes a very large range of velocity values, but most of the data points are clustered in one or more tall towers of dots around 11,000 to 12,000 km/s. 
                   </p>
@@ -112,41 +109,33 @@
                   <div style="color:#1DE9B6!important">
                     Turn on zoom in and reset buttons. Measuring tool should be disabled when zoom is enabled. Measuring tool should be re-enabled when zoom is complete.
                   </div>
-            </v-container>
-          </v-card-text>
-        </v-window-item>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
 
-        <v-window-item :value="3" class="no-transition">
-          <v-card-text>
-            <v-container>
+            <v-window-item :value="3" class="no-transition">
+              <v-card-text>
+                <v-container>
                   <p>
                     You should see that the tall towers of dots have split into smaller towers. If not, zoom in closer by clicking and dragging again, or click (reset icon) to reset the view and try again.
                   </p>
                   <p>
                     This happens because each tower of dots represents a <strong>range</strong> of velocity values. When you zoomed in, the data were rebinned across smaller velocity ranges. What seemed like a big cluster of velocity values has now broken up into a few smaller clusters.
-                  </p>                    
-            </v-container>
-          </v-card-text>
-        </v-window-item>
-
-        <v-window-item :value="4" class="no-transition">
-          <v-card-text>
-            <v-container>
+                  </p>
                   <p>
                     That's all you need to know about dot plots for now. Click done to continue.  
-                  </p>                 
-            </v-container>
-          </v-card-text>
-        </v-window-item>
-        </v-col>
-
+                  </p>                      
+                </v-container>
+              </v-card-text>
+            </v-window-item>  
+          </v-col>
           <v-col
-          v-if="step < length-1"
-          cols="12"
-          lg="7">
-          <jupyter-widget :widget="dotplot_viewer"/>
-        </v-col>
-      </v-row>
+            cols="12"
+            lg="7"
+          >
+           <jupyter-widget :widget="dotplot_viewer"/>
+          </v-col>
+        </v-row>
       </v-window>
       
       <v-divider></v-divider>
@@ -175,7 +164,6 @@
             v-slot="{ active, toggle }"
           >
             <v-btn
-              :disabled="n > maxStepCompleted + 2"
               :input-value="active"
               icon
               @click="toggle"
@@ -186,7 +174,6 @@
         </v-item-group>
         <v-spacer></v-spacer>
           <v-btn
-          :disabled="step > maxStepCompleted"
           v-if="step < length-1"
           color="accent"
           class="black--text"
@@ -200,7 +187,7 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { $emit('close'); dialog = false; step = 0; opened = true }"
+          @click="() => { $emit('close'); dialog = false; step = 0; finished = true }"
         >
           Done
         </v-btn>
@@ -214,8 +201,6 @@ export default {
   
   watch: {
     step(newStep) {
-      const isInteractStep = this.interactSteps.includes(newStep);
-      const newCompleted = isInteractStep ? newStep - 1 : newStep;
       this.maxStepCompleted = Math.max(this.maxStepCompleted, newCompleted);
 
       if (newStep == 1) {
@@ -236,12 +221,10 @@ export default {
 
   methods: {
     closeDialog() {
-      if (this.maxStepCompleted == this.length - 1) {
         this.$emit('close');
         this.dialog = false;
         if (this.step == this.length - 1) {
           this.step = 0;
-        }
       }
     }
   }

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
@@ -201,7 +201,7 @@ export default {
   
   watch: {
     step(newStep) {
-      this.maxStepCompleted = Math.max(this.maxStepCompleted, newCompleted);
+      this.maxStepCompleted = newStep;
 
       if (newStep == 1) {
         this.activateMeasuringTool();

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
@@ -71,9 +71,6 @@
                   <p>
                     The vertical axis shows how many measurements were made in a particular velocity bin.
                   </p>
-                  <div style="color:#1DE9B6!important">
-                    Tools off on this slide
-                  </div>
                 </v-container>
               </v-card-text>
             </v-window-item>
@@ -84,9 +81,6 @@
                   <p>
                     As with the spectrum viewer, if you move your mouse left and right within the dot plot, the vertical marker will display the velocity value for the center of each bin.
                   </p>
-                  <div style="color:#1DE9B6!important">
-                    Activate measuring tool
-                  </div>
                 </v-container>
               </v-card-text>
             </v-window-item>
@@ -95,20 +89,17 @@
               <v-card-text>
                 <v-container>
                   <p>
-                    Our data sample includes a very large range of velocity values, but most of the data points are clustered in one or more tall towers of dots around 11,000 to 12,000 km/s. 
+                    Our data sample includes a very large range of velocity values, but most of the data points are clustered in one or more tall towers of dots between 9,000 to 13,000 km/s. 
                   </p>
                   <p>
                     Let's take a closer look at this cluster of measurements. 
                   </p>
                   <p>
-                    Click (magnifying glass icon) in the toolbar to activate the zoom tool.
+                    Click <v-icon>mdi-select-search</v-icon> in the toolbar to activate the zoom tool.
                   </p>                    
                   <p>
                     Then click and drag across the cluster of velocity measurements to zoom in.
                   </p>
-                  <div style="color:#1DE9B6!important">
-                    Turn on zoom in and reset buttons. Measuring tool should be disabled when zoom is enabled. Measuring tool should be re-enabled when zoom is complete.
-                  </div>
                 </v-container>
               </v-card-text>
             </v-window-item>
@@ -117,10 +108,10 @@
               <v-card-text>
                 <v-container>
                   <p>
-                    You should see that the tall towers of dots have split into smaller towers. If not, zoom in closer by clicking and dragging again, or click (reset icon) to reset the view and try again.
+                    You should see that the tall towers of dots have split into smaller towers. If not, zoom in closer by clicking and dragging again, or click <v-icon>mdi-cached</v-icon> to reset the view and try again.
                   </p>
                   <p>
-                    This happens because each tower of dots represents a <strong>range</strong> of velocity values. When you zoomed in, the data were rebinned across smaller velocity ranges. What seemed like a big cluster of velocity values has now broken up into a few smaller clusters.
+                    This happens because each tower of dots represents a <strong>range</strong> of velocity values. When you zoomed in, the data were rebinned across smaller velocity ranges.
                   </p>
                   <p>
                     That's all you need to know about dot plots for now. Click done to continue.  

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_05.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_05.vue
@@ -15,9 +15,6 @@
       <p>
         See if you can identify features in the spectrum viewer that correspond to outliers and other velocity measurements.
       </p>
-      <span style="color:#1DE9B6!important">
-        <strong>The click wasn't working for me, but I think just synchonizing the markers in the 2 viewers would be better.</strong> (no markers were appearing in the spectrum viewer at all other than my measurement)
-      </span>
     </div>
   </scaffold-alert>
 </template>

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_12.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_dot_sequence_12.vue
@@ -2,11 +2,19 @@
   <scaffold-alert
     @back="() => { state.marker_backward = 1; }"
     @next="() => { state.marker_forward = 1; }"
+    :can-advance="(state) => false"
     :state="state"
   >
+    <template #next-content>
+    </template>
     <div>
-      <span style="color:#1DE9B6!important">Create same choice card and parallel behavior from Stage 3 tutorial to end</span>
-      
+      <p>
+        You can now remeasure the example galaxy using what you've learned and see how your answer changes.
+      </p>
+      <p>
+        Or move on to measure the spectral lines for your 5 galaxies. 
+      </p>
+
       <v-btn 
         block color="accent"
         class="black--text"

--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_intro_dotplot.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_intro_dotplot.vue
@@ -1,7 +1,7 @@
 <template>
   <scaffold-alert
     title-text="Dot plots"
-    :can-advance="(state) => state.dotplot_tutorial_opened"
+    :can-advance="(state) => state.dotplot_tutorial_finished"
     @back="() => { state.marker_backward = 1; }"
     @next="() => { state.marker_forward = 1; }"
     :state="state"

--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_dotplot_seq5.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_dotplot_seq5.vue
@@ -1,9 +1,5 @@
 <template>
   <scaffold-alert
-    color="info"
-    class="mb-4 mx-auto"
-    max-width="800"
-    elevation="6"
     title-text="Measurement Comparison"
     @back="state.marker_backward = 1"
     :can-advance="(state) => false"
@@ -16,7 +12,7 @@
       class="mb-4"
     >
       <p>
-        You can now remeasure the example galaxy using what you've learned and see how your answer changes
+        You can now remeasure the example galaxy using what you've learned and see how your answer changes.
       </p>
       <p>
         Or move on to measure the sizes for your 5 galaxies. 

--- a/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
+++ b/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
@@ -632,7 +632,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
                self.spec_view_first_label, 
                self.spec_view_second_label
                ]
-        marks = [m for m in self.spectrum_viewer.figure.marks if m not in marks_to_remove]
+        marks = [m for m in self.spectrum_viewer.figure.marks if m in marks_to_remove]
         for mark in marks:
             mark.visible = False
         # self.spectrum_viewer.figure.marks = marks

--- a/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
+++ b/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
@@ -219,7 +219,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
             
             self.add_selector_lines()
             self.vue_tracking_lines_off()
-            self.dotplot_viewer.toolbar.set_tool_enabled("bqplot:xzoom",self.zoom_tool_activated)
+            self.dotplot_viewer.toolbar.set_tool_enabled("hubble:wavezoom",self.zoom_tool_activated)
             
             self.spectrum_viewer.add_event_callback(self._update_selector_tool_sv, events=['mousemove'])
             self.dotplot_viewer.add_event_callback(self._update_selector_tool_dp, events=['mousemove'])
@@ -284,7 +284,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
                 print_log('on_click not found')
             
         if new == 'dot_seq2':
-            self.dotplot_viewer.toolbar.set_tool_enabled("bqplot:xzoom", True)
+            self.dotplot_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
             
         
         if new == 'dot_seq5':
@@ -319,10 +319,10 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
                 activateMeasuringTool(viewer)
                 activate_selector(viewer)
                 
-            extend_tool(self.dotplot_viewer, "bqplot:xzoom", 
+            extend_tool(self.dotplot_viewer, "hubble:wavezoom", 
                         activate_cb=partial(on_zoom_active, self.dotplot_viewer), 
                         deactivate_cb=partial(on_zoom_deactive, self.dotplot_viewer))
-            extend_tool(self.dotplot_viewer_2, "bqplot:xzoom", 
+            extend_tool(self.dotplot_viewer_2, "hubble:wavezoom", 
                         activate_cb=partial(on_zoom_active, self.dotplot_viewer_2), 
                         deactivate_cb=partial(on_zoom_deactive, self.dotplot_viewer_2))
         
@@ -331,7 +331,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
             self.example_galaxy_table.filter_by(None)#lambda item: item['measurement_number'] == 'second')
     
         if new == "dot_seq14":
-            self.dotplot_viewer_2.toolbar.set_tool_enabled("bqplot:xzoom", True)
+            self.dotplot_viewer_2.toolbar.set_tool_enabled("hubble:wavezoom", True)
             link((self.spectrum_viewer.state, 'x_min'), (self.dotplot_viewer_2.state, 'x_min'), self.w2v, self.v2w)
             link((self.spectrum_viewer.state, 'x_max'), (self.dotplot_viewer_2.state, 'x_max'), self.w2v, self.v2w)
             self.show_second_measurment = True

--- a/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
+++ b/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
@@ -464,10 +464,12 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
             new_x = event['domain']['x']
             self.dotplot_viewer_2.line.x = [new_x, new_x]
             self.dotplot_viewer_2._update_x_locations()
+            self.dotplot_viewer_2.line_label.text = [self.dotplot_viewer_2._label_text(new_x)]
             
             w = self.v2w(new_x)
             self.spectrum_viewer.line.x = [w,w]
             self.spectrum_viewer._update_x_locations()  
+            self.spectrum_viewer.line_label.text = [self.spectrum_viewer._label_text(w)]
     
     def _update_selector_tool_dp2(self, event = None):
         if not self.show_selector_lines:
@@ -476,10 +478,12 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
             new_x = event['domain']['x']
             self.dotplot_viewer.line.x = [new_x, new_x]
             self.dotplot_viewer._update_x_locations()
+            self.dotplot_viewer.line_label.text = [self.dotplot_viewer._label_text(new_x)]
             
             w = self.v2w(new_x)
             self.spectrum_viewer.line.x = [w,w]
             self.spectrum_viewer._update_x_locations()
+            self.spectrum_viewer.line_label.text = [self.spectrum_viewer._label_text(w)]
             
 
     def _update_selector_tool_sv(self, event = None):
@@ -489,9 +493,11 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
             new_x = self.w2v(event['domain']['x'])
             self.dotplot_viewer.line.x = [new_x, new_x]
             self.dotplot_viewer._update_x_locations()
+            self.dotplot_viewer.line_label.text = [self.dotplot_viewer._label_text(new_x)]
             
             self.dotplot_viewer.line_label.x = [new_x]
             self.dotplot_viewer_2._update_x_locations()
+            self.dotplot_viewer_2.line_label.text = [self.dotplot_viewer_2._label_text(new_x)]
 
     @staticmethod
     def get_bin(bins, x):

--- a/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
+++ b/src/hubbleds/components/spectrum_measurement_tutorial_sequence/spectrum_measurement_tutorial.py
@@ -327,6 +327,7 @@ class SpectrumMeasurementTutorialSequence(v.VuetifyTemplate, HubListener):
                         deactivate_cb=partial(on_zoom_deactive, self.dotplot_viewer_2))
         
         if new == "dot_seq13":
+            self.show_second_measurment = True
             self.example_galaxy_table.filter_by(None)#lambda item: item['measurement_number'] == 'second')
     
         if new == "dot_seq14":

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -315,9 +315,9 @@ class StageOne(HubbleStage):
         # dotplot_viewer_2.toolbar.set_tool_enabled('hubble:towerselect', False)
         # dotplot_viewer_3.toolbar.set_tool_enabled('hubble:towerselect', False)
 
-        dotplot_viewer.toolbar.set_tool_enabled('bqplot:xzoom', False)
-        dotplot_viewer_2.toolbar.set_tool_enabled('bqplot:xzoom', False)
-        dotplot_viewer_3.toolbar.set_tool_enabled('bqplot:xzoom', False)
+        dotplot_viewer.toolbar.set_tool_enabled('hubble:wavezoom', False)
+        dotplot_viewer_2.toolbar.set_tool_enabled('hubble:wavezoom', False)
+        dotplot_viewer_3.toolbar.set_tool_enabled('hubble:wavezoom', False)
         dotplot_viewer_3.toolbar.set_tool_enabled('bqplot:home', False)
                 
         #     HubbleHistogramView, label="dotplot_viewer")
@@ -1140,7 +1140,7 @@ class StageOne(HubbleStage):
         
     #     self.add_selector_lines() 
     #     self.vue_tracking_lines_off()
-    #     self.dotplot_viewer.toolbar.set_tool_enabled("bqplot:xzoom",self.zoom_tool_enabled)
+    #     self.dotplot_viewer.toolbar.set_tool_enabled("hubble:wavezoom",self.zoom_tool_enabled)
         
     #     self.spectrum_viewer.add_event_callback(self._update_selector_tool_sv, events=['mousemove'])
     #     self.dotplot_viewer.add_event_callback(self._update_selector_tool_dp, events=['mousemove'])

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -308,7 +308,7 @@ class StageOne(HubbleStage):
         # Add new dotplot viewer with single galaxy seed data
         dotplot_viewer = self.add_viewer(HubbleDotPlotView, label='dotplot_viewer', viewer_label = 'Example Galaxy Measurement')
         dotplot_viewer_2 = self.add_viewer(HubbleDotPlotView, label='dotplot_viewer_2', viewer_label = 'Second Measurement')
-        dotplot_viewer_3 = self.add_viewer(HubbleDotPlotView, label='dotplot_viewer_3', viewer_label = 'Dot Plot Graph')
+        dotplot_viewer_3 = self.add_viewer(HubbleDotPlotView, label='dotplot_viewer_3', viewer_label = 'Dot Plot')
 
         ### Disable anything to do with towerselect for now
         # dotplot_viewer.toolbar.set_tool_enabled('hubble:towerselect', False)

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -57,7 +57,7 @@ class StageState(CDSState):
     gal_selected = CallbackProperty(False)
     spec_viewer_reached = CallbackProperty(False)
     spec_tutorial_opened = CallbackProperty(False)
-    dotplot_tutorial_opened = CallbackProperty(True) # Need to initialize as false later
+    dotplot_tutorial_finished = CallbackProperty(False) 
     dot_zoom_activated = CallbackProperty(True) # Need to initialize as false later
     dot_zoomed = CallbackProperty(True) # Need to initialize as false later
     dot_seq8_q = CallbackProperty(False)
@@ -444,7 +444,7 @@ class StageOne(HubbleStage):
         
         dotplot_slideshow = DotplotTutorialSlideshow([self.viewers["dotplot_viewer_3"]])
         self.add_component(dotplot_slideshow, label='py-dotplot-tutorial-slideshow')
-        # dotplot_slideshow.observe(self._on_slideshow_opened, names=['opened']) # not implemented
+        dotplot_slideshow.observe(self._dotplot_slideshow_tutorial_finished, names=['finished'])
         
         # callback places velocity value in table
         add_callback(self.stage_state, 'student_vel',
@@ -530,6 +530,8 @@ class StageOne(HubbleStage):
             'cho_row1')
         self.stage_state.doppler_calc_reached = self.stage_state.marker_reached(
             'dop_cal2')
+        self.stage_state.dotplot_tutorial_finished = self.stage_state.marker_reached(
+            'dot_seq1')
 
         # Initialize viewers to provide story state
         if self.stage_state.marker_reached('sel_gal1'):
@@ -789,6 +791,9 @@ class StageOne(HubbleStage):
 
     def _spectrum_slideshow_tutorial_opened(self, msg):
         self.stage_state.spec_tutorial_opened = msg['new']
+
+    def _dotplot_slideshow_tutorial_finished(self, msg):
+        self.stage_state.dotplot_tutorial_finished = msg['new']
 
     def _on_doppler_dialog_changed(self, msg):
         self.stage_state.doppler_calc_dialog = msg['new']

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -318,7 +318,7 @@ class StageOne(HubbleStage):
         dotplot_viewer.toolbar.set_tool_enabled('bqplot:xzoom', False)
         dotplot_viewer_2.toolbar.set_tool_enabled('bqplot:xzoom', False)
         dotplot_viewer_3.toolbar.set_tool_enabled('bqplot:xzoom', False)
-        
+        dotplot_viewer_3.toolbar.set_tool_enabled('bqplot:home', False)
                 
         #     HubbleHistogramView, label="dotplot_viewer")
         example_galaxy_data = self.get_data(EXAMPLE_GALAXY_SEED_DATA)
@@ -1065,12 +1065,10 @@ class StageOne(HubbleStage):
         self.story_state.update_data(SPECTRUM_DATA_LABEL, data)
 
     def fill_table(self, table, tool=None):
-        print("in fill_table")
         self.update_data_value(table._glue_data.label, MEASWAVE_COMPONENT, 6830, 0) 
         self.update_data_value(table._glue_data.label, VELOCITY_COMPONENT, 12130, 0)
 
     def vue_fill_table(self, _args):
-        print("in vue_fill_table")
         self.fill_table(self.example_galaxy_table)
     
     

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -827,6 +827,9 @@ class StageOne(HubbleStage):
         z = galaxy["z"]
         self.story_state.update_data(SPECTRUM_DATA_LABEL, spec_data)
         self.update_spectrum_viewer(name, z,  table )
+        
+        if self.stage_state.marker_reached('cho_row1'):
+            self.stage_state.spec_viewer_reached = True
 
         if self.stage_state.marker == 'cho_row1':
             self.stage_state.spec_viewer_reached = True

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -452,13 +452,7 @@ class StageOne(HubbleStage):
         add_callback(self.stage_state, 'completed',
                      self.complete_stage_1)
         
-        def break_this(x):
-            print('changed show_galaxy_table to', x)
-            # if x:
-            #    raise Exception('break this')
-        add_callback(self.stage_state, 'show_galaxy_table',break_this)
-        add_callback(self.stage_state, 'show_example_galaxy_table',lambda x: print_log('changed show_example_galaxy_table to', x))
-        add_callback(self.stage_state, 'show_meas_tutorial', lambda x: print_log('changed show_meas_tutorial to', x))
+
 
         # Callbacks
         def update_count(change):
@@ -654,8 +648,6 @@ class StageOne(HubbleStage):
         
         # activate the dot plot sequence stuff
         if self.stage_state.marker_reached('int_dot1'):
-            print_log(f'int_dot1 reached and random state variable set from {self.stage_state.dot_zoomed} to False')
-            self.stage_state.dot_zoomed = False
             if (not self.spectrum_measurement_tutorial.been_opened) and self.stage_state.marker_before('rem_gal1'):
                 self.spectrum_measurement_tutorial._on_dialog_open({'new': True})
          

--- a/src/hubbleds/stages/stage_1.vue
+++ b/src/hubbleds/stages/stage_1.vue
@@ -242,7 +242,7 @@
         lg="8"
       >
         <v-row
-          v-if="stage_state.indices[stage_state.marker] >= stage_state.indices['int_dot1'] && stage_state.indices[stage_state.marker] < stage_state.indices['dot_seq13']"
+          v-if="stage_state.indices[stage_state.marker] >= stage_state.indices['int_dot1'] && stage_state.indices[stage_state.marker] < stage_state.indices['dot_seq13'] || stage_state.indices[stage_state.marker] == stage_state.indices['dot_seq14']"
         >
           <v-col
             class="py-0"

--- a/src/hubbleds/viewers/hubble_dotplot.py
+++ b/src/hubbleds/viewers/hubble_dotplot.py
@@ -82,7 +82,7 @@ HubbleDotPlotView = cds_viewer(
     name="HubbleDotPlotView",
     viewer_tools=[
         "bqplot:home",
-        "bqplot:xzoom",
+        "hubble:wavezoom",
         #'hubble:towerselect'
     ],
     label="Dot Plot",


### PR DESCRIPTION
Some minor front end changes and a bit of back end sequencing

- Require students to complete the dot plot tutorial slideshow before proceeding. (It's only considered "finished" when you hit "done" on Slide 4. The team can bypass most of the slideshow by skipping straight to the 4th dot.)
- In slideshow, turn "bqplot:home" button off and on with the bqplot:xzoom button because it doesn't make sense to have a home button that doesn't do anything.
- Remove green "note to team" text and edit slideshow and guideline text

There are a few lingering issues which I will note in additional comments below.