### PR TITLE
Remove sympy import

### DIFF
--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -1,6 +1,5 @@
 import ipyvuetify as v
 from pathlib import Path
-from sympy import preview
 from traitlets import Int, Bool, Unicode, List, Instance
 from cosmicds.utils import load_template, extend_tool
 from glue_jupyter.state_traitlets_helpers import GlueState


### PR DESCRIPTION
This PR removes an import of the `preview` function from `sympy`. This doesn't actually get used anywhere, but is problematic because `sympy` isn't listed in the package requirements - thus, unless you've installed it manually, you get a `ModuleNotFoundError`.