### PR TITLE
Replace toggle tool with layer toggler

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_4/guideline_trends_data2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4/guideline_trends_data2.vue
@@ -11,7 +11,7 @@
     :state="state"
   >
     <template #before-next>
-      Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-google-classroom</v-icon></v-btn> in Toolbar.
+      Click Class Data box
     </template>
 
     <div
@@ -24,7 +24,7 @@
         Since everyone in your class also measured 5 galaxies, let's look at a dataset that combines everyone's measurements.
       </p>
       <p>
-        Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-google-classroom</v-icon></v-btn>  to display measurements from your entire class.
+        Click the box next to  <span style="background-color: white; border-radius : 5px; padding: 3px; color:black!important; font-size: 80%"><strong>Class Data</strong></span>  in the legend panel to display measurements from your entire class.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -168,6 +168,7 @@ class StageThree(HubbleStage):
         link((self.story_state, 'enough_students_ready'), (self.stage_state, 'stage_ready'))
 
         self.show_team_interface = self.app_state.show_team_interface
+        self._setup_complete = False
 
         student_data = self.get_data(STUDENT_DATA_LABEL)
         class_meas_data = self.get_data(CLASS_DATA_LABEL)
@@ -392,7 +393,10 @@ class StageThree(HubbleStage):
             remove_callback(self.story_state, 'stage_index', self._on_stage_index_changed)
 
     def _deferred_setup(self):
+        if self._setup_complete:
+            return
         self._setup_scatter_layers()
+        self._setup_complete = True
 
     @property
     def all_viewers(self):

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -200,6 +200,13 @@ class StageThree(HubbleStage):
             BEST_FIT_SUBSET_LABEL: "Best Fit Galaxy"
         })
         self.ignore_class_layer = lambda layer_state: layer_state.layer.label == CLASS_DATA_LABEL
+        def advance_on_class_toggled(change):
+            if self.stage_state.marker == 'tre_dat2' and 1 in change["new"]:
+                self.stage_state.class_layer_toggled = 1
+                self.stage_state.marker = 'tre_dat3'
+                layer_toggle.unobserve(self.layer_toggle_advance)
+        self.layer_toggle_advance = advance_on_class_toggled
+        layer_toggle.observe(self.layer_toggle_advance, names=['selected'])
         layer_toggle.add_ignore_condition(self.ignore_class_layer)
         layer_toggle.add_ignore_condition(lambda layer_state: layer_state.layer.label in [fit_table.subset_label, BEST_FIT_SUBSET_LABEL])
         self.add_component(layer_toggle, label="py-layer-toggle")     
@@ -282,8 +289,8 @@ class StageThree(HubbleStage):
         markers = self.stage_state.markers
         advancing = markers.index(new) > markers.index(old)
         if advancing and new == "tre_dat2":
-            layer_viewer = self.get_viewer("layer_viewer")
-            layer_viewer.toolbar.set_tool_enabled('hubble:toggleclass', True)
+            layer_toggle = self.get_component("py-layer-toggle")
+            layer_toggle.remove_ignore_condition(self.ignore_class_layer)
         if advancing and new == "tre_lin1":
             layer_viewer = self.get_viewer("layer_viewer")
             class_meas_data = self.get_data(CLASS_DATA_LABEL)
@@ -292,9 +299,6 @@ class StageThree(HubbleStage):
         if advancing and new == "you_age1":
             layer_viewer = self.get_viewer("layer_viewer")                
             layer_viewer.toolbar.tools["hubble:linefit"].show_labels = True
-        if advancing and new == "tre_lin1":
-            layer_viewer = self.get_viewer("layer_viewer")
-            layer_viewer.toolbar.set_tool_enabled('hubble:toggleclass', False)
         if advancing and new == "tre_lin2":
             layer_viewer = self.get_viewer("layer_viewer")
             layer_viewer.toolbar.tools["hubble:linefit"].show_labels = True
@@ -314,13 +318,6 @@ class StageThree(HubbleStage):
     def _on_slideshow_opened(self, msg):
         self.stage_state.hubble_dialog_opened = msg["new"]
     
-    def _on_class_layer_toggled(self, used):
-        self.stage_state.class_layer_toggled = used
-        if self.stage_state.marker == 'tre_dat2':
-            self.stage_state.marker = 'tre_dat3'
-            layer_toggle = self.get_component("py-layer-toggle")
-            layer_toggle.remove_ignore_condition(self.ignore_class_layer)
-
     def _setup_scatter_layers(self):
         layer_viewer = self.get_viewer("layer_viewer")
         student_data = self.get_data(STUDENT_DATA_LABEL)
@@ -344,10 +341,6 @@ class StageThree(HubbleStage):
         class_layer.state.alpha = 1
         class_layer.state.size = 4
         class_layer.state.visible = False
-        toggle_tool = layer_viewer.toolbar.tools['hubble:toggleclass']
-        toggle_tool.set_layer_to_toggle(class_layer)
-
-        layer_viewer.toolbar.set_tool_enabled('hubble:toggleclass', not self.stage_state.marker_before("tre_dat2"))
 
         # cosmicds PR157 - turn off fit line label for layer_viewer
         layer_viewer.toolbar.tools["hubble:linefit"].show_labels = False
@@ -357,10 +350,7 @@ class StageThree(HubbleStage):
         
         line_fit_tool = layer_viewer.toolbar.tools['hubble:linefit']
         add_callback(line_fit_tool, 'active', self._on_best_fit_line_shown)
-        
-        layer_toolbar = layer_viewer.toolbar
-        layer_toolbar.set_tool_enabled("hubble:toggleclass", self.stage_state.marker_reached("tre_dat2"))
-        add_callback(toggle_tool, 'toggled_count', self._on_class_layer_toggled) 
+
         add_callback(self.story_state, 'has_best_fit_galaxy', self._on_best_fit_galaxy_added)
 
         # Ignore the best-fit-galaxy subset in the layer viewer for line fitting

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from numpy import where
-from cosmicds.components.layer_toggle import LayerToggle
+# from cosmicds.components.layer_toggle import LayerToggle
 from cosmicds.components.table import Table
 from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
@@ -271,11 +271,11 @@ class StageFour(HubbleStage):
                      self._on_marker_update, echo_old=True)
         self.trigger_marker_update_cb = True
 
-        layer_toggle = LayerToggle(layer_viewer, names={
-            STUDENT_DATA_LABEL: "My Data",
-            CLASS_DATA_LABEL: "Class Data"
-        })
-        self.add_component(layer_toggle, label="py-layer-toggle")
+        # layer_toggle = LayerToggle(layer_viewer, names={
+        #     STUDENT_DATA_LABEL: "My Data",
+        #     CLASS_DATA_LABEL: "Class Data"
+        # })
+        # self.add_component(layer_toggle, label="py-layer-toggle")
             
         # Grab data
         class_summ_data = self.get_data(CLASS_SUMMARY_LABEL)

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 from numpy import where
+from cosmicds.components.layer_toggle import LayerToggle
 from cosmicds.components.table import Table
 from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
@@ -269,6 +270,12 @@ class StageFour(HubbleStage):
         add_callback(self.stage_state, 'marker',
                      self._on_marker_update, echo_old=True)
         self.trigger_marker_update_cb = True
+
+        layer_toggle = LayerToggle(layer_viewer, names={
+            STUDENT_DATA_LABEL: "My Data",
+            CLASS_DATA_LABEL: "Class Data"
+        })
+        self.add_component(layer_toggle, label="py-layer-toggle")
             
         # Grab data
         class_summ_data = self.get_data(CLASS_SUMMARY_LABEL)
@@ -462,8 +469,6 @@ class StageFour(HubbleStage):
         student_layer.state.visible = False # Don't need to display this in Stage 4.
         class_layer = layer_viewer.layer_artist_for_data(class_meas_data)
         class_layer.state.visible = True
-        toggle_tool = layer_viewer.toolbar.tools['hubble:toggleclass']
-        toggle_tool.set_layer_to_toggle(class_layer)
 
         layer_viewer.toolbar.tools["hubble:linefit"].deactivate() 
 
@@ -479,12 +484,7 @@ class StageFour(HubbleStage):
         add_callback(line_fit_tool, 'active', self._on_best_fit_line_shown)
         
         layer_toolbar = layer_viewer.toolbar
-        # turn this on if we are in this stage
-        if self.story_state.stage_index == self.index: 
-            layer_toolbar.set_tool_enabled("hubble:toggleclass", True)
         
-        toggle_tool = layer_viewer.toolbar.tools['hubble:toggleclass']
-        add_callback(toggle_tool, 'toggled_count', self._on_class_layer_toggled) 
         add_callback(self.story_state, 'has_best_fit_galaxy', self._on_best_fit_galaxy_added)
         
         student_layer = comparison_viewer.layer_artist_for_data(student_data)
@@ -688,9 +688,6 @@ class StageFour(HubbleStage):
         super()._on_dark_mode_change(dark)
         self._update_viewer_style(dark)
         
-    def _on_class_layer_toggled(self, used):
-        self.stage_state.class_layer_toggled = used 
-
     def age_calc_update_guesses(self, responses):
         key = str(self.index)
         state = self.stage_state.age_calc_state

--- a/src/hubbleds/stages/stage_5.vue
+++ b/src/hubbleds/stages/stage_5.vue
@@ -69,7 +69,7 @@
           :class="stage_state.my_galaxies_plot_highlights.includes(stage_state.marker) ? 'pa-1 my-n1' : 'pa-0'"
           outlined
         >
-          <py-layer-toggle/>
+          <!-- <py-layer-toggle/> -->
           <v-lazy>
             <jupyter-widget :widget="viewers.layer_viewer"/>
           </v-lazy>

--- a/src/hubbleds/stages/stage_5.vue
+++ b/src/hubbleds/stages/stage_5.vue
@@ -69,6 +69,7 @@
           :class="stage_state.my_galaxies_plot_highlights.includes(stage_state.marker) ? 'pa-1 my-n1' : 'pa-0'"
           outlined
         >
+          <py-layer-toggle/>
           <v-lazy>
             <jupyter-widget :widget="viewers.layer_viewer"/>
           </v-lazy>

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -54,7 +54,6 @@ HubbleFitLayerView = cds_viewer(
         # 'bqplot:rectangle',
         "hubble:linefit",
         "hubble:linedraw",
-        "hubble:toggleclass",
     ],
     label='Layer View',
     state_cls=HubbleFitViewerState


### PR DESCRIPTION
This PR looks to resolve #175 by replacing the class layer toggle tool with the layer toggler in stages 4 and 5. At the moment this only contains functionality updates - I haven't changed the guideline text. I'm also not sure exactly how we want the layout with this to be in stage 5 - once we decide that I'll change appropriately.