### PR TITLE
Reflection question updates

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_1/reflect_velocity_windows.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/reflect_velocity_windows.vue
@@ -121,13 +121,13 @@
                       'In SOME of my galaxies, the observed wavelengths of the spectral lines are LONGER than the rest wavelengths. In OTHER of my galaxies, the observed wavelengths of the spectral lines are SHORTER than the rest wavelengths.'
                     ]"
                     :feedbacks="[
-                      'Try again. For each galaxy (a row in the table), compare the values for rest wavelength (column 3) and observed wavelength (column 4).',
-                      'That is correct.',
-                      'Try again. For each galaxy (a row in the table), compare the values for rest wavelength (column 3) and observed wavelength (column 4).',
-                      'Try again. For each galaxy (a row in the table), compare the values for rest wavelength (column 3) and observed wavelength (column 4).'
+                      'That is an unexpected result. For each galaxy, compare the values for rest wavelength (column 3) and observed wavelength (column 4). Check with an instructor in case your measurements need adjustment.',
+                      'That is interesting that the observed spectral lines are all longer than the rest wavelengths.',
+                      'That is an unexpected result. For each galaxy, compare the values for rest wavelength (column 3) and observed wavelength (column 4). Check with an instructor in case your measurements need adjustment.',
+                      'That is an unexpected result. For each galaxy, compare the values for rest wavelength (column 3) and observed wavelength (column 4). Check with an instructor in case your measurements need adjustment.'
                     ]"
-                    :correct-answers="[1]"
-                    @select="(state) => { if(state.correct) { max_step_completed = Math.max(max_step_completed, 2); } }"
+                    :neutral-answers="[1]"
+                    @select="(state) => { if(state.neutral) { max_step_completed = Math.max(max_step_completed, 2); } }"
                     score-tag="wavelength-comparison"
                   >
                   </mc-radiogroup>

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data4.vue
@@ -25,9 +25,9 @@
             'Hubble\'s age estimate'
           ]"
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
-          :correct-answers="[0,1]"
-          :neutral-answers='[]'
-          @select="(status) => { if (status.correct) { allowAdvancing(); } }"
+          :correct-answers="[]"
+          :neutral-answers='[0,1]'
+          @select="(status) => { if (status.neutral) { allowAdvancing(); } }"
           score-tag="pro-dat4"
         >
         </mc-radiogroup>

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data5.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data5.vue
@@ -1,48 +1,22 @@
 <template>
   <guideline-professional-data
-    color="info"
-    class="mb-4 mx-auto"
-    max-width="800"
-    elevation="6"
     prev-marker="pro_dat4"
     next-marker="pro_dat6"
-    v-slot:default="{ allowAdvancing }"
+    :auto-advance="true"
     :state="state"
     :index="5"
   >
     <div
       class="mb-4"
     >
-    <p>
-      Now let's consider more modern data from 2001, shown in lime green. 
-      This data is from the HST Key Project, led by astronomer Wendy Freedman, who used data from the Hubble Space Telescope to measure a quantity known as the <strong>Hubble constant</strong>
-      (which is the inverse of the age value you calculated).
-    </p>
-    <p> 
-      Whose data has the least amount of random uncertainty? (It might help to use the magnifying glass tool to zoom in on the x and y axes).
-    </p>
-      <v-container
-        class="px-0"
-        fluid
-      >
-        <mc-radiogroup
-          :radio-options="[
-            'Our class',
-            'Edwin Hubble',
-            'HST Key Project'
-          ]"
-          :feedbacks="[
-            'Try again. ',
-            'Try again. ',
-            'Correct! The HST Key Project data has the least amount of random uncertainty.'
-          ]"
-          :correct-answers="[2]"
-          :neutral-answers='[0,1]'
-          @select="(status) => { if (status.correct) { allowAdvancing(); } }"
-          score-tag="pro-dat5"
-        >
-        </mc-radiogroup>
-      </v-container>
+      <p>
+        Now let's consider more modern data from 2001, shown in lime green. 
+        This data is from the HST Key Project, led by astronomer Wendy Freedman, who used data from the Hubble Space Telescope to measure a quantity known as the <strong>Hubble constant</strong>
+        (which is the inverse of the age value you calculated).
+      </p>
+      <p> 
+        Whose data has the least amount of random uncertainty? (It might help to use the magnifying glass tool to zoom in on the x and y axes).
+      </p>
     </div>
   </guideline-professional-data>
 </template>

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data7.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data7.vue
@@ -22,9 +22,9 @@
         <mc-radiogroup
           :radio-options="['Our age estimate', 'Hubble team\'s age estimate']"
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
-          :correct-answers="[0,1]"
-          :neutral-answers='[]'
-          @select="(status) => { if (status.correct) { allowAdvancing(); } }"
+          :correct-answers="[]"
+          :neutral-answers='[0,1]'
+          @select="(status) => { if (status.neutral) { allowAdvancing(); } }"
           score-tag="pro-dat7"
         >
         </mc-radiogroup>

--- a/src/hubbleds/stages/stage_6.vue
+++ b/src/hubbleds/stages/stage_6.vue
@@ -52,7 +52,6 @@
         <guideline-professional-data5
           v-if="stage_state.marker == 'pro_dat5'"
           v-intersect.once="scrollIntoView"
-          @ready="stage_state.prodata_response = true"
           :state="stage_state"/>
         <guideline-professional-data6
           v-if="stage_state.marker == 'pro_dat6'"


### PR DESCRIPTION
- change some "correct" choices to neutral when there isn't an obvious "correct" answer (so no points would be assigned)
- remove question from pro_dat5 that I think kids will have a hard time answering and isn't that interesting/useful anyway
- Edit feedback text in reflect_velocity_windows slide 1 to account for some students measuring wavelengths completely incorrectly.