### PR TITLE
Make sure we get the same random subset every time

### DIFF
--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -246,7 +246,7 @@ class HubblesLaw(Story):
         seq = SeedSequence(42)
         gen = Generator(PCG64(seq))
         indices = np.arange(len(good))
-        indices = indices[1::2]
+        indices = indices[1::2][:85]
         random_subset = gen.choice(indices[good[1::2]], size=40, replace=False)
         random_subset = np.ravel(np.column_stack((random_subset, random_subset+1)))
         example_galaxy_seed_data = {k: np.array(v)[random_subset] for k,v in example_galaxy_seed_data.items()}


### PR DESCRIPTION
As the database grows, selecting a random subset will change which rows are taken. to make sure this isn't happening, for now we can just lock in [:85] (which are the ones we have been using in testing) until we develop a better/new scheme for grabbing a "good" subset of data