### PR TITLE
Don't reset viewer limits on slider changes

### DIFF
--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -328,11 +328,9 @@ class StageFour(HubbleStage):
             self.class_slider_subset.subset_state = all_data[CLASS_ID_COMPONENT] == id
             color = class_slider.highlight_color if highlighted else class_slider.default_color
             self.class_slider_subset.style.color = color
-            all_viewer.state.reset_limits()
         def class_slider_refresh(slider):
             self.stage_state.cla_low_age = round(min(slider.values))
             self.stage_state.cla_high_age = round(max(slider.values))
-            all_viewer.state.reset_limits()
 
         class_slider.on_id_change(class_slider_change)
         class_slider.on_refresh(class_slider_refresh)

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -312,6 +312,7 @@ class StageFour(HubbleStage):
         def student_slider_refresh(slider):
             self.stage_state.stu_low_age = round(min(slider.values, default=0))
             self.stage_state.stu_high_age = round(max(slider.values, default=0))
+            comparison_viewer.state.reset_limits(visible_only=False)
 
         student_slider.on_id_change(student_slider_change)
         student_slider.on_refresh(student_slider_refresh)
@@ -331,6 +332,7 @@ class StageFour(HubbleStage):
         def class_slider_refresh(slider):
             self.stage_state.cla_low_age = round(min(slider.values))
             self.stage_state.cla_high_age = round(max(slider.values))
+            all_viewer.state.reset_limits(visible_only=False)
 
         class_slider.on_id_change(class_slider_change)
         class_slider.on_refresh(class_slider_refresh)

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -431,6 +431,9 @@ class StageFour(HubbleStage):
             student_layer.state.visible = True
             class_layer.state.visible = False
 
+        if new == 'cla_res1':
+            self.get_component("py-student-slider").refresh()
+
         if advancing and new == "tre_lin2c":
             layer_viewer.toolbar.tools["hubble:linedraw"].erase_line() 
             layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", True)

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -309,11 +309,9 @@ class StageFour(HubbleStage):
             self.student_slider_subset.subset_state = class_meas_data['student_id'] == id
             color = student_slider.highlight_color if highlighted else student_slider.default_color
             self.student_slider_subset.style.color = color
-            comparison_viewer.state.reset_limits()
         def student_slider_refresh(slider):
             self.stage_state.stu_low_age = round(min(slider.values, default=0))
             self.stage_state.stu_high_age = round(max(slider.values, default=0))
-            comparison_viewer.state.reset_limits()
 
         student_slider.on_id_change(student_slider_change)
         student_slider.on_refresh(student_slider_refresh)

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -497,7 +497,7 @@ class StageFour(HubbleStage):
         # comparison_viewer.add_subset(self.student_slider_subset)
         comparison_viewer.state.x_att = class_meas_data.id[DISTANCE_COMPONENT]
         comparison_viewer.state.y_att = class_meas_data.id[VELOCITY_COMPONENT]
-        comparison_viewer.state.reset_limits()
+        comparison_viewer.state.reset_limits(visible_only=False)
 
         comparison_viewer.toolbar.tools["hubble:linefit"].activate() 
 
@@ -517,6 +517,7 @@ class StageFour(HubbleStage):
         all_layer.state.visible = False
         all_viewer.state.x_att = all_data.id[DISTANCE_COMPONENT]
         all_viewer.state.y_att = all_data.id[VELOCITY_COMPONENT]
+        all_viewer.state.reset_limits(visible_only=False)
 
         # Set up all viewer tools
         all_fit_tool = all_viewer.toolbar.tools["hubble:linefit"]
@@ -712,6 +713,7 @@ class StageFour(HubbleStage):
 
         if index == self.index:
             self.reset_viewer_limits()
+            self.get_component("py-student-slider").refresh()
 
             if self.stage_state.marker == 'ran_var1':
                 layer_viewer = self.get_viewer("layer_viewer")

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -16,18 +16,18 @@ __all__ = [
 
 class HubbleScatterViewerState(CDSScatterViewerState):
 
-    def reset_limits(self):
+    def reset_limits(self, visible_only=True):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
-            super().reset_limits()
+            super().reset_limits(visible_only=visible_only)
             self.x_min = min(self.x_min, 0)
             self.y_min = min(self.y_min, 0)
 
 
 class HubbleFitViewerState(HubbleScatterViewerState):
     
-    def reset_limits(self):
+    def reset_limits(self, visible_only=True):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
-            super().reset_limits()
+            super().reset_limits(visible_only=visible_only)
             self.x_max = 1.1 * self.x_max
             self.y_max = 1.1 * self.y_max
 

--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -19,8 +19,8 @@ class HubbleScatterViewerState(CDSScatterViewerState):
     def reset_limits(self, visible_only=True):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             super().reset_limits(visible_only=visible_only)
-            self.x_min = min(self.x_min, 0)
-            self.y_min = min(self.y_min, 0)
+            self.x_min = min(self.x_min, 0) if self.x_min is not None else 0
+            self.y_min = min(self.y_min, 0) if self.y_min is not None else 0
 
 
 class HubbleFitViewerState(HubbleScatterViewerState):


### PR DESCRIPTION
This PR removes the `reset_limits` calls in the update functions for both the student and class sliders.

Note that this relies on https://github.com/cosmicds/cosmicds/pull/228.