### PR TITLE
Send last modified time to backend

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ package_dir =
 install_requires =
     importlib-metadata; python_version>="3.7"
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
+    python-dateutil
 
 
 [options.packages.find]

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -144,7 +144,7 @@ class HubblesLaw(Story):
             HubblesLaw.make_data_writeable(data)
 
         self.class_last_modified = None
-        self.class_data_timer = RepeatedTimer(5, self._on_timer)
+        self.class_data_timer = RepeatedTimer(30, self._on_timer)
         self.class_data_timer.start()
 
     def _on_timer(self):


### PR DESCRIPTION
This PR uses the `last_modified` query parameter added to the `/stage-3-data` endpoint in https://github.com/cosmicds/cds-api/pull/68 so that the server will only send class data if necessary - otherwise, the response body will be an empty list. In that case, the class data won't get updated. If the class data does get updated, we get the UTC timestamp of the last modified point and use this for the query parameter next time.

As described in the linked PR, the intent here is to reduce network traffic.