### PR TITLE
Fix more initialization issues

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_1/guideline_end_stage1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_1/guideline_end_stage1.vue
@@ -1,7 +1,7 @@
 <template>
   <scaffold-alert
     @back="() => { state.marker_backward = 1; }"
-    @next="() => { state.stage_1_complete = true; }"
+    @next="() => { $emit('stage_complete'); }"
     next-text="stage 2"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_fill_remaining_galaxies.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_fill_remaining_galaxies.vue
@@ -3,7 +3,7 @@
     title-text="Estimate Distance"
     next-text="stage 4"
     @back="state.marker = 'rep_rem1'"
-    @next="state.stage_3_complete = true;"
+    @next="() => { $emit('stage_complete'); }"
     :can-advance="(state) => state.distances_total === 5"
     :state="state"
   >

--- a/src/hubbleds/components/generic_state_components/stage_4/guideline_shortcomings_est2.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4/guideline_shortcomings_est2.vue
@@ -5,7 +5,7 @@
     @back="
       state.marker = 'sho_est1';
     "
-    @next="state.stage_4_complete = true;"
+    @next="() => { $emit('stage_complete'); }"
           
   >
   <!-- state.marker = 'ran_var1'; -->

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_account_uncertainty.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_account_uncertainty.vue
@@ -4,7 +4,7 @@
     title-text="Accounting for Uncertainty"
     next-text="stage 6"
     @back="state.marker_backward = 1"
-    @next="state.stage_5_complete = true"
+    @next="() => {$emit('stage_complete');}"
   >
     <div
       class="mb-4"

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -563,6 +563,10 @@ class StageOne(HubbleStage):
         if self.stage_state.marker_reached("obs_wav2"):
             spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
             spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
+        
+        if self.stage_state.doppler_calc_reached:
+            self.enable_velocity_tool(True)
+
 
         # Uncomment this to pre-fill galaxy data for convenience when testing later stages
         # self.vue_fill_data()

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -1076,6 +1076,7 @@ class StageOne(HubbleStage):
         self.story_state.update_data(SPECTRUM_DATA_LABEL, data)
 
     def _on_stage_complete(self, complete):
+        return 
         if complete:
             self.story_state.stage_index = 2
             print("end Stage 1. stage_state.stage_1_complete value after last guideline:", self.stage_state.stage_1_complete)
@@ -1085,6 +1086,11 @@ class StageOne(HubbleStage):
             self.stage_state.stage_1_complete = False
 
             print("end Stage 1. stage_state.stage_1_complete value after reinitializing to false:", self.stage_state.stage_1_complete)
+    
+    def vue_stage_one_complete(self, *args):
+        print('vue_stage_one_complete')
+        self.story_state.stage_index = 2
+        self.stage_state.stage_1_complete = False
 
     def vue_print_state(self, _args=None):
         print("stage state:")

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -1087,7 +1087,7 @@ class StageOne(HubbleStage):
             self.stage_state.stage_1_complete = False
     
     def vue_stage_one_complete(self, *args):
-        print('vue_stage_one_complete')
+        # print('vue_stage_one_complete')
         self.story_state.stage_index = 2
         self.stage_state.stage_1_complete = False
 

--- a/src/hubbleds/stages/stage_1.py
+++ b/src/hubbleds/stages/stage_1.py
@@ -564,7 +564,8 @@ class StageOne(HubbleStage):
             spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)
             spectrum_viewer.toolbar.set_tool_enabled("bqplot:home", True)
         
-        if self.stage_state.doppler_calc_reached:
+        if self.stage_state.marker_reached("dop_cal6"):
+            # if self.stage_state.doppler_calc_reached:
             self.enable_velocity_tool(True)
 
 

--- a/src/hubbleds/stages/stage_1.vue
+++ b/src/hubbleds/stages/stage_1.vue
@@ -169,6 +169,7 @@
           v-if="stage_state.marker === 'end_sta1'"
           v-intersect.once="scrollIntoView"
           :state="stage_state"
+          @stage_complete="() => {stage_one_complete(); console.log('emit: stage one complete');}"
         />  
       </v-col>
       <v-col

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -460,7 +460,7 @@ class StageTwo(HubbleStage):
 
         
     def _on_marker_update(self, old, new):
-        print_log(f"Marker update: {old} -> {new}")
+        #print_log(f"Marker update: {old} -> {new}")
         if not self.trigger_marker_update_cb:
             return
         markers = self.stage_state.markers

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -239,7 +239,6 @@ class StageTwo(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
-        print('at beginning of init', self.stage_state.marker)
         
         dosdonts_slideshow = DosDontsSlideShow(self.stage_state.image_location_dosdonts)
         self.add_component(dosdonts_slideshow, label='py-dosdonts-slideshow')
@@ -447,9 +446,16 @@ class StageTwo(HubbleStage):
             extend_tool(viewers[i], 'bqplot:home', partial(set_x_lim,viewers[i]), activate_before_tool= False)
         
         self._update_viewer_style(dark=self.app_state.dark_mode)
+    
+     #@print_function_name
+    def _update_state_from_measurements(self):
+        student_measurements = self.get_data(STUDENT_MEASUREMENTS_LABEL)
+        angsizes = student_measurements[ANGULAR_SIZE_COMPONENT]
+        self.stage_state.angsizes_total = angsizes[angsizes != None].size
+
         
     def _on_marker_update(self, old, new):
-        # print_log(f"Marker update: {old} -> {new}")
+        print_log(f"Marker update: {old} -> {new}")
         if not self.trigger_marker_update_cb:
             return
         markers = self.stage_state.markers
@@ -522,6 +528,10 @@ class StageTwo(HubbleStage):
             tool = self.distance_table.get_tool("update-distances")
             tool["disabled"] = False
             self.distance_table.update_tool(tool)
+            
+        if advancing and (new in ['rep_rem1', 'fil_rem']) and self.show_team_interface and (self.stage_state.angsizes_total < 5):
+            # this condition occurs if we use fill values in stage 1
+            self._update_state_from_measurements()
     
     @staticmethod
     def add_point(viewer, x, color, label = None): 

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -239,7 +239,8 @@ class StageTwo(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
-
+        if self.stage_state.marker in ['fil_rem1']:
+            self.stage_state.marker_backward = 1
         
         dosdonts_slideshow = DosDontsSlideShow(self.stage_state.image_location_dosdonts)
         self.add_component(dosdonts_slideshow, label='py-dosdonts-slideshow')

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -373,7 +373,7 @@ class StageTwo(HubbleStage):
             new_index = marker_index - 1
             self.stage_state.marker = self.stage_state.marker[new_index]
         
-        if self.stage_state.marker_reached('est_dis4'):
+        if self.stage_state.marker_reached('fil_rem1'):
             self.enable_distance_tool(True)
         
         # Show_ruler should be true from marker ang_siz3 to est_dis4 (inclusive) and from dot_seq5b forward.
@@ -793,7 +793,7 @@ class StageTwo(HubbleStage):
                             index)
 
         self.story_state.update_student_data()
-        if self.stage_state.distance_calc_count == 1:  # as long as at least one thing has been measured, tool is enabled. But if students want to loop through calculation by hand they can.
+        if self.stage_state.distance_calc_count >= 1:  # as long as at least one thing has been measured, tool is enabled. But if students want to loop through calculation by hand they can.
             self.enable_distance_tool(True)
         self.get_distance_count()
     

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -902,6 +902,6 @@ class StageTwo(HubbleStage):
             self.stage_state.stage_3_complete = False
     
     def vue_stage_three_complete(self, *args):
-        print('vue_stage_three_complete')
+        # print('vue_stage_three_complete')
         self.story_state.stage_index = 4
         self.stage_state.stage_3_complete = False

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -370,6 +370,9 @@ class StageTwo(HubbleStage):
             new_index = marker_index - 1
             self.stage_state.marker = self.stage_state.marker[new_index]
         
+        if self.stage_state.marker_reached('est_dist4'):
+            self.enable_distance_tool(True)
+        
         # Show_ruler should be true from marker ang_siz3 to est_dis4 (inclusive) and from dot_seq5b forward.
         if  self.stage_state.marker_reached('ang_siz3') and (not self.stage_state.marker_after('est_dis4')):
             self.stage_state.show_ruler = True

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -370,7 +370,7 @@ class StageTwo(HubbleStage):
             new_index = marker_index - 1
             self.stage_state.marker = self.stage_state.marker[new_index]
         
-        if self.stage_state.marker_reached('est_dist4'):
+        if self.stage_state.marker_reached('est_dis4'):
             self.enable_distance_tool(True)
         
         # Show_ruler should be true from marker ang_siz3 to est_dis4 (inclusive) and from dot_seq5b forward.

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -882,9 +882,15 @@ class StageTwo(HubbleStage):
         return self.current_table._glue_data.label
 
     def _on_stage_complete(self, complete):
+        return
         if complete:
             self.story_state.stage_index = 4
 
             # We need to do this so that the stage will be moved forward every
             # time the button is clicked, not just the first
             self.stage_state.stage_3_complete = False
+    
+    def vue_stage_three_complete(self, *args):
+        print('vue_stage_three_complete')
+        self.story_state.stage_index = 4
+        self.stage_state.stage_3_complete = False

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -324,7 +324,7 @@ class StageTwo(HubbleStage):
                                tools=[add_distances_tool])
 
         if self.stage_state.marker_reached('dot_seq5a'):
-            self.example_galaxy_distance_table.filter_by(None)
+            example_galaxy_distance_table.filter_by(None)
         
         self.add_widget(example_galaxy_distance_table, label="example_galaxy_distance_table")
         example_galaxy_distance_table.observe(

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -324,7 +324,7 @@ class StageTwo(HubbleStage):
                                single_select=True,
                                tools=[add_distances_tool])
 
-        if self.stage_state.marker_reached('dot_seq12'):
+        if self.stage_state.marker_reached('dot_seq5a'):
             self.example_galaxy_distance_table.filter_by(None)
         
         self.add_widget(example_galaxy_distance_table, label="example_galaxy_distance_table")

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -324,6 +324,9 @@ class StageTwo(HubbleStage):
                                single_select=True,
                                tools=[add_distances_tool])
 
+        if self.stage_state.marker_reached('dot_seq12'):
+            self.example_galaxy_distance_table.filter_by(None)
+        
         self.add_widget(example_galaxy_distance_table, label="example_galaxy_distance_table")
         example_galaxy_distance_table.observe(
             self.distance_table_selected_change, names=["selected"])

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -241,7 +241,8 @@ class StageTwo(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
-        if self.stage_state.marker in ['fil_rem1']:
+        # What we really want is for enable_distance_tool to be true if initialized at fil_rem1, but that isn't working, so this is our hacky fix for now. (And really, they shouldn't have to re-click the measuring tape if their distances are already there. It should just be 'next')
+        if self.stage_state.marker in ['fil_rem1']: 
             self.stage_state.marker_backward = 1
         
         dosdonts_slideshow = DosDontsSlideShow(self.stage_state.image_location_dosdonts)

--- a/src/hubbleds/stages/stage_3.vue
+++ b/src/hubbleds/stages/stage_3.vue
@@ -158,7 +158,9 @@
         <guideline-fill-remaining-galaxies
           v-if="stage_state.marker == 'fil_rem1'" 
           :state="stage_state"
-          v-intersect.once="scrollIntoView" />
+          v-intersect.once="scrollIntoView" 
+          @stage_complete="() => {stage_three_complete(); console.log('emit: stage three complete');}"
+          />
       </v-col>
       <v-col
         cols="12"

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -471,9 +471,15 @@ class StageThree(HubbleStage):
             linefit_tool.activate()
     
     def _on_stage_complete(self, complete):
+        return
         if complete:
             self.story_state.stage_index =  5
 
             # We need to do this so that the stage will be moved forward every
             # time the button is clicked, not just the first
             self.stage_state.stage_4_complete = False
+    
+    def vue_stage_four_complete(self, *args):
+        print('vue_stage_four_complete')
+        self.story_state.stage_index = 5
+        self.stage_state.stage_4_complete = False

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -165,6 +165,7 @@ class StageThree(HubbleStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
+        
         add_callback(self.stage_state, 'stage_4_complete',
                      self._on_stage_complete)
 
@@ -172,6 +173,9 @@ class StageThree(HubbleStage):
 
         self.show_team_interface = self.app_state.show_team_interface
         self._setup_complete = False
+        
+        if self.stage_state.marker in ['tre_lin2', 'bes_fit1']:
+            self.stage_state.marker = 'tre_lin1'
 
         student_data = self.get_data(STUDENT_DATA_LABEL)
         class_meas_data = self.get_data(CLASS_DATA_LABEL)
@@ -318,7 +322,8 @@ class StageThree(HubbleStage):
             layer_viewer.toolbar.tools["hubble:linedraw"].erase_line()
         if advancing and new =="age_rac1":
             self._update_hypgal_info()
-
+        
+        
     def _on_slideshow_opened(self, msg):
         self.stage_state.hubble_dialog_opened = msg["new"]
     

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -174,6 +174,7 @@ class StageThree(HubbleStage):
         self.show_team_interface = self.app_state.show_team_interface
         self._setup_complete = False
         
+        # This is a hacky fix because these are not initializing correctly on a reload, so we are backing them up 1 or 2 guidelines, and when they go forward again they will be correct.
         if self.stage_state.marker in ['tre_lin2', 'bes_fit1']:
             self.stage_state.marker = 'tre_lin1'
 

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -485,6 +485,6 @@ class StageThree(HubbleStage):
             self.stage_state.stage_4_complete = False
     
     def vue_stage_four_complete(self, *args):
-        print('vue_stage_four_complete')
+        # print('vue_stage_four_complete')
         self.story_state.stage_index = 5
         self.stage_state.stage_4_complete = False

--- a/src/hubbleds/stages/stage_4.vue
+++ b/src/hubbleds/stages/stage_4.vue
@@ -151,7 +151,9 @@
         <guideline-shortcomings-est2
           v-if="stage_state.marker == 'sho_est2'"
           :state="stage_state"
-          v-intersect.once="scrollIntoView" />
+          v-intersect.once="scrollIntoView"
+          @stage_complete="() => {stage_four_complete(); console.log('emit: stage four complete');}"
+           />
       </v-col>
       <v-col
         cols="12"

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -710,12 +710,18 @@ class StageFour(HubbleStage):
             linefit_tool.activate()
     
     def _on_stage_complete(self, complete):
+        return
         if complete:
             self.story_state.stage_index = 6
 
             # We need to do this so that the stage will be moved forward every
             # time the button is clicked, not just the first
             self.stage_state.stage_5_complete = False
+    
+    def vue_stage_five_complete(self, *args):
+        print('vue_stage_five_complete')
+        self.story_state.stage_index = 6
+        self.stage_state.stage_5_complete = False
     
     def _reset_limits_for_data(self, label):
         viewer_id = self.viewer_ids_for_data.get(label, [])

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -727,7 +727,7 @@ class StageFour(HubbleStage):
             self.stage_state.stage_5_complete = False
     
     def vue_stage_five_complete(self, *args):
-        print('vue_stage_five_complete')
+        # print('vue_stage_five_complete')
         self.story_state.stage_index = 6
         self.stage_state.stage_5_complete = False
     

--- a/src/hubbleds/stages/stage_5.vue
+++ b/src/hubbleds/stages/stage_5.vue
@@ -285,7 +285,9 @@
         <guideline-account-uncertainty
           v-if="stage_state.marker == 'acc_unc1'"
           :state="stage_state"
-          v-intersect.once="scrollIntoView"/>
+          v-intersect.once="scrollIntoView"
+          @stage_complete="() => {stage_five_complete(); console.log('emit: stage five complete');}"
+          />
       </v-col>
       <v-col
         cols="12"

--- a/src/hubbleds/stages/stage_6.py
+++ b/src/hubbleds/stages/stage_6.py
@@ -141,8 +141,9 @@ class StageFive(HubbleStage):
         
         prodata_viewer = self.add_viewer(HubbleScatterView, "prodata_viewer",
                                          "Professional Data")
-        prodata_viewer.toolbar.tools["hubble:linefit"].show_labels = False
         prodata_viewer.toolbar.set_tool_enabled("hubble:linefit", self.stage_state.marker_reached("pro_dat1"))
+        if self.stage_state.marker_reached("pro_dat1") & (not self.stage_state.marker_reached("pro_dat8")) :
+            prodata_viewer.toolbar.tools["hubble:linefit"].show_labels = False
         prodata_viewer.figure.axes[1].label_offset = "5em"
 
         layer_toggle = LayerToggle(prodata_viewer, names={

--- a/src/hubbleds/stages/stage_6.py
+++ b/src/hubbleds/stages/stage_6.py
@@ -141,6 +141,7 @@ class StageFive(HubbleStage):
         
         prodata_viewer = self.add_viewer(HubbleScatterView, "prodata_viewer",
                                          "Professional Data")
+        prodata_viewer.toolbar.tools["hubble:linefit"].show_labels = False
         prodata_viewer.toolbar.set_tool_enabled("hubble:linefit", self.stage_state.marker_reached("pro_dat1"))
         prodata_viewer.figure.axes[1].label_offset = "5em"
 

--- a/src/hubbleds/stages/stage_6.py
+++ b/src/hubbleds/stages/stage_6.py
@@ -140,7 +140,7 @@ class StageFive(HubbleStage):
         
         prodata_viewer = self.add_viewer(HubbleScatterView, "prodata_viewer",
                                          "Professional Data")
-        prodata_viewer.toolbar.set_tool_enabled("hubble:linefit", False)
+        prodata_viewer.toolbar.set_tool_enabled("hubble:linefit", self.stage_state.marker_reached("pro_dat1"))
         prodata_viewer.figure.axes[1].label_offset = "5em"
 
         layer_toggle = LayerToggle(prodata_viewer, names={
@@ -167,7 +167,9 @@ class StageFive(HubbleStage):
         if self.story_state.has_best_fit_galaxy:
             self.set_our_age()
         
-        self.set_class_age()
+        if self.stage_state.marker_reached('pro_dat1'):
+                self.set_class_age()
+
         
     def setup_prodata_viewer(self):
         # load the prodata_viewer


### PR DESCRIPTION
This fixes several sequencing issues. 
-  Makes sure the velocity and distance fill tools are on if the student returns to the appropriate marker. 
-  Stage 1 -> 2 transition is fixed. This is the issue raised in https://github.com/cosmicds/hubbleds/pull/191. The fix is to have the `next` button emit a "stage_complete" which calls a function. 
-  Fix team mode issue where fill value puts stage 3 into a weird state where it can't advance properly because `angsizes_total` isn't set properly. This should only affect team mode