### PR TITLE
Add/update class data in all data

### DIFF
--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -685,7 +685,7 @@ class StageFour(HubbleStage):
                 self.get_component("py-student-slider").refresh()
             elif label == ALL_CLASS_SUMMARIES_LABEL:
                 class_slider = self.get_component("py-class-slider")
-                class_slider.update_data(self, msg.data)
+                class_slider.update_data(msg.data)
             self._reset_limits_for_data(label)
 
     def _on_class_data_update(self, *args):

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -546,11 +546,6 @@ class HubblesLaw(Story):
                     continue
                 all_dict[k] = np.concatenate([all_dict[k], [m[MEAS_TO_STATE.get(k, k)] for m in updated_meas]])
             new_all = Data(label=all_data.label, **all_dict)
-            for k in all_data.main_components:
-                print(k, type(all_data.get_component(k)))
-            for k in new_all.main_components:
-                print(k, type(new_all.get_component(k)))
-                print(k, new_all[k])
             all_data.update_values_from_data(new_all)
             HubblesLaw.prune_none(all_data)
 

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -535,17 +535,24 @@ class HubblesLaw(Story):
         updated_meas, updated_data = self.fetch_measurement_data_and_update(class_data_url, CLASS_DATA_LABEL, prune_none=True, update_if_empty=False, check_update=check_update)
         
         if updated_data is not None:
-            all_data = self.data_collection[ALL_DATA_LABEL]
             self.update_summary_data(updated_data, CLASS_SUMMARY_LABEL, STUDENT_ID_COMPONENT)
+            print("Updating class data")
+            all_data = self.data_collection[ALL_DATA_LABEL]
             indices = all_data[CLASS_ID_COMPONENT] != self.classroom["id"]
             all_dict = { k.label : all_data[k][indices] for k in all_data.main_components }
-            all_dict[CLASS_ID_COMPONENT] = np.concatenate(all_dict[CLASS_ID_COMPONENT], [self.classroom["id"] for _ in range(len(updated_meas))])
+            all_dict[CLASS_ID_COMPONENT] = np.concatenate([all_dict[CLASS_ID_COMPONENT], [self.classroom["id"]] * len(updated_meas)]) 
             for k in all_dict:
                 if k == CLASS_ID_COMPONENT:
                     continue
-                all_dict[k] = np.concatenate(all_dict[k], [m[MEAS_TO_STATE.get(k, k)] for m in updated_meas])
+                all_dict[k] = np.concatenate([all_dict[k], [m[MEAS_TO_STATE.get(k, k)] for m in updated_meas]])
             new_all = Data(label=all_data.label, **all_dict)
+            for k in all_data.main_components:
+                print(k, type(all_data.get_component(k)))
+            for k in new_all.main_components:
+                print(k, type(new_all.get_component(k)))
+                print(k, new_all[k])
             all_data.update_values_from_data(new_all)
+            HubblesLaw.prune_none(all_data)
 
 
     def setup_for_student(self, app_state):

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -564,7 +564,9 @@ class HubblesLaw(Story):
             vels = updated_data[VELOCITY_COMPONENT]
             h0, age = self.create_single_summary(dists, vels)
             all_summ_data = self.data_collection[ALL_CLASS_SUMMARIES_LABEL]
-            index = next((i for i in range(all_summ_data.size) if all_summ_data[CLASS_ID_COMPONENT][i] == class_id))
+            index = next((i for i in range(all_summ_data.size) if all_summ_data[CLASS_ID_COMPONENT][i] == class_id), None)
+            if index is None:
+                return
             h0s = all_summ_data[H0_COMPONENT]
             ages = all_summ_data[AGE_COMPONENT]
             h0s[index]= h0


### PR DESCRIPTION
This PR adds the necessary functionality for keeping the current class data up-to-date in the all/all summary data sets. This is accomplished by adding some extra logic when updating the class data. The basic idea is that, when the class data is updated, we:

* Add the current class data to all data. To save some work, we keep a dictionary of all the data minus the current class data, then add the class data to that each time to construct the updated data object.
* Compute the summary for the current class and update the relevant item in the all classes summary data

To test this, what I was doing is using one of the beta test students, making a wildly off measurement, checking that things updated in stage 5 on `cla_age1c`, then fixing up that measurement (and checking that it updated again).