### PR TITLE
Remove dotplot tutorial scrollbars

### DIFF
--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
@@ -47,7 +47,6 @@
 
         <v-window
           v-model="step"
-          style="height: 70vh;"
           class="overflow-auto"
         >
         <v-row>
@@ -225,8 +224,14 @@ export default {
 
 </script>
 
-<style>
+<style scoped>
 .no-transition {
   transition: none;
+}
+
+.row {
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
 }
 </style>

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.vue
@@ -231,7 +231,7 @@ export default {
 
 .row {
   width: 100%;
-  margin-left: 0;
-  margin-right: 0;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 </style>


### PR DESCRIPTION
This PR aims to fix #236 with some CSS modifications. There are two fixes here:

* First , I removed the `height: 70vh` from the `v-window`. The content of this slideshow doesn't need 70vh screen height (unless your screen is short).
* Next, I set the `v-row` (there's only one) to have `width: 100%`. I'm not completely sure, but my guess for why we need this here and not in, say, the angular slideshow video, is that we aren't using the `v-window-item` elements as the entire `v-window` content - they're side-by-side with the dotplot viewer, and I'm wondering if they expect to contain all of the window content. Since the `v-row` is the child of the `v-window`, setting its width to 100% fixes this. It also seemed to come with left and right margins of -12px, so I've removed those as well.