### PR TITLE
Class data and stage 4 wait handling

### DIFF
--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -1,4 +1,5 @@
 from functools import partial
+from glue.core.subset import RangeSubsetState
 
 from numpy import where
 # from cosmicds.components.layer_toggle import LayerToggle
@@ -306,7 +307,7 @@ class StageFour(HubbleStage):
         student_slider = IDSlider(class_summ_data, STUDENT_ID_COMPONENT, AGE_COMPONENT, highlight_ids=[self.story_state.student_user["id"]])
         self.add_component(student_slider, "py-student-slider")
         def student_slider_change(id, highlighted):
-            self.student_slider_subset.subset_state = class_meas_data['student_id'] == id
+            self.student_slider_subset.subset_state = RangeSubsetState(id, id, class_meas_data.id[STUDENT_ID_COMPONENT])
             color = student_slider.highlight_color if highlighted else student_slider.default_color
             self.student_slider_subset.style.color = color
         def student_slider_refresh(slider):
@@ -329,7 +330,7 @@ class StageFour(HubbleStage):
         class_slider = IDSlider(classes_summary_data, CLASS_ID_COMPONENT, AGE_COMPONENT, highlight_ids=[self.story_state.classroom["id"]], default_color = "#FF006E", highlight_color = "#3A86FF")
         self.add_component(class_slider, "py-class-slider")
         def class_slider_change(id, highlighted):
-            self.class_slider_subset.subset_state = all_data[CLASS_ID_COMPONENT] == id
+            self.class_slider_subset.subset_state = RangeSubsetState(id, id, all_data.id[CLASS_ID_COMPONENT])
             color = "#3A86FF" if highlighted else "#FF006E"
             self.class_slider_subset.style.color = color
         def class_slider_refresh(slider):

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -551,7 +551,7 @@ class HubblesLaw(Story):
             class_data = self.data_collection[CLASS_DATA_LABEL]
             counter = Counter(class_data[STUDENT_ID_COMPONENT])
             students_ready = len([k for k, v in counter.items() if v >= 5])
-            if students_ready >= 10:
+            if students_ready >= min(10, self.classroom["size"]):
                 self.enough_students_ready = True
 
     def fetch_class_data(self):

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -153,7 +153,8 @@ class HubblesLaw(Story):
         self.class_data_timer.start()
 
     def _on_timer(self):
-        self.fetch_class_data()
+        if self.max_stage_index < 5:
+            self.fetch_class_data()
         for cb in self._on_timer_cbs:
             cb()
 
@@ -560,6 +561,7 @@ class HubblesLaw(Story):
             if need_update and last_modified is not None:
                 self.class_last_modified = last_modified
             return need_update
+
         class_data_url = f"{API_URL}/{HUBBLE_ROUTE_PATH}/stage-3-data/{self.student_user['id']}/{self.classroom['id']}"
         if self.class_last_modified is not None:
             timestamp = floor(self.class_last_modified.timestamp() * 1000)

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -550,7 +550,7 @@ class HubblesLaw(Story):
             class_data = self.data_collection[CLASS_DATA_LABEL]
             counter = Counter(class_data[STUDENT_ID_COMPONENT])
             students_ready = len([k for k, v in counter.items() if v >= 5])
-            if students_ready >= 6:
+            if students_ready >= 10:
                 self.enough_students_ready = True
 
     def fetch_class_data(self):


### PR DESCRIPTION
This PR looks to resolve #261 with the following changes:
* Bump the default minimum number of students that we need to have finished data collection to 10 for stage 4
  - If the class size is less than 10 (knowing this is dependent on https://github.com/cosmicds/cosmicds/pull/240), we set the required number to be the entire class
* Once a student has reached stage 5 (even if they go back), their class data no longer updates (we just skip this part of the `_on_timer` call)