### PR TITLE
Fetch data at stage 5 and store class data size

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_class_data.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_class_data.vue
@@ -16,7 +16,7 @@
         Now that you've drawn what conclusions you can from individual students' age measurements, let's turn back to your whole class's dataset, graphed here.
       </p>
       <p>
-        The same way you and your classmates estimated a single age for the universe using your 5 galaxies, you can fit a line to your whole class's dataset and estimate a new age using the <span style="background-color: #02838f;">5 * N_students</span> galaxies you have measured all together.
+        The same way you and your classmates estimated a single age for the universe using your 5 galaxies, you can fit a line to your whole class's dataset and estimate a new age using the {{ 5 * state.class_data_size }} galaxies you have measured all together.
       </p>  
     </div>
   </scaffold-alert>

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -76,6 +76,7 @@ class StageState(CDSState):
     advance_marker = CallbackProperty(True)
 
     image_location = CallbackProperty(f"{IMAGE_BASE_URL}/mean_median_mode") 
+    class_data_size = CallbackProperty(0)
 
     hypgal_distance = CallbackProperty(0)
     hypgal_velocity = CallbackProperty(0)
@@ -591,7 +592,6 @@ class StageFour(HubbleStage):
         
         if not advancing and self.stage_state.marker_before('two_his1'):
             self.match_student_class_hist_axes(False)
-            
 
     def match_student_class_hist_axes(self, match = True):        
         student_tool = self.get_viewer("all_distr_viewer_student").toolbar.tools['bqplot:home']
@@ -884,6 +884,7 @@ class StageFour(HubbleStage):
 
     def _on_class_data_update(self, *args):
         self.reset_viewer_limits()
+        self.stage_state.class_data_size = int(self.get_data(CLASS_DATA_LABEL).size / 5)
 
     def _on_student_data_update(self, *args):
         self.reset_viewer_limits()

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -270,6 +270,9 @@ class StageFour(HubbleStage):
         class_meas_data = self.get_data(CLASS_DATA_LABEL)
         all_data = self.get_data(ALL_DATA_LABEL)
 
+        # Set the size from the class data
+        self.stage_state.class_data_size = int(self.get_data(CLASS_DATA_LABEL).size / 5)
+
         fit_table = Table(self.session,
                           data=student_data,
                           glue_components=[NAME_COMPONENT,
@@ -882,13 +885,9 @@ class StageFour(HubbleStage):
                 class_slider.update_data(msg.data)
             self._reset_limits_for_data(label)
 
-    def _on_class_data_update(self, *args):
-        self.reset_viewer_limits()
-        self.stage_state.class_data_size = int(self.get_data(CLASS_DATA_LABEL).size / 5)
+        if label == CLASS_DATA_LABEL:
+            self.stage_state.class_data_size = int(self.get_data(CLASS_DATA_LABEL).size / 5)
 
-    def _on_student_data_update(self, *args):
-        self.reset_viewer_limits()
-    
     def _on_dark_mode_change(self, dark):
         super()._on_dark_mode_change(dark)
         self._update_viewer_style(dark)

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -13,7 +13,7 @@ from cosmicds.phases import Story
 from cosmicds.registries import story_registry
 from cosmicds.utils import API_URL, RepeatedTimer
 from dateutil.parser import isoparse
-from echo import DictCallbackProperty, CallbackProperty
+from echo import DictCallbackProperty, CallbackProperty, add_callback
 from echo.callback_container import CallbackContainer
 from glue.core import Data
 from glue.core.component import CategoricalComponent, Component
@@ -151,6 +151,16 @@ class HubblesLaw(Story):
         self.class_last_modified = None
         self.class_data_timer = RepeatedTimer(30, self._on_timer)
         self.class_data_timer.start()
+
+        add_callback(self, 'max_stage_index', self._on_max_stage_index_changed)
+
+    def _on_max_stage_index_changed(self, value):
+        # Fetch data one last time as the student starts stage 5
+        # We need to do this on a max index change (rather than
+        # stage_index) so that this only happens once
+        # Otherwise the student's stage 5 data will change!
+        if value == 5:
+            self.fetch_class_data()
 
     def _on_timer(self):
         if self.max_stage_index < 5:


### PR DESCRIPTION
This PR adds an additional call to update the class data when the student first reaches stage 5. Once `max_stage_index` is at least 5, the repeated query for more class data is stopped (to keep the data constant as the student explores/answers questions about it), so this gives one last update.

Additionally, this adds a stage 5 state variable `class_data_size`, which is updated whenever the class data is updated.