### PR TITLE
Guard angular size measurements

### DIFF
--- a/src/hubbleds/components/distance_tool/distance_tool.py
+++ b/src/hubbleds/components/distance_tool/distance_tool.py
@@ -97,8 +97,10 @@ class DistanceTool(v.VueTemplate):
         fov = self.widget.get_fov()
         widget_height = self._height_from_pixel_str(self.widget.layout.height)
         ang_size = Angle(((change["new"] / widget_height) * fov))
-        if not self.validate_angular_size(ang_size):
-            return None
+        valid = self.validate_angular_size(ang_size, change['new'] > 0)
+        # print(ang_size, change["new"], valid)
+        # if valid:
+        #     print('valid measurement')
         self.angular_size = ang_size
         self.measurement_count += 1
 
@@ -160,13 +162,16 @@ class DistanceTool(v.VueTemplate):
         self.galaxy_max_size = max or self.galaxy_max_size
         self.galaxy_min_size = min or self.galaxy_min_size
     
-    def validate_angular_size(self, angular_size):
+    def validate_angular_size(self, angular_size, check = True):
         if not self.guard:
             return True
+        if not check:
+            return self.bad_measurement
         max_wwt_size = Angle("60 deg")
         c1 = (angular_size < max_wwt_size) 
         c2 = (angular_size >= self.galaxy_min_size) 
         c3 = (angular_size <= self.galaxy_max_size)
         self.bad_measurement = not (c1 and c2 and c3)
         return c1 and c2 and c3
+    
     

--- a/src/hubbleds/components/distance_tool/distance_tool.py
+++ b/src/hubbleds/components/distance_tool/distance_tool.py
@@ -159,8 +159,8 @@ class DistanceTool(v.VueTemplate):
         
     def set_guard(self, max = None, min = None):
         self.activate_guard()
-        self.galaxy_max_size = max or self.galaxy_max_size
-        self.galaxy_min_size = min or self.galaxy_min_size
+        self.galaxy_max_size = Angle(max) or self.galaxy_max_size
+        self.galaxy_min_size = Angle(min) or self.galaxy_min_size
     
     def validate_angular_size(self, angular_size, check = True):
         if not self.guard:

--- a/src/hubbleds/components/distance_tool/distance_tool.py
+++ b/src/hubbleds/components/distance_tool/distance_tool.py
@@ -159,8 +159,8 @@ class DistanceTool(v.VueTemplate):
         
     def set_guard(self, max = None, min = None):
         self.activate_guard()
-        self.galaxy_max_size = Angle(max) or self.galaxy_max_size
-        self.galaxy_min_size = Angle(min) or self.galaxy_min_size
+        self.galaxy_max_size = Angle(max) if max is not None else self.galaxy_max_size
+        self.galaxy_min_size = Angle(min) if min is not None else  self.galaxy_min_size
     
     def validate_angular_size(self, angular_size, check = True):
         if not self.guard:

--- a/src/hubbleds/components/distance_tool/distance_tool.py
+++ b/src/hubbleds/components/distance_tool/distance_tool.py
@@ -97,7 +97,7 @@ class DistanceTool(v.VueTemplate):
         fov = self.widget.get_fov()
         widget_height = self._height_from_pixel_str(self.widget.layout.height)
         ang_size = Angle(((change["new"] / widget_height) * fov))
-        valid = self.validate_angular_size(ang_size, change['new'] > 0)
+        valid = self.validate_angular_size(ang_size, True)
         # print(ang_size, change["new"], valid)
         # if valid:
         #     print('valid measurement')

--- a/src/hubbleds/components/distance_tool/distance_tool.py
+++ b/src/hubbleds/components/distance_tool/distance_tool.py
@@ -39,8 +39,8 @@ class DistanceTool(v.VueTemplate):
     wwtStyle = Dict().tag(sync=True)
     reset_style = Bool(False).tag(sync=True)
     
-    # Gaurd
-    gaurd = Bool(False).tag(sync=True)
+    # Guard
+    guard = Bool(False).tag(sync=True)
     galaxy_max_size = Angle("60 arcmin") # 2 x Pinwheel galaxy (d = 7 Mpc, r = 1.7 Rmw)
     galaxy_min_size = Angle("6 arcsec") # 3 x sdss resoltuion
     bad_measurement = Bool(False).tag(sync=True)
@@ -52,7 +52,7 @@ class DistanceTool(v.VueTemplate):
         self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self._setup_widget()
         self.measuring = kwargs.get('measuring', False)
-        self.gaurd = kwargs.get('gaurd', False)
+        self.guard = kwargs.get('guard', False)
         self.angular_size = Angle(0, u.deg)
         self.angular_height = Angle(60, u.deg)
         self.widget._set_message_type_callback('wwt_view_state',
@@ -148,20 +148,20 @@ class DistanceTool(v.VueTemplate):
         self.reset_style = True
         self.reset_style = False
     
-    def activate_gaurd(self):
-        self.gaurd = True
+    def activate_guard(self):
+        self.guard = True
         
-    def deactivate_gaurd(self):
-        self.gaurd = False
+    def deactivate_guard(self):
+        self.guard = False
         self.bad_measurement = False
         
-    def set_gaurd(self, max = None, min = None):
-        self.activate_gaurd()
+    def set_guard(self, max = None, min = None):
+        self.activate_guard()
         self.galaxy_max_size = max or self.galaxy_max_size
         self.galaxy_min_size = min or self.galaxy_min_size
     
     def validate_angular_size(self, angular_size):
-        if not self.gaurd:
+        if not self.guard:
             return True
         max_wwt_size = Angle("60 deg")
         c1 = (angular_size < max_wwt_size) 

--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -29,7 +29,7 @@
       </v-btn>
     </v-toolbar>
     <div class="distance-content">
-      <v-snackbar
+      <!-- <v-snackbar
         v-model="bad_measurement"
         transition="fab-transition"
         timeout="5000"
@@ -42,7 +42,7 @@
         elevation="24"
       >
         You've measured an impossible size for the galaxy. Please try again.
-      </v-snackbar>
+      </v-snackbar> -->
       <canvas
         v-show="measuring"
         class="distance-canvas"
@@ -386,7 +386,7 @@ export default {
     },
 
     perpSlope: function(p1=this.startPoint, p2=this.endPoint) {
-      if (!(p1 && p2)) { return undefined; }
+      if (!(p1 && p2)) { return 1; }
       return (p1[0] - p2[0]) / (p2[1] - p1[1]);
     },
 

--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -29,6 +29,20 @@
       </v-btn>
     </v-toolbar>
     <div class="distance-content">
+      <v-snackbar
+        v-model="bad_measurement"
+        transition="fab-transition"
+        timeout="5000"
+        top
+        right
+        color="warning lighten-2"
+        class="pa-4 black--text"
+        style="font-size: 1.25rem;"
+        multi-line
+        elevation="24"
+      >
+        You've measured an impossible size for the galaxy. Please try again.
+      </v-snackbar>
       <canvas
         v-show="measuring"
         class="distance-canvas"

--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_repeat_remaining_galaxies.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_repeat_remaining_galaxies.vue
@@ -11,20 +11,42 @@
     :state="state"
   >
     <template #before-next>
-      Measure angular size<span v-if="state.angsizes_total < 4">s</span> for {{ 5 - state.angsizes_total }} more <span v-if="state.angsizes_total < 4">galaxies</span><span v-if="state.angsizes_total == 4">galaxy</span>.
+      <span v-if="!state.bad_angsize">
+        Measure angular size<span v-if="state.angsizes_total < 4">s</span> for {{ 5 - state.angsizes_total }} more <span v-if="state.angsizes_total < 4">galaxies</span><span v-if="state.angsizes_total == 4">galaxy</span>.
+      </span>
+      <span v-if="state.bad_angsize">
+        <strong>Remeasure angular size</strong>
+        <br/>
+      </span>
     </template>
 
+    <!-- If there are no bad measurements and measurements are not complete -->
     <div
       class="mb-4"
-      v-if="state.angsizes_total < 5"
+      v-if="state.angsizes_total < 5 && !state.bad_angsize"
     >
       <p>
         Repeat the angular size measurements for each of the remaining galaxies in your table.
       </p>
     </div>
+
+    <!-- If there are any bad measurements -->
     <div
       class="mb-4"
-      v-if="state.angsizes_total >= 5"
+      v-if="state.bad_angsize"
+    >
+      <p>
+        Your measured angular size is not within the expected range. Please try again.
+      </p>
+      <p>
+        Ask your instructor if you are not sure where to measure.
+      </p>
+    </div>
+
+    <!-- If measurements are complete and there are no bad measurements -->  
+    <div
+      class="mb-4"
+      v-if="state.angsizes_total >= 5 && !state.bad_angsize"
     >
       <p>
         You have measured angular sizes for all of your galaxies.

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -351,6 +351,8 @@ class StageTwo(HubbleStage):
         self.distance_tool.observe(self._distance_tool_flagged,
                                    names=["flagged"])
 
+        self.distance_tool.activate_gaurd()
+        
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_changed)
         add_callback(self.stage_state, 'show_ruler', self._show_ruler_changed)
         add_callback(self.stage_state, 'brightness', self._update_brightness)

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -363,6 +363,7 @@ class StageTwo(HubbleStage):
                                    names=["flagged"])
 
         self.distance_tool.activate_guard()
+        self.distance_tool.set_guard(max = '30 arcmin', min = '5 arcsec')
         
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_changed)
         add_callback(self.stage_state, 'show_ruler', self._show_ruler_changed)

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -694,6 +694,10 @@ class StageTwo(HubbleStage):
     
     #@print_function_name
     def _make_measurement(self):
+        bad_meas = self.distance_tool.bad_measurement
+        if bad_meas:
+            print("Bad measurement")
+            return
         galaxy = self.stage_state.galaxy
         table = self.current_table
         data_label = table._glue_data.label
@@ -766,7 +770,7 @@ class StageTwo(HubbleStage):
                     v4.toolbar.tools['bqplot:home'].activate()
             
 
-            
+        
 
         if data_label == STUDENT_MEASUREMENTS_LABEL:
             self.story_state.update_student_data()

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -61,6 +61,7 @@ class StageState(CDSState):
     meas_theta = CallbackProperty(0)
     distance_calc_count = CallbackProperty(0)
     ruler_clicked_total = CallbackProperty(0)
+    bad_angsize = CallbackProperty(False)
     
     show_dotplot1 = CallbackProperty(False)
     show_dotplot2 = CallbackProperty(False)
@@ -694,10 +695,12 @@ class StageTwo(HubbleStage):
     
     #@print_function_name
     def _make_measurement(self):
-        bad_meas = self.distance_tool.bad_measurement
-        if bad_meas:
+        self.stage_state.bad_angsize = self.distance_tool.bad_measurement
+        if self.stage_state.bad_angsize:
             print("Bad measurement")
             return
+        else:
+            print('Good measurment')
         galaxy = self.stage_state.galaxy
         table = self.current_table
         data_label = table._glue_data.label

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -351,7 +351,7 @@ class StageTwo(HubbleStage):
         self.distance_tool.observe(self._distance_tool_flagged,
                                    names=["flagged"])
 
-        self.distance_tool.activate_gaurd()
+        self.distance_tool.activate_guard()
         
         add_callback(self.stage_state, 'galaxy', self._on_galaxy_changed)
         add_callback(self.stage_state, 'show_ruler', self._show_ruler_changed)


### PR DESCRIPTION
Implement #289

Adds a guard for the galaxy size in the distance tool. By default, the guard is not active. If activated, by default it will show the user a warning if the galaxy size is larger than 60 arcminutes or smaller than 6 arcseconds. This can be set using the `set_guard` method and can be turned on and off using the `(de)activate_guard` methods. 

Looking at the data, our smallest galaxy is 11 arcseconds, and the largest real measurements are about 12 arcminutes. 