### PR TITLE
Modify distance tool interaction to avoid stuck state

### DIFF
--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -244,9 +244,8 @@ export default {
       // If we haven't put the second point down
       } else if (this.endPoint === null) {
 
-        // If we haven't moved since we put the first point down, reset
+        // If we haven't moved since we put the first point down, do nothing
         if (!this.hasMovedWhileDrawing) {
-          this.startPoint = null;
           return;
         }
 

--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -243,6 +243,13 @@ export default {
 
       // If we haven't put the second point down
       } else if (this.endPoint === null) {
+
+        // If we haven't moved since we put the first point down, reset
+        if (!this.hasMovedWhileDrawing) {
+          this.startPoint = null;
+          return;
+        }
+
         this.endPoint = coordinates;
         this.clearCanvas();
         this.drawLine(this.startPoint, this.endPoint);
@@ -284,6 +291,13 @@ export default {
     },
 
     handleMouseUp: function(event) {
+      if (this.lineCreated && this.shouldFollowMouse) {
+        const coordinates = this.position(event);
+        this.endPoint = this.position(event);
+        this.clearCanvas();
+        this.drawLine(this.startPoint, this.endPoint);
+        this.drawEndcaps(this.startPoint, this.endPoint);
+      }
       this.mouseDown = false;
       this.canvas.classList.remove(this.grabbingClass);
       this.mouseMoving = false;
@@ -295,7 +309,7 @@ export default {
       if (this.shouldFollowMouse) {
         this.hasMovedWhileDrawing = true;
         this.lineFollow(event, true);
-      } else {
+      } else if (this.startPoint && this.endPoint) {
         this.lookForEndpoints(event);
       }
     },
@@ -365,6 +379,7 @@ export default {
 
     lineFollow: function(event, requireMouseDown) {
       this.mouseMoving = true;
+      this.hasMovedWhileDrawing = true;
       if (requireMouseDown && !this.mouseDown) { return; }
       const coordinates = this.position(event);
       this.clearCanvas();

--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -218,9 +218,9 @@ export default {
       this.hasMovedWhileDrawing = false;
 
       // Set the canvas handlers
-      this.canvas.onmousemove = null;
+      this.canvas.onmousemove = this.handleMouseMove;
       this.canvas.onmousedown = this.addInitialPoint;
-      this.canvas.onmouseup = this.addInitialPoint;
+      this.canvas.onmouseup = null;
 
       // Clear the canvas, if necessary
       this.clearCanvas();
@@ -261,27 +261,11 @@ export default {
       // If we aren't drawing the line
       // and we aren't on one of the endpoints,
       // then we're done here
-      if (!this.shouldFollowMouse && !(this.onStart || this.onEnd)) {
+      if (!(this.onStart || this.onEnd)) {
         event.stopImmediatePropagation();
         return;
       }
 
-      // If we've already setthe first endpoint,
-      // we now want to set the second
-      if (this.shouldFollowMouse) {
-
-        // If the user didn't move between clicks, don't
-        // count these as line endpoints
-
-        this.endPoint = this.position(event);
-        this.clearCanvas();
-        this.drawLine(this.startPoint, this.endPoint);
-        this.drawEndcaps(this.startPoint, this.endPoint);
-        this.updateMeasuredDistance();
-        return;
-      }
-
-      // Otherwise, we've already drawn the line and are grabbing
       // To make things easier, we define the point that
       // isn't being modified as the 'start' point
       if (this.onStart) {


### PR DESCRIPTION
This PR modifies the interaction of the distance-measuring tool to match the scheme described in #293. Now, the initial creation of the measuring line is done without dragging - after the tool has been activated, the first click places one endpoint of the line, and the line will follow the user's mouse until they make another click. If the user doesn't move between the first and second clicks, the second click is just ignored and the tool remains in the "drag to extend line" mode.

Note that the post-line creation interaction has not been modified - it's still the same grab-and-drag interaction.