### PR TITLE
Track stage progress and extract marker functionality

### DIFF
--- a/src/hubbleds/marker_state.py
+++ b/src/hubbleds/marker_state.py
@@ -65,4 +65,4 @@ class MarkerState(CDSState):
         if index is None:
             return
         self.max_marker_index = max(index, self.max_marker_index)
-        self.progress = self.max_marker_index / len(self.markers)
+        self.progress = self.max_marker_index / (len(self.markers) - 1)

--- a/src/hubbleds/marker_state.py
+++ b/src/hubbleds/marker_state.py
@@ -1,0 +1,58 @@
+from echo import CallbackProperty, add_callback, callback_property
+
+from cosmicds.phases import CDSState 
+
+
+class MarkerState(CDSState):
+    marker = CallbackProperty("")
+    markers = CallbackProperty([])
+    indices = CallbackProperty({})
+    advance_marker = CallbackProperty(True)
+    progress = CallbackProperty(0)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.marker_index = 0
+        self.marker = self.markers[0]
+        self.indices = {marker: idx for idx, marker in enumerate(self.markers)}
+        add_callback(self, 'marker', self._on_marker_update)
+
+    @callback_property
+    def marker_backward(self):
+        return None
+
+    @callback_property
+    def marker_forward(self):
+        return None
+
+    @marker_backward.setter
+    def marker_backward(self, value):
+        index = self.indices[self.marker]
+        new_index = min(max(index - value, 0), len(self.markers) - 1)
+        self.marker = self.markers[new_index]
+
+    @marker_forward.setter
+    def marker_forward(self, value):
+        index = self.indices[self.marker]
+        new_index = min(max(index + value, 0), len(self.markers) - 1)
+        self.marker = self.markers[new_index]
+
+    def marker_before(self, marker):
+        return self.indices[self.marker] < self.indices[marker]
+
+    def marker_after(self, marker):
+        return self.indices[self.marker] > self.indices[marker]
+    
+    def marker_reached(self, marker):
+        return self.indices[self.marker] >= self.indices[marker]
+
+    def move_marker_forward(self, marker_text, _value=None):
+        index = min(self.markers.index(marker_text) + 1, len(self.markers) - 1)
+        self.marker = self.markers[index]
+
+    def marker_index(self, marker):
+        return self.indices[marker]
+
+    def _on_marker_update(self, marker):
+        index = self.indices[marker]
+        self.progress = max(index / len(self.markers), self.progress)

--- a/src/hubbleds/marker_state.py
+++ b/src/hubbleds/marker_state.py
@@ -6,6 +6,7 @@ from cosmicds.phases import CDSState
 class MarkerState(CDSState):
     marker = CallbackProperty("")
     markers = CallbackProperty([])
+    n_markers = CallbackProperty(0)
     max_marker_index = CallbackProperty(0)
     indices = CallbackProperty({})
     advance_marker = CallbackProperty(True)
@@ -15,6 +16,7 @@ class MarkerState(CDSState):
         super().__init__(*args, **kwargs)
         self.marker_index = 0
         self.marker = self.markers[0]
+        self.n_markers = len(self.markers)
         self.indices = {marker: idx for idx, marker in enumerate(self.markers)}
         add_callback(self, 'marker', self._on_marker_update)
 

--- a/src/hubbleds/marker_state.py
+++ b/src/hubbleds/marker_state.py
@@ -6,6 +6,7 @@ from cosmicds.phases import CDSState
 class MarkerState(CDSState):
     marker = CallbackProperty("")
     markers = CallbackProperty([])
+    max_marker_index = CallbackProperty(0)
     indices = CallbackProperty({})
     advance_marker = CallbackProperty(True)
     progress = CallbackProperty(0)
@@ -27,12 +28,16 @@ class MarkerState(CDSState):
 
     @marker_backward.setter
     def marker_backward(self, value):
+        if value is None:
+            return
         index = self.indices[self.marker]
         new_index = min(max(index - value, 0), len(self.markers) - 1)
         self.marker = self.markers[new_index]
 
     @marker_forward.setter
     def marker_forward(self, value):
+        if value is None:
+            return
         index = self.indices[self.marker]
         new_index = min(max(index + value, 0), len(self.markers) - 1)
         self.marker = self.markers[new_index]
@@ -54,5 +59,8 @@ class MarkerState(CDSState):
         return self.indices[marker]
 
     def _on_marker_update(self, marker):
-        index = self.indices[marker]
-        self.progress = max(index / len(self.markers), self.progress)
+        index = self.indices.get(marker, None)
+        if index is None:
+            return
+        self.max_marker_index = max(index, self.max_marker_index)
+        self.progress = self.max_marker_index / len(self.markers)

--- a/src/hubbleds/stages/stage_4.py
+++ b/src/hubbleds/stages/stage_4.py
@@ -1,17 +1,15 @@
 from functools import partial
-from os.path import join
-from pathlib import Path
 
-from numpy import asarray, where
+from numpy import where
 from cosmicds.components.layer_toggle import LayerToggle
 from cosmicds.components.table import Table
-from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
 from cosmicds.utils import extend_tool, load_template, update_figure_css
 from echo import CallbackProperty, add_callback, remove_callback, DictCallbackProperty, ListCallbackProperty
 from glue.core.message import NumericalDataChangedMessage
 from glue.core.data import Data
 from glue_jupyter.link import link
+from hubbleds.marker_state import MarkerState
 from hubbleds.utils import IMAGE_BASE_URL, AGE_CONSTANT
 from traitlets import default, Bool
 from ..data.styles import load_style
@@ -24,7 +22,7 @@ from ..viewers import HubbleScatterView
 from ..viewers.viewers import HubbleFitLayerView
 
 
-class StageState(CDSState):
+class StageState(MarkerState):
     trend_response = CallbackProperty(False)
     relvel_response = CallbackProperty(False)
     race_response = CallbackProperty(False)
@@ -35,16 +33,11 @@ class StageState(CDSState):
     stage_4_complete = CallbackProperty(False)
     stage_ready = CallbackProperty(False)
 
-    marker = CallbackProperty("")
-    indices = CallbackProperty({})
-    advance_marker = CallbackProperty(True)
-
     image_location = CallbackProperty(f"{IMAGE_BASE_URL}/stage_three")
 
     hypgal_distance = CallbackProperty(0)
     hypgal_velocity = CallbackProperty(0)
     age_const = CallbackProperty(float(AGE_CONSTANT))
-
 
     #TrendsData ver
     define_trend = CallbackProperty(False)
@@ -110,24 +103,6 @@ class StageState(CDSState):
         'my_galaxies_plot_highlights', 'all_galaxies_plot_highlights',
     ]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.marker_index = 0
-        self.marker = self.markers[0]
-        self.indices = {marker: idx for idx, marker in enumerate(self.markers)}
-
-    def marker_before(self, marker):
-        return self.indices[self.marker] < self.indices[marker]
-
-    def marker_after(self, marker):
-        return self.indices[self.marker] > self.indices[marker]
-    
-    def marker_reached(self, marker):
-        return self.indices[self.marker] >= self.indices[marker]
-
-    def move_marker_forward(self, marker_text, _value=None):
-        index = min(self.markers.index(marker_text) + 1, len(self.markers) - 1)
-        self.marker = self.markers[index]
 
 @register_stage(story="hubbles_law", index=4, steps=[
     # "MY DATA"

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -5,13 +5,13 @@ from glue.core.subset import RangeSubsetState
 from numpy import where
 # from cosmicds.components.layer_toggle import LayerToggle
 from cosmicds.components import PercentageSelector, StatisticsSelector, Table 
-from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
 from cosmicds.utils import extend_tool, load_template, update_figure_css
 from echo import CallbackProperty, DictCallbackProperty, add_callback, callback_property, ListCallbackProperty, delay_callback
 from glue.core.message import NumericalDataChangedMessage
 from glue_jupyter.link import link
 from hubbleds.components.id_slider import IDSlider
+from hubbleds.marker_state import MarkerState
 from hubbleds.utils import IMAGE_BASE_URL, AGE_CONSTANT
 from traitlets import default, Bool
 from ..data.styles import load_style
@@ -24,7 +24,7 @@ from ..viewers.viewers import \
     HubbleClassHistogramView, HubbleHistogramView
 
 
-class StageState(CDSState):
+class StageState(MarkerState):
     relage_response = CallbackProperty(False)
     two_hist_response = CallbackProperty(False)
     two_hist3_response = CallbackProperty(False)
@@ -70,10 +70,6 @@ class StageState(CDSState):
             "Mode"
         ]
     })
-
-    marker = CallbackProperty("")
-    indices = CallbackProperty({})
-    advance_marker = CallbackProperty(True)
 
     image_location = CallbackProperty(f"{IMAGE_BASE_URL}/mean_median_mode") 
     class_data_size = CallbackProperty(0)
@@ -172,44 +168,6 @@ class StageState(CDSState):
         'my_class_hist_highlights', 'all_classes_hist_highlights',
     ]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.marker_index = 0
-        self.marker = self.markers[0]
-        self.indices = {marker: idx for idx, marker in enumerate(self.markers)}
-
-    @callback_property
-    def marker_forward(self):
-        return None
-
-    @callback_property
-    def marker_backward(self):
-        return None
-    
-    @marker_backward.setter
-    def marker_backward(self, value):
-        index = self.indices[self.marker]
-        new_index = min(max(index - value, 0), len(self.markers) - 1)
-        self.marker = self.markers[new_index]
-
-    @marker_forward.setter
-    def marker_forward(self, value):
-        index = self.indices[self.marker]
-        new_index = min(max(index + value, 0), len(self.markers) - 1)
-        self.marker = self.markers[new_index]
-
-    def marker_before(self, marker):
-        return self.indices[self.marker] < self.indices[marker]
-
-    def marker_after(self, marker):
-        return self.indices[self.marker] > self.indices[marker]
-    
-    def marker_reached(self, marker):
-        return self.indices[self.marker] >= self.indices[marker]
-
-    def move_marker_forward(self, marker_text, _value=None):
-        index = min(self.markers.index(marker_text) + 1, len(self.markers) - 1)
-        self.marker = self.markers[index]
 
 @register_stage(story="hubbles_law", index=5, steps=[
     # "CLASS AGE",

--- a/src/hubbleds/stages/stage_6.py
+++ b/src/hubbleds/stages/stage_6.py
@@ -1,6 +1,3 @@
-from os.path import join
-from pathlib import Path
-
 from numpy import where, round
 
 from echo import CallbackProperty, add_callback, callback_property, ListCallbackProperty
@@ -9,11 +6,10 @@ from glue.core import Subset
 from traitlets import Bool, default
 
 from cosmicds.components.layer_toggle import LayerToggle
-from cosmicds.phases import CDSState
 from cosmicds.registries import register_stage
-from cosmicds.utils import (RepeatedTimer, extend_tool, load_template,
-                            update_figure_css)
-from hubbleds.utils import HST_KEY_AGE, IMAGE_BASE_URL, AGE_CONSTANT
+from cosmicds.utils import load_template, update_figure_css
+from hubbleds.marker_state import MarkerState
+from hubbleds.utils import HST_KEY_AGE, AGE_CONSTANT
 
 from ..data.styles import load_style
 from ..data_management import *
@@ -21,11 +17,8 @@ from ..stage import HubbleStage
 
 from ..viewers.viewers import HubbleScatterView
 
-class StageState(CDSState):
+class StageState(MarkerState):
     
-    marker = CallbackProperty("")
-    indices = CallbackProperty({})
-
     hst_age = CallbackProperty(HST_KEY_AGE)
     our_age = CallbackProperty(0)
     class_age = CallbackProperty(0)
@@ -63,45 +56,6 @@ class StageState(CDSState):
         'image_location',
         'marker_forward', 'marker_backward',
     ]
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.marker_index = 0
-        self.marker = self.markers[0]
-        self.indices = {marker: idx for idx, marker in enumerate(self.markers)}
-
-    @callback_property
-    def marker_forward(self):
-        return None
-
-    @callback_property
-    def marker_backward(self):
-        return None
-    
-    @marker_backward.setter
-    def marker_backward(self, value):
-        index = self.indices[self.marker]
-        new_index = min(max(index - value, 0), len(self.markers) - 1)
-        self.marker = self.markers[new_index]
-
-    @marker_forward.setter
-    def marker_forward(self, value):
-        index = self.indices[self.marker]
-        new_index = min(max(index + value, 0), len(self.markers) - 1)
-        self.marker = self.markers[new_index]
-
-    def marker_before(self, marker):
-        return self.indices[self.marker] < self.indices[marker]
-
-    def marker_after(self, marker):
-        return self.indices[self.marker] > self.indices[marker]
-    
-    def marker_reached(self, marker):
-        return self.indices[self.marker] >= self.indices[marker]
-
-    def move_marker_forward(self, marker_text, _value=None):
-        index = min(self.markers.index(marker_text) + 1, len(self.markers) - 1)
-        self.marker = self.markers[index]
 
 
 @register_stage(story="hubbles_law", index=6, steps=[


### PR DESCRIPTION
This PR aims to resolve #298 by adding a `progress` value in stage states that updates whenever the marker is changed. Additionally, the total marker count (`n_markers`) and the max marker index reached (`max_marker_index`) are stored as well (so `progress = max_marker_index / n_markers`).

Additionally, this PR extracts all of the marker-based functionality, which is currently duplicated across stage states, into a single `MarkerState` class. The relevant stage states (i.e. all of them except the slideshows) now inherit from this class.

@patudom @johnarban Let me know if there's anything else that we'd like to have with respect to this.