### PR TITLE
Apply validation functionality from cosmicds #249 to our free responses

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_4/guideline_shortcomings_est_reflect1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_4/guideline_shortcomings_est_reflect1.vue
@@ -35,6 +35,7 @@
         label="Other Shortcomings"
         hint="(if you can think of any more)"
         tag="other-shortcomings"
+        allow-empty="true"
       ></free-response>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect2_c.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect2_c.vue
@@ -80,6 +80,7 @@
             rows="1"
             label="New Most Likely Age"
             tag="new-most-likely-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col>
@@ -157,6 +158,7 @@
             rows="1"
             label="New Likely Low Age"
             tag="new-likely-low-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col
@@ -171,6 +173,7 @@
             rows="1"
             label="New Likely High Age"
             tag="new-likely-high-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_confidence_interval_reflect3.vue
@@ -92,6 +92,7 @@
             rows="1"
             label="Likely Low Age"
             tag="likely-low-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col
@@ -106,6 +107,7 @@
             rows="1"
             label="Likely High Age"
             tag="likely-high-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_most_likely_value_reflect4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_most_likely_value_reflect4.vue
@@ -84,6 +84,7 @@
             rows="1"
             label="Most Likely Age"
             tag="best-guess-age"
+            type="float"
           ></free-response>
         </v-col>
         <v-col>

--- a/src/hubbleds/components/generic_state_components/stage_5/slideshow_uncertainty1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/slideshow_uncertainty1.vue
@@ -142,6 +142,7 @@
                     label="Shortcoming #4"
                     hint="(if you can think of any more)"
                     tag="shortcoming-4"
+                    allow-empty="true"
                   ></free-response>
                 </v-col>
               </v-row>

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data8.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data8.vue
@@ -29,22 +29,24 @@
         tag="prodata-reflect-8a"
       ></free-response>
       
-      <p>What age of the universe can be obtained from Edwin Hubble's data?</p>
+      <p>What age of the universe can be obtained from Edwin Hubble's data (in Gyr)?</p>
       <free-response
         outlined
         auto-grow
         rows="2"
         label="Age from Edwin Hubble"
         tag="prodata-reflect-8b"
+        type="float"
       ></free-response>
       
-    <p>What age of the universe can be obtained from the HST Key project's data?</p>
+    <p>What age of the universe can be obtained from the HST Key project's data (in Gyr)?</p>
       <free-response
         outlined
         auto-grow
         rows="2"
         label="Age from HST Key Project"
         tag="prodata-reflect-8c"
+        type="float"
       ></free-response>
       </v-container>
     </div>


### PR DESCRIPTION
This applies the functionality from https://github.com/cosmicds/cosmicds/pull/249 to relevant free-response questions in hubbleds. Be sure to get the latest on main because that branch was only just merged.

-  If something requires some text response, I did not add any props to those questions. 
- Anything that is asking for an age or age range requires a float, in case someone wants to use decimals.
- Questions that are optional have `allow-empty="true"`.
- To pro_dat8, I added units in the questions, so good doobies who know to include units won't get stymied by our requirement that only numbers can be entered.