### PR TITLE
Silence dotenv output

### DIFF
--- a/src/hubbleds/HubbleDS.ipynb
+++ b/src/hubbleds/HubbleDS.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "from dotenv import load_dotenv\n",
-    "load_dotenv()"
+    "load_dotenv();"
    ]
   },
   {


### PR DESCRIPTION
This is a tiny PR to silence the output from `load_dotenv` in the notebook.