### PR TITLE
Fixing Issue 313 - overwide image on stage 2 slideshow

### DIFF
--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
@@ -348,6 +348,7 @@
                   class="mx-a"
                   contain
                   max-height="300"
+                  aspect-ratio="2.6288"
                   :src="`${image_location}/cosmicgraphic.png`"
                 ></v-img>
               </v-col>


### PR DESCRIPTION
This PR fixes #313. The issue was that while the displayed image only took up a small amount a space, the surrounding stuff was still at the full 2500px width of the original image