### PR TITLE
Redo layout for dot plot sequence

### DIFF
--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_angsize_meas4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_angsize_meas4.vue
@@ -17,11 +17,11 @@
     <div
       class="mb-4"
     >
-      <p>
+    <p>
         Click on one edge of your galaxy to mark the ruler's starting point.
       </p>
       <p>
-        With the button held down, drag to the other edge of your galaxy and release the button.
+        Move the cursor to the other edge of your galaxy click again.
       </p>
       <p>
         If you want to adjust your measurement, you can click on the ends of the green line and move them to a new location.

--- a/src/hubbleds/components/generic_state_components/stage_3/guideline_dotplot_seq4.vue
+++ b/src/hubbleds/components/generic_state_components/stage_3/guideline_dotplot_seq4.vue
@@ -9,7 +9,7 @@
       class="mb-4"
     >
       <p>
-        Here is the distribution of angular size measurements for this galaxy. Notice the angular size measurements also tend to group around more than one value.
+        Below is the distribution of angular size measurements for this galaxy. Notice the angular size measurements also tend to group around more than one value.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_classmates_results.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_classmates_results.vue
@@ -17,7 +17,7 @@
         Your value appears in orange-red, and your classmates' are blue.
       </p>
       <p>
-        To exclude outliers, click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-select-search</v-icon></v-btn> to zoom in to a smaller velocity or distance range.
+        Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-select-search</v-icon></v-btn> to zoom in to a smaller velocity or distance range.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_classmates_results_c.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_classmates_results_c.vue
@@ -17,7 +17,7 @@
         Use the slider to scan through the age estimates that each participating class measured. 
       </p>
       <p>
-        To exclude outliers, click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-select-search</v-icon></v-btn> to zoom in to a smaller velocity or distance range.
+        Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-select-search</v-icon></v-btn> to zoom in to a smaller velocity or distance range.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms1.vue
@@ -14,7 +14,7 @@
       class="mb-4"
     >
       <p>
-        Another data set to explore are the age values measured by All Students who have completed this Data Story. 
+        The top graph shows the age values measured by All Students who have completed this Data Story. 
       </p>
       <p>
         Notice how the All Students histogram (top) differs from the All Classes histogram (bottom).

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_mc3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_mc3.vue
@@ -14,7 +14,7 @@
     <div
       class="mb-4"
     >
-      Now try comparing the 50%, 68%, and 95% confidence ranges between the two histograms. (The switches will display the same percentage range on both histograms.)
+      Now try comparing the inner 50%, 68%, and 95% confidence ranges between the two histograms. (The switches will display the same percentage range on both histograms.)
       <v-container
         class="px-0"
         fluid

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_mc3a.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_mc3a.vue
@@ -1,0 +1,50 @@
+<!-- this state.marker = 'two_his2' -->
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Student Histogram vs. Class Histogram"
+    @back="state.marker_backward = 1"
+    @next="state.marker_forward = 1"
+    :can-advance="(state) => state.two_hist3a_response"
+    :state="state"
+  >
+    <div
+      class="mb-4"
+    >
+      Perhaps even more important than the range of ages is <strong>how those ages are distributed</strong>. If most of the measurements are bunched closely together, that gives us more confidence than
+      if they are spread across a large range of values or are bunched around multiple values. As with the dot plots you saw earlier, more <strong>consensus</strong> in measurements generally gives us more <strong>confidence</strong> in a result.
+      <v-container
+        class="px-0"
+        fluid
+      >
+        <p>How would you describe the distribution of age measurements for these histograms?</p>
+        <mc-radiogroup
+          :radio-options="[
+            'The distribution for the student and class age measurements look similar to each other.',
+            'The distribution for the student measurements are more concentrated around a central value than the class measurements.',
+            'The distribution for the class measurements are more concentrated around a central value than the student measurements.'
+          ]"
+          :feedbacks="[
+            'Not quite. One histogram looks more like a spike, while the other looks more like a bell. Which is which?',
+            'Not quite. One histogram looks more like a spike, while the other looks more like a bell. Which is which?',
+            'That\'s right. The student histogram looks more like a bell, while the class histogram looks more like a spike, so there is more consensus within the class age measurements.',
+          ]"
+          :correct-answers="[2]"
+          :wrong-answers='[0,1]'
+          @select="(state) => { if (state.correct) { $emit('ready'); } }"
+          score-tag="histogram-distribution"
+        >
+        </mc-radiogroup>
+      </v-container>
+    </div>
+  </scaffold-alert>
+</template>
+
+<script>
+module.exports = {
+  props: ['state']
+}
+</script>

--- a/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_reflect5.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/guideline_two_histograms_reflect5.vue
@@ -9,7 +9,7 @@
       class="mb-4"
     >
       <p>
-        The broader confidence intervals for the All Students data tell us that an age value measured by one student has more uncertainty than an age value measured by a single class.
+        The smoother, less clustered distribution for the All Students data tells us that an age value measured by one student has more uncertainty than an age value measured by a single class.
       </p>
       <p>
         Explain why you think this might be true.

--- a/src/hubbleds/components/generic_state_components/stage_5/slideshow_uncertainty1.vue
+++ b/src/hubbleds/components/generic_state_components/stage_5/slideshow_uncertainty1.vue
@@ -100,7 +100,7 @@
               <v-row>
                 <v-col>
                   <p>
-                    Recall your thoughts about shortcomings in your measurements and your estimate of the universe's age.
+                    If you recall, you identified these shortcomings in your measurements and your estimate of the universe's age.
                   </p>
                   <p
                     class="mb-3 mt-10"

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data9.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_professional_data9.vue
@@ -23,7 +23,7 @@
       >
         <mc-radiogroup
           :radio-options="[
-              'Scientists can\'t really know what the age of the universe is.',
+              'Scientists do not really know how to measure the age of the universe.',
               'Scientists measure different ages because the universe is always getting older.',
               'The measured age of the universe can change based on new and better data.'
           ]"

--- a/src/hubbleds/components/generic_state_components/stage_6/guideline_story_finish3.vue
+++ b/src/hubbleds/components/generic_state_components/stage_6/guideline_story_finish3.vue
@@ -15,7 +15,7 @@
               color="accent"
               elevation="2"
               target="_blank"
-              href='https://harvard.az1.qualtrics.com/jfe/form/SV_08L8G4zPV0O5JVc'
+              href='https://harvard.az1.qualtrics.com/jfe/form/SV_d0V9oiJpW0jjz94'
             >
               <strong>survey</strong>
             </v-btn>

--- a/src/hubbleds/stages/stage_3.vue
+++ b/src/hubbleds/stages/stage_3.vue
@@ -184,7 +184,7 @@
         cols="12"
         lg="4"
       >
-          <guideline-dotplot-seq1
+        <guideline-dotplot-seq1
           v-if="stage_state.marker == 'dot_seq1'" 
           :state="stage_state"
           v-intersect.once="scrollIntoView" />
@@ -197,6 +197,15 @@
           v-if="stage_state.marker == 'dot_seq3'" 
           :state="stage_state"
           v-intersect.once="scrollIntoView"/>
+        <guideline-dotplot-seq4
+          v-if="stage_state.marker == 'dot_seq4'" 
+          :state="stage_state"
+          v-intersect.once="scrollIntoView"/>
+        <guideline-dotplot-seq4a
+          v-if="stage_state.marker == 'dot_seq4a'" 
+          :state="stage_state"
+          v-intersect.once="scrollIntoView" 
+          @ready="stage_state.dot_seq4a_q = true"/>
         <guideline-dotplot-seq6
           v-if="stage_state.marker == 'dot_seq6'" 
           :state="stage_state"
@@ -222,12 +231,15 @@
             <v-card class="dotplot" v-if="stage_state.show_dotplot2 || ((stage_state.indices['dot_seq5c'] <= stage_state.indices[stage_state.marker]) && (stage_state.indices[stage_state.marker] < stage_state.indices['rep_rem1']))">
               <jupyter-widget :widget="viewers.dotplot_viewer_dist_2"/>
             </v-card>
+            <v-card class='dotplot' v-if="stage_state.show_dotplot1_ang || stage_state.marker == 'dot_seq4' || stage_state.marker == 'dot_seq4a'">
+              <jupyter-widget :widget="viewers.dotplot_viewer_ang"/>
+            </v-card>
           </v-col>
         </v-row>
       </v-col>
     </v-row>
 
-    <v-row>
+    <!-- <v-row>
       <v-col
         cols="12"
         lg="4"
@@ -236,11 +248,6 @@
         v-if="stage_state.marker == 'dot_seq4'" 
           :state="stage_state"
           v-intersect.once="scrollIntoView"/>
-        <guideline-dotplot-seq4a
-        v-if="stage_state.marker == 'dot_seq4a'" 
-          :state="stage_state"
-          v-intersect.once="scrollIntoView" 
-          @ready="stage_state.dot_seq4a_q = true"/>
       </v-col>
       <v-col
         cols="12"
@@ -264,7 +271,7 @@
           </v-col>
         </v-row>
       </v-col>
-    </v-row>
+    </v-row> -->
   </v-container>
 </template>
 

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -27,6 +27,7 @@ class StageState(CDSState):
     relage_response = CallbackProperty(False)
     two_hist_response = CallbackProperty(False)
     two_hist3_response = CallbackProperty(False)
+    two_hist3a_response = CallbackProperty(False)
     # two_hist4_response = CallbackProperty(False)
     lack_bias_response = CallbackProperty(False)
     uncertainty_hint_dialog = CallbackProperty(False)
@@ -128,6 +129,7 @@ class StageState(CDSState):
         'two_his1',
         'two_his2',
         'two_his3',
+        'two_his3a',
         # 'two_his4', cutting because it's too long redundant
         'two_his5',
         #'lac_bia1',
@@ -354,6 +356,9 @@ class StageFour(HubbleStage):
         student_slider.on_id_change(student_slider_change)
         student_slider.on_refresh(student_slider_refresh)
 
+        if self.stage_state.marker_reached("cla_dat1"):
+            layer_viewer.state.reset_limits()
+
         layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", self.stage_state.marker_reached("cla_dat1"))
         layer_viewer.toolbar.set_tool_enabled("hubble:linefit", self.stage_state.marker_reached("bes_fit1c"))
 
@@ -558,8 +563,10 @@ class StageFour(HubbleStage):
                 all_viewer.toolbar.tools["hubble:linefit"].activate() # toggle on
                     
         if advancing and new == "cla_dat1":
+            layer_viewer.state.reset_limits()
             layer_viewer.toolbar.tools["hubble:linedraw"].erase_line() 
-            layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", True)
+            layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", False)
+            layer_viewer.toolbar.set_tool_enabled("hubble:linefit", False )
             student_data = self.get_data(STUDENT_DATA_LABEL)
             if len(student_data.subsets) > 0:
                 best_fit_subset = student_data.subsets[0]
@@ -569,9 +576,9 @@ class StageFour(HubbleStage):
             class_layer.state.visible = True
             student_layer = layer_viewer.layer_artist_for_data(student_data)
             student_layer.state.visible = False
-            linefit_tool = layer_viewer.toolbar.tools["hubble:linefit"]
-            if linefit_tool.active:
-                linefit_tool.activate()
+
+        if advancing and new == "tre_lin2c":
+            layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", True)
 
         if advancing and new == "bes_fit1c":
             linefit_tool = layer_viewer.toolbar.tools["hubble:linefit"]

--- a/src/hubbleds/stages/stage_5.py
+++ b/src/hubbleds/stages/stage_5.py
@@ -566,7 +566,6 @@ class StageFour(HubbleStage):
             layer_viewer.state.reset_limits()
             layer_viewer.toolbar.tools["hubble:linedraw"].erase_line() 
             layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", False)
-            layer_viewer.toolbar.set_tool_enabled("hubble:linefit", False )
             student_data = self.get_data(STUDENT_DATA_LABEL)
             if len(student_data.subsets) > 0:
                 best_fit_subset = student_data.subsets[0]
@@ -576,6 +575,10 @@ class StageFour(HubbleStage):
             class_layer.state.visible = True
             student_layer = layer_viewer.layer_artist_for_data(student_data)
             student_layer.state.visible = False
+            linefit_tool = layer_viewer.toolbar.tools["hubble:linefit"]
+            if linefit_tool.active:
+                linefit_tool.activate()
+            layer_viewer.toolbar.set_tool_enabled("hubble:linefit", False )
 
         if advancing and new == "tre_lin2c":
             layer_viewer.toolbar.set_tool_enabled("hubble:linedraw", True)

--- a/src/hubbleds/stages/stage_5.vue
+++ b/src/hubbleds/stages/stage_5.vue
@@ -350,6 +350,11 @@
           :state="stage_state"
           v-intersect.once="scrollIntoView"
           @ready="stage_state.two_hist3_response = true"/>
+          <guideline-two-histograms-mc3a
+          v-if="stage_state.marker == 'two_his3a'"
+          :state="stage_state"
+          v-intersect.once="scrollIntoView"
+          @ready="stage_state.two_hist3a_response = true"/>
         <guideline-two-histograms-reflect5
           v-if="stage_state.marker == 'two_his5'"
           :state="stage_state"


### PR DESCRIPTION
This builds on #325 and resolves #318 by putting both dot plot viewers into the same row.

<img width="1601" alt="Screen Shot 2023-11-08 at 10 33 26 PM" src="https://github.com/cosmicds/hubbleds/assets/12750048/248df231-296d-43c9-89bf-791bdbd0f392">
