### PR TITLE
Give free response alerts more contrast

### DIFF
--- a/src/hubbleds/components/distance_tool/distance_tool.vue
+++ b/src/hubbleds/components/distance_tool/distance_tool.vue
@@ -70,7 +70,7 @@
             bottom
             right
             absolute
-            :color="measuring ? 'red' : 'success'"
+            :color="measuring ? 'red' : '#00E676'"
             class="measuring-fab black--text"
             :ripple="false"
             v-bind="attrs"

--- a/src/hubbleds/components/intro_slideshow/intro_slideshow.vue
+++ b/src/hubbleds/components/intro_slideshow/intro_slideshow.vue
@@ -825,7 +825,7 @@
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
         v-if="step < 6 && show_team_interface"
-        color="error"
+        color="success"
         class="black--text"
         depressed
         @click="() => {

--- a/src/hubbleds/components/selection_tool/selection_tool.vue
+++ b/src/hubbleds/components/selection_tool/selection_tool.vue
@@ -148,7 +148,7 @@
             bottom
             left
             absolute
-            color="success"
+            color="#00E676"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
@@ -168,7 +168,7 @@
           bottom
           right
           absolute
-          color="success"
+          color="#00E676"
           class="selection-fab black--text"
           v-bind="attrs"
           v-on="on"

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
@@ -813,7 +813,7 @@
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
         v-if="step < 12 && show_team_interface"
-        color="error"
+        color="success"
         class="black--text"
         depressed
         @click="() => {

--- a/src/hubbleds/stages/stage_1.vue
+++ b/src/hubbleds/stages/stage_1.vue
@@ -3,12 +3,12 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="fill_data();"
         >fill data points</v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);
@@ -18,7 +18,7 @@
           console.log State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             print_state();
@@ -27,7 +27,7 @@
           Print Python State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             fill_data();
@@ -74,7 +74,7 @@
         />
         <v-btn
           v-if="show_team_interface && (stage_state.marker === 'sel_gal2' || 'sel_gal3 || sel_gal4' && stage_state.gals_total < stage_state.gals_max)"
-          color="error"
+          color="success"
           class="black--text"
           block
           max-width="800"
@@ -444,7 +444,7 @@
           <v-col
             v-if="show_team_interface">
             <v-btn
-              color="error"
+              color="success"
               class="black--text"
               @click="update_velocities()"
             >

--- a/src/hubbleds/stages/stage_3.vue
+++ b/src/hubbleds/stages/stage_3.vue
@@ -3,7 +3,7 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);
@@ -13,7 +13,7 @@
           State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('jumping');
@@ -262,7 +262,7 @@
             </v-card>
             <v-btn
               v-if="show_team_interface"
-              color="error"
+              color="success"
               class="black--text"
               @click="update_distances()"
             >

--- a/src/hubbleds/stages/stage_4.vue
+++ b/src/hubbleds/stages/stage_4.vue
@@ -7,7 +7,7 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);
@@ -17,7 +17,7 @@
           State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             stage_state.marker = 'sho_est1';

--- a/src/hubbleds/stages/stage_5.vue
+++ b/src/hubbleds/stages/stage_5.vue
@@ -3,7 +3,7 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);
@@ -13,7 +13,7 @@
           State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             stage_state.marker = 'lea_unc1';
@@ -416,7 +416,7 @@
       <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);
@@ -426,7 +426,7 @@
           State
         </v-btn>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             stage_state.marker = 'lea_unc1';

--- a/src/hubbleds/stages/stage_6.vue
+++ b/src/hubbleds/stages/stage_6.vue
@@ -3,7 +3,7 @@
     <v-row v-if="show_team_interface">
       <v-col>
         <v-btn
-          color="error"
+          color="success"
           class="black--text"
           @click="() => {
             console.log('stage state:', stage_state);

--- a/src/hubbleds/story.py
+++ b/src/hubbleds/story.py
@@ -176,13 +176,13 @@ class HubblesLaw(Story):
         v.theme.themes.light.secondary = 'colors.cyan.darken4'
         v.theme.themes.dark.accent = 'colors.amber.accent3'   # Next/Back buttons
         v.theme.themes.light.accent = 'colors.amber.accent2'
-        v.theme.themes.dark.error = 'colors.pink.lighten1'  # Team insider buttons that will not appear for user
-        v.theme.themes.light.error = 'colors.indigo.lighten2'
+        v.theme.themes.dark.error = 'colors.lime.accent1'  # New: Error alerts for free response inputs
+        v.theme.themes.light.error = 'colors.indigo.darken4' 
         v.theme.themes.dark.info = 'colors.deepOrange.darken4'  # Instruction scaffolds & viewer highlights
         v.theme.themes.light.info = 'colors.deepOrange.lighten1'
-        v.theme.themes.dark.success = 'colors.green.accent3'   # Actions and interactions
-        v.theme.themes.light.success = 'colors.green.accent3'
-        v.theme.themes.dark.warning = 'colors.deepOrange.accent4' # Unallocated (maybe viewer highlights?)
+        v.theme.themes.dark.success = 'colors.pink.lighten1'   # New: Team insider buttons that will not appear for user
+        v.theme.themes.light.success = 'colors.indigo.lighten2' #formerly green.accent3 or 00E676
+        v.theme.themes.dark.warning = 'colors.deepOrange.accent4' # Reflection and some other slideshow headers
         v.theme.themes.light.warning = 'colors.deepOrange.accent4'
         #Alt Palette 1:  Y:FFBE0B, O:FB5607, Pi:FF006E, Pu:8338EC, Bl:3A86FF, LiBl:619EFF
 


### PR DESCRIPTION
This resolves #329 (a la the puzzle with the canoe that doesn't hold enough people to cross the river.)

Vuetify uses the "error" theme color for the validation alerts, so we had to free that up from the team interface buttons we'd previously allocated "error" to.

The "success" theme color is the one we were using the least, so I hard-coded in the old "success" color in the 2 places it was being used, then repurposed the "success" color to be the new team interface color.

New colors were then assigned to "error" with sufficient contrast.
<img width="1173" alt="Screen Shot 2023-11-09 at 12 13 21 AM" src="https://github.com/cosmicds/hubbleds/assets/12750048/64ae3fc6-e566-4e4b-8bfa-4a033b7ffa0a">
<img width="1160" alt="Screen Shot 2023-11-09 at 12 13 30 AM" src="https://github.com/cosmicds/hubbleds/assets/12750048/ff9ca244-785f-4b84-8b99-cc24a6eda542">


