### PR TITLE
Set total distances during stage 3 initialization

### DIFF
--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -16,7 +16,6 @@ from ..utils import DISTANCE_CONSTANT, GALAXY_FOV, HUBBLE_ROUTE_PATH, IMAGE_BASE
 from ..viewers import HubbleDotPlotView
 from ..data.styles import load_style
 from cosmicds.utils import  update_figure_css
-from numpy import searchsorted
 
 from bqplot.marks import Scatter
 

--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -276,6 +276,7 @@ class StageTwo(HubbleStage):
         dotplot_viewer_dist_2.ignore(lambda layer: layer in [first])
         
         self.setup_dotplot_viewers()
+        self.get_distance_count()
         
         add_distances_tool = \
             dict(id="update-distances",


### PR DESCRIPTION
This PR updates Stage 3 to set `distances_total` stage state during the stage initialization. This should help fix the issue that we were seeing during the deployment today - at the least, it will make the issue go away on a refresh.