### PR TITLE
pass correct table when we have a bad measurement

### DIFF
--- a/src/hubbleds/stages/stage_3.py
+++ b/src/hubbleds/stages/stage_3.py
@@ -723,7 +723,7 @@ class StageTwo(HubbleStage):
         self.stage_state.bad_angsize = self.distance_tool.bad_measurement
 
         if self.stage_state.bad_angsize:
-            change = {'new':galaxy, 'old': None, 'owner': self.distance_table}
+            change = {'new':galaxy, 'old': None, 'owner': table}
             self.distance_table_selected_change(change)
             self.stage_state.bad_angsize_index = index
 


### PR DESCRIPTION
In the stage 3 `_make_measurements` function, when there is a bad measurement, the table that got passed to `distance_table_selected_change` was always the main distance table, and was not properly switched to the example galaxy distance table leading to an error. this makes a simple change to fix this