### PR TITLE
Add empty limit guards in fit viewer state

### DIFF
--- a/src/hubbleds/viewers/viewers.py
+++ b/src/hubbleds/viewers/viewers.py
@@ -30,8 +30,10 @@ class HubbleFitViewerState(HubbleScatterViewerState):
     def reset_limits(self, visible_only=True):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             super().reset_limits(visible_only=visible_only)
-            self.x_max = 1.1 * self.x_max
-            self.y_max = 1.1 * self.y_max
+            if self.x_max is not None:
+                self.x_max = 1.1 * self.x_max
+            if self.y_max is not None:
+                self.y_max = 1.1 * self.y_max
 
 class HubbleHistogramViewerState(LineHoverStateMixin, CDSHistogramViewerState):
     


### PR DESCRIPTION
This PR looks to provide a band-aid fix for #332 - it doesn't change whatever's causing the limits to be `None`, but it guards against that case when limit-padding to prevent an error.