### PR TITLE
Add distance intro

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -21,6 +21,34 @@
     padding-inline: 20px;
 }
 
+.theme--dark .MathJax {
+    color: white !important;
+}
+
+.theme--light .MathJax {
+    color: black !important;
+}
+
+.JaxEquation .MathJax {
+    margin: 16px auto !important;
+}
+
+.v-container .v-card__text {
+    font-size: 18px !important;
+    line-height: 1.5 !important;
+}
+
+.v-radio label.theme--dark{
+    color: white !important;
+}
+.v-radio label.theme--light{
+    color: black !important;
+}
+
+.v-alert .v-input--radio-group+.v-alert, .v-dialog .v-input--radio-group+.v-alert {
+    background-color: #000b !important;
+}
+
 /*.solara-container-main {*/
 /*    max-width: 1264px;*/
 /*    height: 100%;*/

--- a/src/hubbleds/components/__init__.py
+++ b/src/hubbleds/components/__init__.py
@@ -3,3 +3,4 @@ from .data_table.data_table import DataTable
 from .spectrum_viewer.spectrum_viewer import SpectrumViewer
 from .spectrum_slideshow.spectrum_slideshow import SpectrumSlideshow
 from .doppler_slideshow.doppler_slideshow import DopplerSlideshow
+from .stage_2_slideshow.stage_2_slideshow import Stage2Slideshow

--- a/src/hubbleds/components/intro_slideshow/intro_slideshow.py
+++ b/src/hubbleds/components/intro_slideshow/intro_slideshow.py
@@ -18,12 +18,13 @@ _titles = [
     "Vesto Slipher and Spectral Data"
 ]
 
+@solara.component
 def carousel_title(step, titles):
     with rv.Toolbar(color="warning", dense=True,):
         with rv.ToolbarTitle( ):
             solara.Text(titles[step], classes=["toolbar-title"])
 
-
+@solara.component
 def IntroSlideshow():
     step, on_step = solara.use_state(0)
 
@@ -93,54 +94,53 @@ def IntroSlideshow():
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
-            with solara.Row():
-                with solara.ColumnsResponsive(12, large=[7,5]):
-                    with solara.Column(align="center"):
-                        solara.HTML(
-                            unsafe_innerHTML=
-                            """
-                                <p>
-                                    When scientists collect data to answer questions no one has answered yet, there is no answer key in the back of some book. So, as you explore this data story, you will learn how to <b>evaluate the reliability</b> of your results. Are the data really good enough to support a conclusion? <b>How can you know?</b> 
-                                </p>
-                                <p>
-                                    Just as scientists constantly must, you'll <b>determine what can be concluded</b> from the data at-hand, and <b>how much confidence</b> you can have in your conclusions.
-                                </p>
-                                <p>
-                                    Let's get started.
-                                </p>
-                            """,
-                        classes = ["padded-text"],                       
-                        )
+            with solara.ColumnsResponsive(12, large=[7,5]):
+                with solara.Column(align="center"):
+                    solara.HTML(
+                        unsafe_innerHTML=
+                        """
+                            <p>
+                                When scientists collect data to answer questions no one has answered yet, there is no answer key in the back of some book. So, as you explore this data story, you will learn how to <b>evaluate the reliability</b> of your results. Are the data really good enough to support a conclusion? <b>How can you know?</b> 
+                            </p>
+                            <p>
+                                Just as scientists constantly must, you'll <b>determine what can be concluded</b> from the data at-hand, and <b>how much confidence</b> you can have in your conclusions.
+                            </p>
+                            <p>
+                                Let's get started.
+                            </p>
+                        """,
+                    classes = ["padded-text"],                       
+                    )
 
-                    with solara.Column(align="center"):
-                        with solara.ColumnsResponsive(6, large=12):
-                            with solara.Column(align="center", classes=[]):
-                                solara.HTML(
-                                    unsafe_innerHTML=
-                                    f"""
-                                    <img
-                                        src = '{ image_location }HST-SM4.jpeg'
-                                        style = 'max-height: 250px;'
-                                        alt = 'The Hubble Space Telescope against a dark background'
-                                    />
-                                    """
-                                )
-                            with solara.Column(align="center", classes=[]):
-                                solara.HTML(
-                                    unsafe_innerHTML=
-                                    f"""
-                                    <img
-                                        src = '{ image_location }EdwinHubble.jpg'
-                                        style = 'max-height: 250px;'
-                                        alt = 'Astronomer Edwin Hubble holding an image of the Andromeda Galaxy'
-                                    />
-                                    """
-                                )
-                        solara.Text(
-                            "The Hubble Space Telescope and Edwin Hubble, the astronomer it was named for. Hubble holds an image of the Andromeda Galaxy, for which the earliest recorded observation was made in 964 AD by Iranian scholar al-Sufi.",
-                            classes=["caption", ],
-                            style="text-align: center; max-width: 80%",
-                        )        
+                with solara.Column(align="center"):
+                    with solara.ColumnsResponsive(6, large=12):
+                        with solara.Column(align="center", classes=[]):
+                            solara.HTML(
+                                unsafe_innerHTML=
+                                f"""
+                                <img
+                                    src = '{ image_location }HST-SM4.jpeg'
+                                    style = 'max-height: 250px;'
+                                    alt = 'The Hubble Space Telescope against a dark background'
+                                />
+                                """
+                            )
+                        with solara.Column(align="center", classes=[]):
+                            solara.HTML(
+                                unsafe_innerHTML=
+                                f"""
+                                <img
+                                    src = '{ image_location }EdwinHubble.jpg'
+                                    style = 'max-height: 250px;'
+                                    alt = 'Astronomer Edwin Hubble holding an image of the Andromeda Galaxy'
+                                />
+                                """
+                            )
+                    solara.Text(
+                        "The Hubble Space Telescope and Edwin Hubble, the astronomer it was named for. Hubble holds an image of the Andromeda Galaxy, for which the earliest recorded observation was made in 964 AD by Iranian scholar al-Sufi.",
+                        classes=["caption", ],
+                        style="text-align: center; max-width: 80%",
+                    )        
 
         # Slide 2
         with rv.CarouselItem():

--- a/src/hubbleds/components/intro_slideshow/intro_slideshow.py
+++ b/src/hubbleds/components/intro_slideshow/intro_slideshow.py
@@ -59,7 +59,7 @@ def IntroSlideshow():
                         classes = ["padded-text"],                 
                     )
 
-                    with solara.Card(style="background-color: blue"):
+                    with solara.Card(style="background-color: #0D47A1"):
                         solara.HTML(
                             unsafe_innerHTML=
                             """

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.py
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.py
@@ -1,0 +1,17 @@
+import solara
+import reacton.ipyvuetify as rv
+from ipyvuetify import VuetifyTemplate
+
+@solara.component_vue("stage_2_slideshow.vue")
+def Stage2Slideshow (
+    step,
+    length,
+    titles,
+    max_step_completed,
+    interact_steps,
+    stage_2_complete,
+    show_team_interface,
+    distance_const,
+    image_location,
+):
+    pass

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
@@ -1,0 +1,888 @@
+<template>
+  <v-container
+    class="py-0"
+  >
+    <v-row
+      justify="center"
+    >
+      <v-col cols="12">
+
+  <v-card
+    elevation="6"
+  >
+    <v-toolbar
+      ref="toolbar"
+      color="warning"
+      dense
+      dark
+    >
+      <v-toolbar-title
+        class="text-h6 text-uppercase font-weight-regular"
+      >
+        {{ titles[step] }}
+      </v-toolbar-title>
+      <v-spacer></v-spacer>
+      <speech-synthesizer
+        ref="synth"
+        :root="$el"
+        :element-filter="(element) => {
+          // There's some annoying behavior with when elements lose visibility when changing
+          // window items. Rather than doing some crazy shenanigans to wait the right amount of time,
+          // we just explicitly filter out elements that aren't descendants of the toolbar
+          // or the current window item
+          if (this.$refs.toolbar.$el.contains(element)) { return true; }
+          const currentWindowItem = this.$el.querySelector('.v-window-item--active');
+          return currentWindowItem?.contains(element) ?? false;
+        }"
+        :autospeak-on-change="step"
+        :selectors="['div.v-toolbar__title.text-h6', 'div.v-card__text.black--text', 'h3', 'p']"
+      />
+    </v-toolbar>
+
+    <v-window
+      v-model="step"
+      style="height: 70vh;"
+      class="overflow-auto"
+    >
+      <v-window-item :value="0" 
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row> 
+              <v-col>
+                <div>
+                  <p>
+                    You’ve now uncovered evidence that <b>galaxies</b> are for the most part <b>moving AWAY from our Milky Way galaxy</b>. To scientists in the 1920s, this led to a <b>radical shift in their world view</b>. Once they knew galaxies do not, in fact, move about randomly, they needed to come up with a <b>new explanation for this surprising phenomenon.</b>
+                  </p>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="1" 
+          class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <div>                    
+                  <p>
+                    <b>Edwin Hubble</b> was an astronomer who was interested in these galaxies. After looking at Slipher’s velocity measurements, Hubble wondered if there is a <b>relationship between</b> the galaxies’ <b>velocities</b> and their <b>distances</b> from the Milky Way. 
+                  </p>
+                  <p>
+                    Measuring <b>distances</b> to objects in space is one of the most challenging things to do in astronomy. In the next section, you will learn a method for determining distances to galaxies.
+                  </p>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="2"
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col
+                cols="6"
+                class="d-flex flex-column"
+                height="100%"
+                flat
+                tile
+              >
+                <h3
+                  class="mb-4"
+                >
+                  Distance and Apparent Size
+                </h3>
+                <div>
+                  <p>
+                    Consider the people in this image. Do you think that there really is a giant sized person holding a smaller person in their hand?
+                  </p>
+                  <p>
+                    No! The people are not at the same distance from the photographer. 
+                  </p>
+                </div>
+              </v-col>
+              <v-col
+                cols="6"
+              >
+                <h4
+                  class="mb-2"
+                >
+                  People on the Beach
+                </h4>
+                <v-img
+                  class="mb-4 mx-a"
+                  contain
+                  :src="`${image_location}/PeopleLargeSmallAngularSize.png`"
+                ></v-img>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+    
+
+      <v-window-item :value="3" 
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3
+                  class="mb-4"
+                >
+                  Distance and Apparent Size
+                </h3>
+                <div>
+                  <p>  
+                  From looking at these images, can you guess (or know) which person and which galaxy are <b>closer</b> to the viewer? Think about what visual cues you are using and what assumptions you are making as you ponder your answer.
+                  </p>
+                </div>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="6"
+              >
+                <h4
+                  class="mb-2"
+                >
+                  People on the beach 
+                </h4>
+                <v-img
+                  class="mb-4 mx-a"
+                  contain
+                  :src="`${image_location}/PeopleLargeSmallAngularSize.png`"
+                ></v-img>
+              </v-col>
+              <v-col
+                cols="6"
+              >
+                <h4
+                  class="mb-2"
+                >
+                  Galaxies in the night sky 
+                </h4>
+                <v-img
+                  class="mb-4 mx-a"
+                  contain
+                  :src="`${image_location}/esahubble_potw2031a_1600_cleaned.png`"
+                ></v-img>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="4" 
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3
+                  class="mb-4"
+                >
+                  Distance and Apparent Size
+                </h3>
+                <div>
+                  <p>
+                    You know how big a typical person is, and people are generally similar in size to each other, so the ones that are closest to you will appear bigger than the ones that are farthest away.
+                  </p>
+                  <p>
+                    If we make the same assumption about galaxies, you can use this information to <b>determine how far away</b> they are.
+                  </p>
+                </div>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="6"
+              >
+                <h4
+                  class="mb-2"
+                >
+                  People on the beach 
+                </h4>
+                <v-img
+                  class="mb-4 mx-a"
+                  contain
+                  :src="`${image_location}/PeopleLargeSmallAngularSize labeled.png`"
+                ></v-img>
+              </v-col>
+              <v-col cols="6">
+                <h4 class="mb-2">
+                  Galaxies in the night sky 
+                </h4>
+                <v-img
+                  class="mb-4 mx-a"
+                  contain
+                  :src="`${image_location}/esahubble_potw2031a_1600_cleaned.png`"
+                ></v-img>
+              </v-col> 
+            </v-row> 
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="5" 
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3>
+                  How to measure apparent size
+                </h3>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="8"
+              >
+                <p>
+                  We need a way to measure “how big” an object seems. We call this “apparent” or “angular” size.
+                </p>
+                <p>
+                  The apparent (or <strong>angular</strong>) size of objects in the sky is measured in degrees, or in fractions of a degree. 
+                </p>
+                <p>
+                  To get a sense for how big 1 degree is, hold your pinky out at arm’s length. Your pinky fingernail at arm’s length covers about 1 degree of arc in the sky.
+                </p>
+              </v-col>
+              <v-col
+                cols="4"
+              >
+                <v-card
+                  class="mt-auto"
+                  flat
+                  color="secondary lighten-3"
+                  light
+                > 
+                  <v-card-text
+                    class="black-text"
+                  >
+                    <p>
+                      <strong>Bonus experiment</strong>: Do you think your pinky held at arm’s length would cover the moon? 
+                      Try it the next time you see the moon in the sky!
+                    </p>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+            <v-row 
+              justify="center"
+            >
+              <div
+                class="text-center"
+                style="width: 100%;"
+              >
+                <h4
+                  class="mb-2"
+                >
+                  One degree of angular size in the sky is a pinky's width at arm's length. 
+                </h4>
+              </div>
+              <v-img
+                class="mx-a"
+                contain
+                max-height="300"
+                :src="`${image_location}/erinmoon.png`"
+              ></v-img>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="6" 
+        class="no-transition" 
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3
+                  class="mb-4"
+                >
+                  Distance and angular size
+                </h3>
+                <div>
+                  <p>
+                    As with the people, if we know the physical size of a galaxy, then its angular size tells us its distance from us. 
+                  </p>
+                  <p>
+                    For very far away objects like galaxies, the relationship is described by the formula:
+                  </p>
+                  <v-card
+                    class="mt-auto white--text"
+                    flat
+                    color="info"
+                    v-intersect = "(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                  >
+                    <v-card-text>
+                      <div
+                        class="JaxEquation"
+                      >
+                        $$ \small{\text{Galaxy's Angular Size } (\theta) = \frac{\text{Galaxy's Physical Size } (L)}{\text{Galaxy's Distance } (D)}} $$  
+                      </div>
+                      <h5>
+                        (ask your instructor for more information if you want to know how to use trigonometry to derive this formula).
+                      </h5> 
+                    </v-card-text>
+                  </v-card>
+                </div>
+              </v-col>
+            </v-row>
+            <v-spacer></v-spacer>
+            <v-row>
+              <v-col>
+                <v-img
+                  class="mx-a"
+                  contain
+                  max-height="300"
+                  aspect-ratio="2.6288"
+                  :src="`${image_location}/cosmicgraphic.png`"
+                ></v-img>
+              </v-col>
+            </v-row>
+            <p
+              class="mt-4"
+            >
+              For galaxies that are the <strong>same physical size</strong>, the larger the distance, the smaller the galaxy will appear in angular size.   
+            </p>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+    
+
+      <v-window-item :value="7" 
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col
+                cols="7"
+              >
+                <div>
+                  <h3
+                    class="mb-4"
+                  >
+                    Reflect
+                  </h3>
+                  <v-row>                     
+                    <v-card
+                      class="mt-auto white--text"
+                      flat
+                      color="info"
+                    >
+                      <v-card-text 
+                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                      >
+                        <div
+                          class="JaxEquation"
+                        >
+                          $$ \small{\text{Galaxy's Angular Size } (\theta) = \frac{\text{Galaxy's Physical Size } (L)}{\text{Galaxy's Distance } (D)}} $$ 
+                        </div>
+                      </v-card-text>
+                    </v-card>
+                    </v-row>
+                    <v-spacer></v-spacer>
+                    <v-row>
+                      <p
+                        class="mt-4"
+                      >
+                        Assume galaxies A and B in this image have the <strong>same physical size</strong>. What can you determine about their relative distances?
+                      </p>
+                      <!-- Whoops, is there any way to pass on the formatting info in the feedback responses without treating them as strings? -->
+                      <mc-radiogroup
+                        :radio-options="[
+                          'Galaxy A and Galaxy B are the same distance away from us.',
+                          'Galaxy A is farther away from us than Galaxy B.',
+                          'Galaxy A is closer to us than Galaxy B.',
+                          'We do not have enough information to answer this question'
+                        ]"
+                        :feedbacks="[
+                          'Try again. \n Think about the people on the beach. Did the closer person appear bigger or smaller than the farther person?',
+                          'Try again. \n Think about the people on the beach. Did the closer person appear bigger or smaller than the farther person?',
+                          'That\'s right! The <strong>closer</strong> galaxy has a <strong>larger</strong> angular size in the sky.',
+                          'Try again. \n Think about the people on the beach. Did the closer person appear bigger or smaller than the farther person?'
+                        ]"
+                        :correct-answers="[2]"
+                        @select="(option) => { if(option.correct || option.neutral) { max_step_completed = Math.max(this.max_step_completed, 7); } }"
+                        score-tag="which-galaxy-closer"
+                      >
+                      </mc-radiogroup>
+                    </v-row>
+                  </div>
+                </v-col> 
+                <v-col
+                  cols="5"
+                >
+                  <h4
+                    class="mb-2"
+                  >
+                    Galaxies in the Sky
+                  </h4>
+                  <v-img
+                    class="mx-a"
+                    contain
+                    :src="`${image_location}/galaxies_a_b_boxed.png`"
+                  ></v-img>
+                </v-col>
+            </v-row> 
+          </v-container>            
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="8" 
+          class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3
+                  class="mb-4"
+                >
+                  Angular Size and Distance
+                </h3>
+                <div>                    
+                  <p>
+                    Now let’s think in terms of actual numbers.
+                  </p>
+                  <v-col
+                    cols="7"
+                  >
+                    <v-card
+                      class="white--text"
+                      flat
+                      color="info"
+                    >
+                      <v-card-text
+                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                      >
+                        <div
+                          class="JaxEquation"
+                        >
+                          $$ \small{\text{Galaxy's Angular Size } (\theta) = \frac{\text{Galaxy's Physical Size } (L)}{\text{Galaxy's Distance } (D)}} $$ 
+                        </div>
+                      </v-card-text>
+                    </v-card>
+                  </v-col>
+                  <v-spacer></v-spacer>
+                  <p>
+                    This relationship tells us: if two galaxies are the same size and one is <strong>2 times</strong> farther from us as the other, the far one will have 1/2 the angular size in our sky.
+                  </p>
+                  <p>
+                    If one galaxy is <strong>50 times</strong> farther from us as the other, the far one will have <strong>1/50</strong> the angular size in our sky, and so on.
+                  </p>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="9"
+        class="no-transition"
+      >
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col
+                cols="7"
+              >
+                <div>
+                  <v-row>
+                    <h3
+                      class="mb-4"
+                    >
+                      Reflect
+                    </h3>                           
+                    <p>
+                      Use the image to estimate <strong>how much</strong> closer Galaxy A is than Galaxy B. Assume galaxies A and B have the <strong>same physical size</strong>.
+                    </p>
+                    <v-card
+                      class="mt-auto white--text"
+                      flat
+                      color="info"
+                    >
+                      <v-card-text
+                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                      >
+                        <div
+                          class="JaxEquation"
+                        >
+                          $$ \small{\text{Galaxy's Angular Size } (\theta) = \frac{\text{Galaxy's Physical Size } (L)}{\text{Galaxy's Distance } (D)}} $$ 
+                        </div>
+                      </v-card-text>
+                    </v-card>
+                  </v-row>
+                  <v-row>
+                    <mc-radiogroup
+                      :radio-options="[
+                        'Galaxy A is about 2 times closer to us than Galaxy B.',
+                        'Galaxy A is about 10 times closer to us than Galaxy B.',
+                        'Galaxy A is about 1000 times closer to us than Galaxy B.',
+                        'There is not enough information to estimate the relative distances to the galaxies.'
+                      ]"
+                      :feedbacks="[
+                        'Try again. \n Try to imagine how many times you could lay Galaxy B across Galaxy A.',
+                        'That\'s right!',
+                        'Try again. \n Try to imagine how many times you could lay Galaxy B across Galaxy A.',
+                        'Try again. \ You could probably fit 10 Galaxy B’s across Galaxy A.'
+                      ]"
+                      :correct-answers="[1]"
+                      @select="(option) => { if(option.correct || option.neutral) { max_step_completed = Math.max(this.max_step_completed, 9); } }"
+                      score-tag="how-much-closer-galaxies"
+                    >
+                    </mc-radiogroup>
+                  </v-row>
+                </div>
+              </v-col> 
+              <v-col
+                cols="5"
+              >
+                <div>
+                  <h4
+                    class="mb-2"
+                  >
+                    Galaxies in the Sky
+                  </h4>
+                  <v-img
+                    class="mx-a"
+                    contain
+                    :src="`${image_location}/galaxies_a_b_boxed.png`"
+                  ></v-img>
+                </div>
+              </v-col>
+            </v-row> 
+          </v-container>            
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="10"
+        class="no-transition"
+      >
+        <v-card-text
+          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+        >
+          <v-container>
+            <v-row>
+              <v-col
+                cols="8"
+              >
+                <h3
+                  class="mb-4"
+                >
+                  Distance and Angular Size
+                </h3>
+                <div>
+                  <p>
+                    Nice work! To estimate distances to <strong>your</strong> galaxies, we start with this same formula:
+                  </p>
+                  <div
+                    class="JaxEquation"
+                  >
+                    $$ \small{\text{Galaxy's Angular Size } (\theta) = \frac{\text{Galaxy's Physical Size } (L)}{\text{Galaxy's Distance } (D)}} $$ 
+                  </div>
+                  <p>
+                    With some algebra and unit conversions, this becomes: 
+                  </p>
+                  <v-card
+                    class="mt-3 white--text"
+                    flat
+                    color="info"
+                  >
+                    <v-card-text
+                      v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                    >
+                      <div
+                        class="JaxEquation"
+                      >
+                        $$ \small{\text{Galaxy Distance} =  210,000 \cdot \frac{\text{Galaxy's physical size}}{\text{Galaxy’s angular size ($\theta$, in arcseconds)}}} $$
+                      </div>
+                    </v-card-text>
+                  </v-card>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>
+
+
+      <v-window-item :value="11"
+        class="no-transition"
+      >
+        <v-card-text
+          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+        >
+          <v-container>
+            <v-row>
+              <v-col
+                cols="9"
+              >
+                <h3
+                  class="mb-4"
+                >
+                  Physical size of a Galaxy
+                </h3>
+                <v-card
+                  class="white--text"
+                  flat
+                  color="info"
+                >
+                  <v-card-text
+                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                  >
+                    <div
+                      class="JaxEquation"
+                    >
+                      $$ \small{\text{Galaxy Distance} = 210,000 \cdot \frac{\text{Galaxy's physical size}}{\text{Galaxy’s angular size ($\theta$, in arcseconds)}}} $$
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+            <v-row> 
+              <v-col>         
+                <p>
+                  This equation from the previous slide requires two pieces of information to determine the distance to a galaxy:
+                  <ol>
+                    <li>the <strong>physical size</strong> of the galaxy</li>
+                    <li>the <strong>angular size</strong> of the galaxy</li> 
+                  </ol>
+                </p>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="9"
+              >
+                <p>
+                  In this data story, we are going to make an assumption that all galaxies are the <strong>same physical size as the Milky Way galaxy</strong>:
+                </p>
+                <v-card
+                  class="mb-3 white--text"
+                  flat
+                  color="info"
+                >
+                  <v-card-text
+                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                  >
+                    <div
+                      class="JaxEquation"
+                    >
+                      $$ \text{Physical size of Milky Way galaxy, }  L = 100,000 \text{ light years}$$
+                    </div>
+                  </v-card-text>
+                </v-card>
+                <p>
+                  <strong>(You can ponder later whether you think this is a good or bad assumption!)</strong>
+                </p>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-window-item>          
+
+
+      <v-window-item :value="12"
+        class="no-transition"
+      >
+        <v-card-text
+          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+        >
+          <v-container>
+            <v-row>
+              <v-col>
+                <h3
+                  class="mb-4"
+                >
+                  Milky Way Size in Mpc
+                </h3>
+                <p>
+                  When measuring very large distances, astronomers use a unit called a Megaparsec (Mpc). 
+                </p>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="8"
+              >
+                <p>
+                  If we substitute the physical size of the Milky Way (L=0.03 Mpc) in our equation, we get:
+                </p>
+                <v-card
+                  class="mb-3 white--text"
+                  flat
+                  color="info"
+                >
+                  <v-card-text
+                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                  >
+                    <div
+                      class="JaxEquation"
+                    >
+                      $$ \text{ Distance in Mpc} = \frac{ {{ Math.round(distance_const) }} }{ \text{galaxy's angular size (}\theta \text{ in arcseconds)}} $$
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <p>
+                  So, to measure the distance to a galaxy like the Milky Way, all you have to do is measure its <strong>angular size</strong> in arcseconds. Let’s get started.
+                </p>
+              </v-col>
+            </v-row> 
+          </v-container>
+        </v-card-text>    
+      </v-window-item>
+    </v-window>
+
+    <v-divider></v-divider>
+
+    <v-card-actions
+      class="justify-space-between"
+    >
+      <v-btn
+        :disabled="step === 0"
+        class="black--text"
+        color="accent"
+        depressed
+        @click="step--"
+      >
+        Back
+      </v-btn>
+
+      <v-spacer></v-spacer>
+      
+      <v-item-group
+        v-model="step"
+        class="text-center"
+        mandatory
+      >
+        <v-item
+          v-for="n in length"
+          :key="`btn-${n}`"
+          v-slot="{ active, toggle }"
+        >
+          <v-btn
+            :disabled="n > max_step_completed + 2"
+            :input-value="active"
+            icon
+            @click="toggle"
+          >
+            <v-icon
+              color="info lighten-1"
+            >
+              mdi-record
+            </v-icon>
+          </v-btn>
+        </v-item>
+      </v-item-group>
+
+      <v-spacer></v-spacer>
+
+      <v-btn
+        :disabled="!show_team_interface && step > max_step_completed"
+        v-if="step < length-1"
+        class="black--text"
+        color="accent"
+        depressed
+        @click="step++;"
+      >
+        next
+      </v-btn>
+
+      <!-- first button below just being used for testing, delete when using live with students -->
+      <v-btn
+        v-if="step < 12 && show_team_interface"
+        color="success"
+        class="black--text"
+        depressed
+        @click="() => {
+          stage_2_complete = true;
+          step = 0;
+          //this.$refs.synth.stopSpeaking();
+        }"
+      >
+        get started
+      </v-btn>
+      
+      <v-btn
+        v-if="step >= 12"
+        :disabled="step > 12"
+        color="accent"
+        class="black--text"
+        depressed
+        @click="() => {
+          stage_2_complete = true;
+          step = 0;
+          //this.$refs.synth.stopSpeaking();
+        }"
+      >
+        get started
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+  
+  
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+module.exports = {
+  props: ["buttonText", "titleText", "closeText"],
+
+  mounted() {
+    console.log("Two Intro");
+    console.log(this);
+    console.log(this.$el);
+  },
+
+  watch: {
+    step(newStep, oldStep) {
+      const isInteractStep = this.interact_steps.includes(newStep);
+      const newCompleted = isInteractStep ? newStep - 1 : newStep;
+      this.max_step_completed = Math.max(this.max_step_completed, newCompleted);
+    },
+  },
+};
+</script>
+
+<style>
+.no-transition {
+  transition: none;
+}
+
+#slideshow-root .v-card__text{
+  padding: 0px 15px 0px;
+  min-height: 550px;
+}
+</style>

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
@@ -860,6 +860,12 @@
 module.exports = {
   props: ["buttonText", "titleText", "closeText"],
 
+  computed: {
+    MathJax() {
+      return document.defaultView.MathJax
+    },
+  },
+
   mounted() {
     console.log("Two Intro");
     console.log(this);

--- a/src/hubbleds/pages/02-distance-introduction/__init__.py
+++ b/src/hubbleds/pages/02-distance-introduction/__init__.py
@@ -1,0 +1,43 @@
+import solara
+from cosmicds import load_custom_vue_components
+from glue_jupyter.app import JupyterApplication
+from reacton import ipyvuetify as rv
+
+from ...components import Stage2Slideshow
+
+from ...state import GLOBAL_STATE, LOCAL_STATE
+from .component_state import ComponentState
+from ...utils import IMAGE_BASE_URL, DISTANCE_CONSTANT
+
+
+component_state = ComponentState()
+
+@solara.component
+def Page():
+    load_custom_vue_components()
+
+    Stage2Slideshow(
+        step = component_state.distance_slideshow_state.step_dist.value,
+        max_step_completed = component_state.distance_slideshow_state.max_step_completed.value,
+        stage_2_complete = component_state.distance_slideshow_state.complete.value,
+        length = 13,
+        titles = [
+            "1920's Astronomy",
+            "1920's Astronomy",
+            "How can we know how far away something is?",
+            "How can we know how far away something is?",
+            "How can we know how far away something is?",
+            "How can we know how far away something is?",
+            "Galaxy Distances",
+            "Galaxy Distances",
+            "Galaxy Distances",
+            "Galaxy Distances",
+            "Galaxy Distances",
+            "Galaxy Distances",
+            "Galaxy Distances"
+        ],   
+        interact_steps=[7,9],     
+        show_team_interface = True,
+        distance_const=DISTANCE_CONSTANT,
+        image_location=f"{IMAGE_BASE_URL}/stage_two_intro",
+    )    

--- a/src/hubbleds/pages/02-distance-introduction/component_state.py
+++ b/src/hubbleds/pages/02-distance-introduction/component_state.py
@@ -1,0 +1,15 @@
+from solara import Reactive
+import dataclasses
+from ...state import GLOBAL_STATE
+
+@dataclasses.dataclass
+class DistanceSlideshow:
+    step_dist: Reactive[int] = dataclasses.field(default=Reactive(0))
+    max_step_completed: Reactive[int] = dataclasses.field(default=Reactive(0)) 
+    complete: Reactive[bool] = dataclasses.field(default=Reactive(False))
+
+@dataclasses.dataclass
+class ComponentState:
+    distance_slideshow_state: DistanceSlideshow = dataclasses.field(
+        default_factory=DistanceSlideshow
+    )


### PR DESCRIPTION
This adds the Stage 2 slideshow to solara.

One issue I noticed is that if I switch to a different stage and come back to the Distance Intro, some of the MathJax gets re-rendered and equations appear twice. I can't reproduce this reliably and have no idea what is triggering this.
<img width="1587" alt="Screenshot 2024-05-02 at 12 49 15 PM" src="https://github.com/cosmicds/hubbleds/assets/12750048/a5ec269b-6259-404a-af6a-14597c1e866f">
