### PR TITLE
Stage 5

### DIFF
--- a/src/hubbleds/components/plotly_viewer/plotly_viewer.py
+++ b/src/hubbleds/components/plotly_viewer/plotly_viewer.py
@@ -1,5 +1,0 @@
-import solara
-
-@solara.component
-def PlotlyViewer(
-    

--- a/src/hubbleds/components/plotly_viewer/plotly_viewer.py
+++ b/src/hubbleds/components/plotly_viewer/plotly_viewer.py
@@ -1,0 +1,5 @@
+import solara
+
+@solara.component
+def PlotlyViewer(
+    

--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -1,7 +1,9 @@
 import solara
 from cosmicds import load_custom_vue_components
 from cosmicds.components import ScaffoldAlert, ViewerLayout
+from glue.core import Data
 from glue_jupyter import JupyterApplication
+from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_plotly.viewers.scatter import PlotlyScatterView 
 from pathlib import Path
 from reacton import ipyvuetify as rv
@@ -16,7 +18,12 @@ component_state = ComponentState()
 
 gjapp = JupyterApplication(GLOBAL_STATE.data_collection, GLOBAL_STATE.session)
 
-viewer = gjapp.new_data_viewer(PlotlyScatterView)
+test_data = Data(x=[1,2,3,4,5], y=[1,4,9,16,26])
+test_data.style.color = "red"
+GLOBAL_STATE.data_collection.append(test_data)
+viewer = gjapp.new_data_viewer(PlotlyScatterView, data=test_data)
+layer = viewer.layers[0]
+layer.state.size = 30
 
 @solara.component
 def Page():

--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -1,8 +1,7 @@
 import solara
 from cosmicds import load_custom_vue_components
-from cosmicds.components import ScaffoldAlert
+from cosmicds.components.scaffold_alert import ScaffoldAlert
 from cosmicds.viewers import CDSScatterView
-from cosmicds.widgets.viewer_layout import ViewerLayout
 from glue.core import Data
 from glue_jupyter import JupyterApplication
 from glue_jupyter.bqplot.scatter import BqplotScatterView
@@ -46,7 +45,7 @@ def GridViewer(viewer):
         classes=["elevation-2"],
     )
     with solara.Card(
-        title="Viewer Card",
+        title=viewer.state.title,
         children=[layout]
     ):
         pass

--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -1,12 +1,11 @@
 import solara
 from cosmicds import load_custom_vue_components
 from cosmicds.components import ScaffoldAlert
+from cosmicds.viewers import CDSScatterView
 from cosmicds.widgets.viewer_layout import ViewerLayout
 from glue.core import Data
 from glue_jupyter import JupyterApplication
 from glue_jupyter.bqplot.scatter import BqplotScatterView
-from glue_plotly.viewers.histogram import PlotlyHistogramView 
-from glue_plotly.viewers.scatter import PlotlyScatterView 
 from pathlib import Path
 from reacton import ipyvuetify as rv
 
@@ -61,7 +60,9 @@ def Page():
         test_data = Data(x=[1,2,3,4,5], y=[1,4,9,16,26])
         test_data.style.color = "red"
         gjapp.data_collection.append(test_data)
-        gjapp.new_data_viewer(PlotlyScatterView, data=test_data, show=False)
+        viewer = gjapp.new_data_viewer(CDSScatterView, data=test_data, show=False)
+        layer = viewer.layers[0]
+        layer.state.size = 25
         return gjapp 
     gjapp = solara.use_memo(glue_setup, [])
 

--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -1,0 +1,62 @@
+import solara
+from cosmicds import load_custom_vue_components
+from cosmicds.components import ScaffoldAlert, ViewerLayout
+from glue_jupyter import JupyterApplication
+from glue_plotly.viewers.scatter import PlotlyScatterView 
+from pathlib import Path
+from reacton import ipyvuetify as rv
+
+from ...state import GLOBAL_STATE, LOCAL_STATE
+from .component_state import ComponentState, Marker
+
+
+GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
+
+component_state = ComponentState()
+
+gjapp = JupyterApplication(GLOBAL_STATE.data_collection, GLOBAL_STATE.session)
+
+viewer = gjapp.new_data_viewer(PlotlyScatterView)
+
+@solara.component
+def Page():
+    # Custom vue-only components have to be registered in the Page element
+    #  currently, otherwise they will not be available in the front-end
+    load_custom_vue_components()
+
+    # Solara's reactivity is often tied to the _context_ of the Page it's
+    #  being rendered in. Currently, in order to trigger subscribed callbacks,
+    #  state connections need to be initialized _inside_ a Page.
+    # component_state.setup()
+
+    solara.Text(
+        f"Current step: {component_state.current_step.value}, "
+        f"Next step: {Marker(component_state.current_step.value.value + 1)}"
+        f"Can advance: {component_state.can_transition(next=True)}"
+    )
+
+    with rv.Row():
+        with rv.Col(cols=4):
+            ScaffoldAlert(
+                GUIDELINE_ROOT / "GuidelineRandomVariability.vue",
+                event_next_callback=lambda *args: component_state.transition_next(),
+                can_advance=component_state.can_transition(next=True),
+                show=component_state.is_current_step(Marker.ran_var1),
+            )
+            ScaffoldAlert(
+                GUIDELINE_ROOT / "GuidelineFinishedClassmates.vue",
+                event_next_callback=lambda *args: component_state.transition_next(),
+                event_back_callback=lambda *args: component_state.transition_previous(),
+                can_advance=component_state.can_transition(next=True),
+                show=component_state.is_current_step(Marker.fin_cla1),
+            )
+            ScaffoldAlert(
+                GUIDELINE_ROOT / "GuidelineClassData.vue",
+                event_next_callback=lambda *args: component_state.transition_next(),
+                event_back_callback=lambda *args: component_state.transition_previous(),
+                can_advance=component_state.can_transition(next=True),
+                show=component_state.is_current_step(Marker.cla_dat1),
+            )
+
+        with rv.Col(cols=8):
+            ViewerLayout(viewer=viewer)

--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -6,6 +6,7 @@ from glue.core import Data
 from glue_jupyter import JupyterApplication
 from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_plotly.viewers.histogram import PlotlyHistogramView 
+from glue_plotly.viewers.scatter import PlotlyScatterView 
 from pathlib import Path
 from reacton import ipyvuetify as rv
 
@@ -16,8 +17,6 @@ from .component_state import ComponentState, Marker
 GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 
 component_state = ComponentState()
-
-
 
 
 @solara.component
@@ -62,9 +61,11 @@ def Page():
         test_data = Data(x=[1,2,3,4,5], y=[1,4,9,16,26])
         test_data.style.color = "red"
         gjapp.data_collection.append(test_data)
-        gjapp.new_data_viewer("plotly_histogram", data=test_data, show=False)
+        gjapp.new_data_viewer(PlotlyScatterView, data=test_data, show=False)
         return gjapp 
     gjapp = solara.use_memo(glue_setup, [])
+
+    test = solara.use_reactive(False)
 
     # Custom vue-only components have to be registered in the Page element
     #  currently, otherwise they will not be available in the front-end
@@ -104,5 +105,10 @@ def Page():
                 show=component_state.is_current_step(Marker.cla_dat1),
             )
 
+        def toggle_viewer():
+            test.value = not test.value
+
         with rv.Col(cols=8):
-            GridViewer(viewer=gjapp.viewers[0])
+            if test.value:
+                GridViewer(viewer=gjapp.viewers[0])
+            solara.Button("Testing", on_click=toggle_viewer)

--- a/src/hubbleds/pages/05-examining-data/component_state.py
+++ b/src/hubbleds/pages/05-examining-data/component_state.py
@@ -1,0 +1,139 @@
+import dataclasses
+from solara import Reactive
+import enum
+
+__all__ = ["Marker", "ComponentState"]
+
+class Marker(enum.Enum):
+    ran_var1 = enum.auto()
+    fin_cla1 = enum.auto()
+    cla_res1 = enum.auto()
+    rel_age1 = enum.auto()
+    cla_age1 = enum.auto()
+    cla_age2 = enum.auto()
+    cla_age3 = enum.auto()
+    cla_age4 = enum.auto()
+    lea_unc1 = enum.auto()
+    mos_lik1 = enum.auto()
+    age_dis1 = enum.auto()
+    mos_lik2 = enum.auto()
+    mos_lik3 = enum.auto()
+    mos_lik4 = enum.auto()
+    con_int1 = enum.auto()
+    con_int2 = enum.auto()
+    con_int3 = enum.auto()
+
+    cla_dat1 = enum.auto()
+    tre_lin2c = enum.auto()
+    bes_fit1c = enum.auto()
+    you_age1c = enum.auto()
+    cla_res1c = enum.auto()
+    cla_age1c = enum.auto()
+    age_dis1c = enum.auto()
+    con_int2c = enum.auto()
+    
+    two_his1 = enum.auto()
+    two_his2 = enum.auto()
+    two_his3 = enum.auto()
+    two_his3a = enum.auto()
+    two_his5 = enum.auto()
+    mor_dat1 = enum.auto()
+
+    @staticmethod
+    def next(step):
+        return Marker(step.value + 1)
+    
+    @staticmethod
+    def previous(step):
+        return Marker(step.value - 1)
+
+
+@dataclasses.dataclass
+class UncertaintyState:
+    step: Reactive[int] = dataclasses.field(default=Reactive(0))
+    length: Reactive[int] = dataclasses.field(default=Reactive(10))
+    titles: Reactive[list] = dataclasses.field(
+        default=Reactive(
+            [
+                'What is the true age of the universe?',
+                "Shortcomings in our measurements",
+                "Shortcomings in our measurements",
+                "Messiness in our distance measurements",
+                "Uncertainty",            
+                "Random Uncertainty (Noise)",
+                "Systematic Uncertainty (Bias)",
+                "Causes of Systematic Uncertainty",
+                "Systematic Uncertainty",
+                "Finished Uncertainty Tutorial",
+            ]
+        )
+    )
+
+
+@dataclasses.dataclass
+class MMMState:
+    step: Reactive[int] = dataclasses.field(default=Reactive(0))
+    length: Reactive[int] = dataclasses.field(default=Reactive(3))
+    titles: Reactive[list] = dataclasses.field(
+        default=Reactive(
+            [
+                "Mean",
+                "Median",
+                "Mode",
+            ]
+        )
+    )
+
+
+@dataclasses.dataclass
+class AgeCalcState:
+    hint1_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
+    hint2_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
+    hint3_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
+    best_guess: Reactive[str] = dataclasses.field(default=Reactive(""))
+    low_guess: Reactive[str] = dataclasses.field(default=Reactive(""))
+    high_guess: Reactive[str] = dataclasses.field(default=Reactive(""))
+    short_one: Reactive[str] = dataclasses.field(default=Reactive(""))
+    short_two: Reactive[str] = dataclasses.field(default=Reactive(""))
+    short_other: Reactive[str] = dataclasses.field(default=Reactive(""))
+
+
+@dataclasses.dataclass
+class ComponentState:
+    current_step: Reactive[Marker] = dataclasses.field(default=Reactive(Marker.ran_var1))
+
+    def is_current_step(self, step: Marker):
+        return self.current_step.value == step
+
+    def can_transition(self, step: Marker=None, next=False, prev=False):
+        if next:
+            step = Marker.next(self.current_step.value)
+        elif prev:
+            step = Marker.previous(self.current_step.value)
+
+        if hasattr(self, f"{step.name}_gate"):
+            return getattr(
+                self,
+                f"{step.name}_gate",
+            )().value
+
+        print(f"No gate exists for step {step.name}, allowing anyway.")
+        return True
+
+    def transition_to(self, step: Marker, force=False):
+        if self.can_transition(step) or force:
+            self.current_step.set(step)
+        else:
+            print(
+                f"Conditions not met to transition from "
+                f"{self.current_step.value.name} to {step.name}."
+            )
+
+    def transition_next(self):
+        next_marker = Marker.next(self.current_step.value)
+        self.transition_to(next_marker)
+
+    def transition_previous(self):
+        previous_marker = Marker.previous(self.current_step.value)
+        self.transition_to(previous_marker, force=True)
+    

--- a/src/hubbleds/pages/05-examining-data/guidelines/GuidelineBestFitLinec.vue
+++ b/src/hubbleds/pages/05-examining-data/guidelines/GuidelineBestFitLinec.vue
@@ -1,0 +1,25 @@
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Best Fit Line"
+    @back="back_callback()"
+    @next="next_callback()"
+    :can-advance="can_advance"
+  >
+    <template #before-next>
+      Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-chart-timeline-variant</v-icon></v-btn> to show best fit.
+    </template>
+
+    <div class="mb-4">
+      <p>
+        Now let's look at the best-fit line for your class's data and see how that compares with your trend line.
+      </p>
+      <p>
+        Click on <v-icon>mdi-chart-timeline-variant</v-icon> in the Toolbar to display the best fit line.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/pages/05-examining-data/guidelines/GuidelineClassData.vue
+++ b/src/hubbleds/pages/05-examining-data/guidelines/GuidelineClassData.vue
@@ -1,0 +1,23 @@
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Trend Lines"
+    @back="back_callback()"
+    @next="next_callback()"
+  >
+    <div
+      class="mb-4"
+    >
+      <p>
+        Now that you've drawn what conclusions you can from individual students' age measurements, let's turn back to your whole class's dataset, graphed here.
+      </p>
+      <p>
+        The same way you and your classmates each estimated an age for the universe using your 5 galaxies, you can fit a line to your whole class's dataset and estimate a new age using the {{ 5 * state_view.class_data_size }} galaxies you have measured all together.
+      </p>  
+    </div>
+  </scaffold-alert>
+</template>
+

--- a/src/hubbleds/pages/05-examining-data/guidelines/GuidelineFinishedClassmates.vue
+++ b/src/hubbleds/pages/05-examining-data/guidelines/GuidelineFinishedClassmates.vue
@@ -1,0 +1,14 @@
+<template>
+  <scaffold-alert
+    title-text="Finished Classmates"
+    @back="back_callback()"
+    @next="next_callback()"
+  >
+    <div
+    >
+      <p>
+        Note: "Your class" refers to you and the {{ state_view.class_data_size - 1 }} others who have completed their measurements (and might not represent your entire class). To avoid confusion, we will <strong>not</strong> add new measurements as they come in, so you may obtain different results from classmates who complete their measurements after you.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/pages/05-examining-data/guidelines/GuidelineRandomVariability.vue
+++ b/src/hubbleds/pages/05-examining-data/guidelines/GuidelineRandomVariability.vue
@@ -1,0 +1,15 @@
+<template>
+  <scaffold-alert
+    title-text="Random Variability"
+    @next="next_callback()"
+    :allow-back="false"
+  >
+    <div
+      class="mb-4"
+    >
+      <p>
+        Due to the shortcomings you just considered, your age estimate may or may not reflect the "true" age of the universe, especially since you have a small sample of only 5 galaxies. It might help to explore data from your class and others who have completed this Data Story.  
+      </p>
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/pages/05-examining-data/guidelines/GuidelineTrendLinesDraw2c.vue
+++ b/src/hubbleds/pages/05-examining-data/guidelines/GuidelineTrendLinesDraw2c.vue
@@ -1,0 +1,27 @@
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Trend Lines"
+    @back="back_callback()"
+    @next="next_callback()"
+    :can-advance="can_advance"
+  >
+    <template #before-next>
+      Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-message-draw</v-icon></v-btn> and draw a trend line.
+    </template>
+
+    <div
+      class="mb-4"
+    >
+      <p>
+        First, draw a trend line for your class's data set.
+      </p>
+      <p>
+        Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-message-draw</v-icon></v-btn> in the Toolbar to activate the drawing tool and try drawing a trend line through your class's data points.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>


### PR DESCRIPTION
This PR adds stage 5 to the Solara version of the Hubble story. This is very much still a draft - it only adds the first handful of guidelines and a viewer - but I wanted to submit this as a draft PR to share the method of setting up the glue viewers. What I had to do to get this to work (which I copied from `glue-solara`) is to set up the glue application and the viewers that we want inside of a `use_memo` call inside of the page setup. Without this, attempting to create a viewer was consistently giving me issues with widgets closing, as a viewer actually consists of several widgets together (e.g. the figure widget, the layer options widget, and the viewer options widget).