### PR TITLE
Add dotplot tutorial slideshow to stage 1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata
+    glue-plotly>=0.7.1
 
 
 [options.packages.find]

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
@@ -1,0 +1,237 @@
+<template>
+  <!-- add persistant to prevent closing by clicking out -->
+  <v-dialog
+      v-model="dialog"
+      max-width="1000px"
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        class="my-2"
+        block
+        color="secondary"
+        elevation="2"
+        id="slideshow-button"
+        @click.stop="() => { dialog = true; }"
+      >
+        Dot Plot Tutorial
+      </v-btn>
+    </template>
+    <v-card
+      class="mx-auto"
+      ref="content"
+    >
+      <v-toolbar
+        color="secondary"
+        dense
+        dark
+      >
+        <v-toolbar-title
+          class="text-h6 text-uppercase font-weight-regular"
+        >
+          Dot Plot Tutorial
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <speech-synthesizer
+          :root="() => this.$refs.content.$el"
+          :autospeak-on-change="step"
+          :speak-flag="dialog"
+          :selectors="['div.v-toolbar__title', 'div.v-card__text.black--text', 'h3', 'p']"
+          />
+        <v-btn
+          icon
+          @click="closeDialog()"
+        >
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+        <v-window
+          v-model="step"
+          class="overflow-auto"
+        >
+        <v-row>
+          <v-col
+            cols="12"
+            lg="5"
+            >
+            
+            <v-window-item :value="0" class="no-transition">
+              <v-card-text>
+                <v-container>
+                  <p>
+                    This <strong>dot plot</strong> displays&#8212;as a dot&#8212;every velocity measurement in our sample (excluding yours for now).
+                  </p>
+                  <p>
+                    Dots are stacked within velocity <strong>ranges</strong> called <strong>bins</strong>.
+                  </p>
+                  <p>
+                    The horizontal axis shows the measured velocity values.
+                  </p>
+                  <p>
+                    The vertical axis shows how many measurements were made in a particular velocity bin.
+                  </p>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
+
+            <v-window-item :value="1" class="no-transition">
+              <v-card-text>
+                <v-container>
+                  <p>
+                    As with the spectrum viewer, if you move your mouse left and right within the dot plot, the vertical marker will display the velocity value for the center of each bin.
+                  </p>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
+
+            <v-window-item :value="2" class="no-transition">
+              <v-card-text>
+                <v-container>
+                  <p>
+                    Our data sample includes a very large range of velocity values, but most of the data points are clustered in one or more tall towers of dots between 9,000 to 13,000 km/s. 
+                  </p>
+                  <p>
+                    Let's take a closer look at this cluster of measurements. 
+                  </p>
+                  <p>
+                    Click <v-icon>mdi-select-search</v-icon> in the toolbar to activate the zoom tool.
+                  </p>                    
+                  <p>
+                    Then click and drag across the cluster of velocity measurements to zoom in.
+                  </p>
+                </v-container>
+              </v-card-text>
+            </v-window-item>
+
+            <v-window-item :value="3" class="no-transition">
+              <v-card-text>
+                <v-container>
+                  <p>
+                    You should see that the tall towers of dots have split into smaller towers. If not, zoom in closer by clicking and dragging again, or click <v-icon>mdi-cached</v-icon> to reset the view and try again.
+                  </p>
+                  <p>
+                    This happens because each tower of dots represents a <strong>range</strong> of velocity values. When you zoomed in, the data were rebinned across smaller velocity ranges.
+                  </p>
+                  <p>
+                    That's all you need to know about dot plots for now. Click done to continue.  
+                  </p>                      
+                </v-container>
+              </v-card-text>
+            </v-window-item>  
+          </v-col>
+          <v-col
+            cols="12"
+            lg="7"
+          >
+           <jupyter-widget :widget="dotplot_viewer"/>
+          </v-col>
+        </v-row>
+      </v-window>
+      
+      <v-divider></v-divider>
+
+      <v-card-actions
+        class="justify-space-between"
+      >
+        <v-btn
+          :disabled="step === 0"
+          class="black--text"
+          color="accent"
+          depressed
+          @click="step--"
+        >
+          Back
+        </v-btn>
+        <v-spacer></v-spacer>
+        <v-item-group
+          v-model="step"
+          class="text-center"
+          mandatory
+        >
+          <v-item
+            v-for="n in length"
+            :key="`btn-${n}`"
+            v-slot="{ active, toggle }"
+          >
+            <v-btn
+              :input-value="active"
+              icon
+              @click="toggle"
+            >
+              <v-icon>mdi-record</v-icon>
+            </v-btn>
+          </v-item>
+        </v-item-group>
+        <v-spacer></v-spacer>
+          <v-btn
+          v-if="step < length-1"
+          color="accent"
+          class="black--text"
+          depressed
+          @click="() => { step++; }"
+        >
+          {{ step < length-1 ? 'next' : '' }}
+        </v-btn>
+        <v-btn
+          v-if = "step == length-1"
+          color="accent"
+          class="black--text"
+          depressed
+          @click="() => { $emit('close'); dialog = false; step = 0; finished = true }"
+        >
+          Done
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  
+  watch: {
+    step(newStep) {
+      this.maxStepCompleted = newStep;
+
+      if (newStep == 1) {
+        this.activateMeasuringTool();
+      }
+
+      if (newStep == 2) {
+        this.activate_zoom_tool();
+        this.home_add_line();
+      }
+
+      if (newStep == 3) {
+        this.activate_selector();
+        this.home_add_previous_line()
+      }
+    },
+  },
+
+  methods: {
+    closeDialog() {
+        this.$emit('close');
+        this.dialog = false;
+        if (this.step == this.length - 1) {
+          this.step = 0;
+      }
+    }
+  }
+
+  
+};
+
+</script>
+
+<style scoped>
+.no-transition {
+  transition: none;
+}
+
+.row {
+  width: 100%;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+</style>

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
@@ -177,7 +177,7 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { $emit('close'); dialog = false; step = 0; finished = true }"
+          @click="() => { $emit('close'); dialog = false }"
         >
           Done
         </v-btn>
@@ -185,44 +185,6 @@
     </v-card>
   </v-dialog>
 </template>
-
-<script>
-export default {
-  
-  watch: {
-    step(newStep) {
-      this.maxStepCompleted = newStep;
-
-      if (newStep == 1) {
-        this.activateMeasuringTool();
-      }
-
-      if (newStep == 2) {
-        this.activate_zoom_tool();
-        this.home_add_line();
-      }
-
-      if (newStep == 3) {
-        this.activate_selector();
-        this.home_add_previous_line()
-      }
-    },
-  },
-
-  methods: {
-    closeDialog() {
-        this.$emit('close');
-        this.dialog = false;
-        if (this.step == this.length - 1) {
-          this.step = 0;
-      }
-    }
-  }
-
-  
-};
-
-</script>
 
 <style scoped>
 .no-transition {

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/__init__.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/__init__.py
@@ -1,0 +1,1 @@
+from .dotplot_tutorial_slideshow import DotplotTutorialSlideshow

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -1,0 +1,12 @@
+from solara import component_vue
+
+
+@component_vue("DotplotTutorialSlideshow.vue")
+def DotplotTutorialSlideshow(
+    dialog,
+    step,
+    length,
+    max_step_completed,
+    dotplot_viewer,
+):
+    pass

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -1,5 +1,4 @@
 from solara import Reactive
-import solara
 import enum
 from ...utils import HUBBLE_ROUTE_PATH
 from ...decorators import computed_property
@@ -95,6 +94,14 @@ class DopplerCalculation:
 
 
 @dataclasses.dataclass
+class DotPlotTutorialState:
+    step: Reactive[int] = dataclasses.field(default=Reactive(0))
+    length: Reactive[int] = dataclasses.field(default=Reactive(4))
+    max_step_completed: Reactive[int] = dataclasses.field(default=Reactive(0))
+    current_title: Reactive[str] = dataclasses.field(default=Reactive(""))
+
+
+@dataclasses.dataclass
 class ComponentState:
     current_step: Reactive[Marker] = dataclasses.field(
         default=Reactive(Marker.mee_gui1)
@@ -118,6 +125,10 @@ class ComponentState:
         default_factory=DopplerCalculation
     )
     student_vel: Reactive[float] = dataclasses.field(default=Reactive(0))
+    dotplot_tutorial_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
+    dotplot_tutorial_state: DotPlotTutorialState = dataclasses.field(
+        default_factory=DotPlotTutorialState
+    )
     dotplot_tutorial_finished: Reactive[bool] = dataclasses.field(default=Reactive(False))
 
     def __post_init__(self):

--- a/src/hubbleds/viewers/__init__.py
+++ b/src/hubbleds/viewers/__init__.py
@@ -1,0 +1,1 @@
+from .hubble_dotplot import *

--- a/src/hubbleds/viewers/hubble_dotplot.py
+++ b/src/hubbleds/viewers/hubble_dotplot.py
@@ -1,0 +1,22 @@
+from cosmicds.viewers import PlotlyDotPlotView, cds_viewer
+from .tools import WavelengthZoom  # noqa
+
+__all__ = ["HubbleDotPlotView"]
+
+
+class HubbleDotPlotViewer(PlotlyDotPlotView):
+
+    @staticmethod
+    def _label_text(value):
+        return f"{value:0.f} km/s"
+
+    
+HubbleDotPlotView = cds_viewer(
+    HubbleDotPlotViewer,
+    name="HubbleDotPlotView",
+    viewer_tools=[
+        "plotly:home",
+        "hubble:wavezoom"
+    ],
+    label="Dot Plot",
+)

--- a/src/hubbleds/viewers/tools/__init__.py
+++ b/src/hubbleds/viewers/tools/__init__.py
@@ -1,0 +1,1 @@
+from .wavelength_zoom import WavelengthZoom

--- a/src/hubbleds/viewers/tools/wavelength_zoom.py
+++ b/src/hubbleds/viewers/tools/wavelength_zoom.py
@@ -1,0 +1,24 @@
+from echo import CallbackProperty
+from glue.config import viewer_tool
+from glue_plotly.viewers import PlotlyHZoomMode
+
+
+@viewer_tool
+class WavelengthZoom(PlotlyHZoomMode):
+    icon = "glue_zoom_to_rect"
+    mdi_icon = "mdi-select-search"
+    tool_id = "hubble:wavezoom"
+    action_text = "x axis zoom"
+    tool_tip = "Zoom in on a region of the x-axis"
+    zoom_tool_activated = CallbackProperty(False)
+
+    on_zoom = None
+
+    def _on_selection(self, _trace, _points, selector):
+        state = self.viewer.state
+        xbounds_old = [state.x_min, state.x_max]
+        super()._on_selection(_trace, _points, selector)
+        if self.on_zoom is not None:
+            xbounds_new = [state.x_min, state.x_max]
+            self.on_zoom(xbounds_old, xbounds_new)
+


### PR DESCRIPTION
This PR adds the dotplot tutorial slideshow to stage 1. This adds the dotplot viewer, but I haven't yet wired up the hoverover line in the viewer and the various line showing/hiding that takes place - I'll take care of that in a future PR.

This depends on https://github.com/cosmicds/cosmicds/pull/277, as it pulls in the `ViewerLayout` component that I've added there. It also depends on the newest version of `glue-plotly` for the dotplot layer artist, and so I've added that to the dependencies in `setup.cfg`.