### PR TITLE
Hot reloading fix

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -153,7 +153,7 @@ class ComponentState:
         self.selected_example_galaxy.subscribe(_on_example_galaxy_selected)
 
     def is_current_step(self, step: Marker):
-        return self.current_step.value == step
+        return self.current_step.value.value == step.value
 
     def can_transition(self, step: Marker = None, next=False, prev=False):
         if next:

--- a/src/hubbleds/viewers/tools/wavelength_zoom.py
+++ b/src/hubbleds/viewers/tools/wavelength_zoom.py
@@ -22,3 +22,8 @@ class WavelengthZoom(PlotlyHZoomMode):
             xbounds_new = [state.x_min, state.x_max]
             self.on_zoom(xbounds_old, xbounds_new)
 
+
+try:
+    viewer_tool(WavelengthZoom)
+except ValueError as e:
+    print("Wavelength Zoom already registered.")


### PR DESCRIPTION
This PR does two things

1. Prevents the error on the glue tool import when hot reloading.
2. Allows for properly equivalence checks for state markers.

Note that for other stages you'll need to update the `is_current_marker` method of the component state implemented for that stage.