### PR TITLE
Remove decorator in lieu of function call

### DIFF
--- a/src/hubbleds/viewers/tools/wavelength_zoom.py
+++ b/src/hubbleds/viewers/tools/wavelength_zoom.py
@@ -3,7 +3,6 @@ from glue.config import viewer_tool
 from glue_plotly.viewers import PlotlyHZoomMode
 
 
-@viewer_tool
 class WavelengthZoom(PlotlyHZoomMode):
     icon = "glue_zoom_to_rect"
     mdi_icon = "mdi-select-search"


### PR DESCRIPTION
Follow up to #369: I forgot to remove the decorator.