### PR TITLE
Modify guidelines to use method in MathJax intersection observers

### DIFF
--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -42,11 +42,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-              if (!intersecting) return;
-              const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-              MathJax.typesetPromise(targets);
-            }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <p>
@@ -156,11 +152,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-                if (!intersecting) return;
-                const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-                MathJax.typesetPromise(targets);
-              }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <v-card
@@ -273,11 +265,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-              if (!intersecting) return;
-              const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-              MathJax.typesetPromise(targets);
-            }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <v-card
@@ -393,11 +381,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-              if (!intersecting) return;
-              const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-              MathJax.typesetPromise(targets);
-            }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <v-card
@@ -520,11 +504,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-              if (!intersecting) return;
-              const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-              MathJax.typesetPromise(targets);
-            }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <p>
@@ -605,11 +585,7 @@
                 </v-row>
                 <v-row
                     v-if="failed_validation_5"
-                    v-intersect="(entries, _observer, intersecting) => {
-                    if (!intersecting) return;
-                    const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-                    MathJax.typesetPromise(targets);
-                  }"
+                    v-intersect="typesetMathJax"
                     class="my-1 yellow--text font-weight-bold"
                     no-gutters
                 >
@@ -663,11 +639,7 @@
                        class="no-transition"
         >
           <v-card-text
-              v-intersect="(entries, _observer, intersecting) => {
-              if (!intersecting) return;
-              const targets = entries.filter(entry => entry.isIntersecting).map(entry => entry.target);
-              MathJax.typesetPromise(targets);
-            }"
+              v-intersect="typesetMathJax"
               class="pt-8"
           >
             <v-card
@@ -907,6 +879,12 @@ mjx-mpadded {
 <script>
 module.exports = {
   methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
+    },
+
     getValue(inputID) {
       const input = document.getElementById(inputID);
       if (!input) {
@@ -937,9 +915,6 @@ module.exports = {
     }
   },
   computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    },
     // step() {
     //   return this.step_proxy;
     // }

--- a/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/stage_2_slideshow.vue
@@ -333,7 +333,7 @@
                     class="mt-auto white--text"
                     flat
                     color="info"
-                    v-intersect = "(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                    v-intersect = "typesetMathJax"
                   >
                     <v-card-text>
                       <div
@@ -393,7 +393,7 @@
                       color="info"
                     >
                       <v-card-text 
-                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                        v-intersect="typesetMathJax"
                       >
                         <div
                           class="JaxEquation"
@@ -477,7 +477,7 @@
                       color="info"
                     >
                       <v-card-text
-                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                        v-intersect="typesetMathJax"
                       >
                         <div
                           class="JaxEquation"
@@ -527,7 +527,7 @@
                       color="info"
                     >
                       <v-card-text
-                        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                        v-intersect="typesetMathJax"
                       >
                         <div
                           class="JaxEquation"
@@ -585,7 +585,7 @@
         class="no-transition"
       >
         <v-card-text
-          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+          v-intersect="typesetMathJax"
         >
           <v-container>
             <v-row>
@@ -615,7 +615,7 @@
                     color="info"
                   >
                     <v-card-text
-                      v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                      v-intersect="typesetMathJax"
                     >
                       <div
                         class="JaxEquation"
@@ -636,7 +636,7 @@
         class="no-transition"
       >
         <v-card-text
-          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+          v-intersect="typesetMathJax"
         >
           <v-container>
             <v-row>
@@ -654,7 +654,7 @@
                   color="info"
                 >
                   <v-card-text
-                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                    v-intersect="typesetMathJax"
                   >
                     <div
                       class="JaxEquation"
@@ -689,7 +689,7 @@
                   color="info"
                 >
                   <v-card-text
-                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                    v-intersect="typesetMathJax"
                   >
                     <div
                       class="JaxEquation"
@@ -712,7 +712,7 @@
         class="no-transition"
       >
         <v-card-text
-          v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+          v-intersect="typesetMathJax"
         >
           <v-container>
             <v-row>
@@ -740,7 +740,7 @@
                   color="info"
                 >
                   <v-card-text
-                    v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+                    v-intersect="typesetMathJax"
                   >
                     <div
                       class="JaxEquation"
@@ -860,16 +860,17 @@
 module.exports = {
   props: ["buttonText", "titleText", "closeText"],
 
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    },
-  },
-
   mounted() {
     console.log("Two Intro");
     console.log(this);
     console.log(this.$el);
+  },
+
+  methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
   },
 
   watch: {

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc2.vue
@@ -17,7 +17,7 @@
         color="info"
       >
         <v-container
-            v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+            v-intersect="typesetMathJax"
         >
           <v-row
             no-gutters
@@ -118,10 +118,12 @@
 
 <script>
 module.exports = {
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
+  methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
     }
-  },
+  }
 }
 </script>

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
@@ -15,7 +15,7 @@
       }"
   >
     <div
-        v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+        v-intersect="typesetMathJax"
         class="mb-4"
     >
       <p>
@@ -160,17 +160,18 @@ mjx-mstyle {
 
 <script>
 module.exports = {
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    }
-  },
   data: () => ({
     state_view: {
       failed_validation_4: false
     }
   }),
   methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
+    },
+
     getValue(inputID) {
       const input = document.getElementById(inputID);
       if (!input) {

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance2.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance2.vue
@@ -7,7 +7,7 @@
   >
     <div
       class="mb-4"
-      v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+      v-intersect="typesetMathJax"
     >
       <p>
         Recall, if we assume a galaxy is the <strong>same size as our Milky Way galaxy</strong>, the distance to the galaxy can be found using:
@@ -71,13 +71,14 @@
 
 <script>
 module.exports = {
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    },    
+  methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
+    }
   }
 }
-
 </script>
 
 <style>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance3.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance3.vue
@@ -15,7 +15,7 @@
   >
     <div
       class="mb-4"
-      v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+      v-intersect="typesetMathJax"
     >
       <v-card color="error" class="mb-4">
         <v-card-text>
@@ -110,13 +110,13 @@ module.exports = {
     }
   },
 
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    },    
-  },
-
   methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
+    },
+
     getValue(inputID) {
       const input = document.getElementById(inputID);
       if (!input) { return null; }

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance4.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance4.vue
@@ -11,7 +11,7 @@
   >
     <div
       class="mb-4"
-      v-intersect="(entries, _observer, intersecting) => { if (intersecting) { MathJax.typesetPromise(entries.map(entry => entry.target)) }}"
+      v-intersect="typesetMathJax"
     >
       <p class="mb-4">
         You entered:
@@ -86,11 +86,13 @@
 
 <script>
 module.exports = {
-  computed: {
-    MathJax() {
-      return document.defaultView.MathJax
-    },    
-  },
+  methods: {
+    typesetMathJax(entries, _observer, intersecting) {
+      if (intersecting) {
+        MathJax.typesetPromise(entries.map(entry => entry.target));
+      }
+    }
+  }
 }
 </script>
 


### PR DESCRIPTION
@nmearl and I discussed this and decided that using a method was clearer than making the window-level `MathJax` object be a computed value. This PR updates existing guidelines to use that method for consistency.