### PR TITLE
Put common marker functionality into base class

### DIFF
--- a/src/hubbleds/marker_base.py
+++ b/src/hubbleds/marker_base.py
@@ -1,0 +1,20 @@
+from enum import EnumMeta
+
+
+class MarkerBase(metaclass=EnumMeta):
+
+    @classmethod
+    def next(cls, step):
+        return cls(step.value + 1)
+
+    @classmethod
+    def previous(cls, step):
+        return cls(step.value - 1)
+
+    @classmethod
+    def first(cls):
+        return cls(1)
+
+    @classmethod
+    def last(cls):
+        return cls(len(cls))

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -1,5 +1,6 @@
 from solara import Reactive
 import enum
+from ...marker_base import MarkerBase
 from ...utils import HUBBLE_ROUTE_PATH
 from ...decorators import computed_property
 import dataclasses
@@ -17,7 +18,7 @@ ELEMENT_REST = {
 }
 
 
-class Marker(enum.Enum):
+class Marker(enum.Enum, MarkerBase):
     mee_gui1 = enum.auto()
     sel_gal1 = enum.auto()
     sel_gal2 = enum.auto()
@@ -54,14 +55,6 @@ class Marker(enum.Enum):
     ref_vel1 = enum.auto()
     end_sta1 = enum.auto()
     NA3 = enum.auto()
-
-    @staticmethod
-    def next(step):
-        return Marker(step.value + 1)
-
-    @staticmethod
-    def previous(step):
-        return Marker(step.value - 1)
 
 
 @dataclasses.dataclass

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -2,6 +2,7 @@ from solara import Reactive
 import solara
 import enum
 from ...decorators import computed_property
+from ...marker_base import MarkerBase
 import dataclasses
 from cosmicds.utils import API_URL
 from ...state import GLOBAL_STATE
@@ -17,7 +18,7 @@ ELEMENT_REST = {
 }
 
 
-class Marker(enum.Enum):
+class Marker(enum.Enum, MarkerBase):
     ang_siz1 = enum.auto()	
     cho_row1 = enum.auto()	
     ang_siz2 = enum.auto()	
@@ -46,22 +47,6 @@ class Marker(enum.Enum):
     rep_rem1 = enum.auto()	
     fil_rem1 = enum.auto()
 
-    @staticmethod
-    def next(step):
-        return Marker(step.value + 1)
-
-    @staticmethod
-    def previous(step):
-        return Marker(step.value - 1)
-    
-    @staticmethod
-    def first():
-        return Marker(1)
-    
-    @staticmethod
-    def last():
-        return Marker(len(Marker))
-
 
 @dataclasses.dataclass
 class ComponentState:
@@ -78,7 +63,7 @@ class ComponentState:
     def is_current_step(self, step: Marker):
         return self.current_step.value == step
 
-    def can_transition(self, step: Marker = None, next=False, prev=False):
+    def can_transition(self, step: Marker=None, next=False, prev=False):
         if next:
             if self.current_step.value is Marker.last():
                 return False  # FIX once we sort out transitions between stages

--- a/src/hubbleds/pages/04-explore-data/component_state.py
+++ b/src/hubbleds/pages/04-explore-data/component_state.py
@@ -1,6 +1,7 @@
 from solara import Reactive
 import solara
 import enum
+from ...marker_base import MarkerBase
 from ...decorators import computed_property
 import dataclasses
 from cosmicds.utils import API_URL
@@ -17,7 +18,7 @@ ELEMENT_REST = {
 }
 
 
-class Marker(enum.Enum):
+class Marker(enum.Enum, MarkerBase):
     exp_dat1 = enum.auto()
     tre_dat1 = enum.auto()
     tre_dat2 = enum.auto()
@@ -37,21 +38,6 @@ class Marker(enum.Enum):
     sho_est1 = enum.auto()
     sho_est2 = enum.auto()
 
-    @staticmethod
-    def next(step):
-        return Marker(step.value + 1)
-
-    @staticmethod
-    def previous(step):
-        return Marker(step.value - 1)
-
-    @staticmethod
-    def first():
-        return Marker(1)
-    
-    @staticmethod
-    def last():
-        return Marker(len(Marker))
 
 @dataclasses.dataclass
 class HubbleSlideshowState:

--- a/src/hubbleds/pages/05-examining-data/component_state.py
+++ b/src/hubbleds/pages/05-examining-data/component_state.py
@@ -4,10 +4,11 @@ from solara import Reactive
 import enum
 
 from hubbleds.state import LOCAL_STATE
+from hubbleds.marker_base import MarkerBase
 
 __all__ = ["Marker", "ComponentState"]
 
-class Marker(enum.Enum):
+class Marker(enum.Enum, MarkerBase):
     ran_var1 = enum.auto()
     fin_cla1 = enum.auto()
     cla_res1 = enum.auto()
@@ -41,14 +42,6 @@ class Marker(enum.Enum):
     two_his3a = enum.auto()
     two_his5 = enum.auto()
     mor_dat1 = enum.auto()
-
-    @staticmethod
-    def next(step):
-        return Marker(step.value + 1)
-    
-    @staticmethod
-    def previous(step):
-        return Marker(step.value - 1)
 
 
 @dataclasses.dataclass

--- a/src/hubbleds/pages/06-prodata/component_state.py
+++ b/src/hubbleds/pages/06-prodata/component_state.py
@@ -5,13 +5,14 @@ from ...utils import HUBBLE_ROUTE_PATH, HST_KEY_AGE
 from ...data_management import HUBBLE_1929_DATA_LABEL, HUBBLE_KEY_DATA_LABEL
 
 from ...decorators import computed_property
+from ...marker_base import MarkerBase
 import dataclasses
 from cosmicds.utils import API_URL
 from ...state import GLOBAL_STATE
 from ...data_models.student import StudentMeasurement
 from contextlib import closing
 
-class Marker(enum.Enum):
+class Marker(enum.Enum, MarkerBase):
     pro_dat0 = enum.auto()
     pro_dat1 = enum.auto()
     pro_dat2 = enum.auto()
@@ -26,13 +27,6 @@ class Marker(enum.Enum):
     sto_fin2 = enum.auto()
     sto_fin3 = enum.auto()
     
-    @staticmethod
-    def next(step):
-        return Marker(step.value + 1)
-    
-    @staticmethod
-    def previous(step):
-        return Marker(step.value - 1)
     
 @dataclasses.dataclass
 class ComponentState:


### PR DESCRIPTION
Currently there's a lot of boilerplate functionality for our marker types that's re-implemented in each stage's component state. This PR refactors these methods into a base class that stage marker classes can then inherit to get this functionality for free, and sets up the existing marker classes to do just that.