### PR TITLE
Fix issue with slider data reference

### DIFF
--- a/src/hubbleds/pages/05-examining-data/__init__.py
+++ b/src/hubbleds/pages/05-examining-data/__init__.py
@@ -27,7 +27,7 @@ def Page():
 
     def glue_setup():
         gjapp = JupyterApplication(GLOBAL_STATE.data_collection, GLOBAL_STATE.session)
-        test_data = Data(x=[1,2,3,4,5], y=[1,4,9,16,25])
+        test_data = Data(x=[1,2,3,4,5], y=[1,4,9,16,25], label="Stage 5 Test Data")
         test_data.style.color = "green"
         test_data.style.alpha = 0.5
     
@@ -289,7 +289,7 @@ def Page():
         with rv.Col(cols=8):
             if test.value:
                 ViewerLayout(viewer=gjapp.viewers[0])
-                test_data = gjapp.data_collection[0]
+                test_data = gjapp.data_collection["Stage 5 Test Data"]
                 IdSlider(gjapp=gjapp,
                          data=test_data,
                          on_id=update_test_subset,

--- a/src/hubbleds/pages/05-examining-data/component_state.py
+++ b/src/hubbleds/pages/05-examining-data/component_state.py
@@ -106,7 +106,6 @@ class ComponentState:
     age_calc_state: AgeCalcState = dataclasses.field(default_factory=AgeCalcState)
 
     def is_current_step(self, step: Marker):
-        print(step, self.current_step.value == step)
         return self.current_step.value == step
 
     def can_transition(self, step: Marker=None, next=False, prev=False):


### PR DESCRIPTION
This PR fixes a small issue with the slider data. While setting up the slider I grabbed the relevant data by index rather than label. This worked fine at the time but is no longer valid since we've now added other data to the data collection. This PR updates the slider setup to reference the data by label, which solves this issue.