### PR TITLE
Add distance measuring tool

### DIFF
--- a/src/hubbleds/data_models/student.py
+++ b/src/hubbleds/data_models/student.py
@@ -21,6 +21,9 @@ class StudentMeasurement(BaseModel):
     measured_wave: Optional[float] = 0.0
     velocity: Optional[float] = 0.0
     spectrum: Optional[SpectrumData] = None
+    theta: Optional[float] = 0.0
+    distance: Optional[float] = 0.0
+    measurement_number: Optional[int] = 0
 
 
 class StudentData(BaseModel):

--- a/src/hubbleds/data_models/student.py
+++ b/src/hubbleds/data_models/student.py
@@ -21,7 +21,7 @@ class StudentMeasurement(BaseModel):
     measured_wave: Optional[float] = 0.0
     velocity: Optional[float] = 0.0
     spectrum: Optional[SpectrumData] = None
-    theta: Optional[float] = 0.0
+    angular_size: Optional[float] = 0.0
     distance: Optional[float] = 0.0
     measurement_number: Optional[int] = 0
 

--- a/src/hubbleds/data_models/student.py
+++ b/src/hubbleds/data_models/student.py
@@ -21,7 +21,7 @@ class StudentMeasurement(BaseModel):
     measured_wave: Optional[float] = 0.0
     velocity: Optional[float] = 0.0
     spectrum: Optional[SpectrumData] = None
-    angular_size: Optional[float] = 0.0
+    angular_size: Optional[int] = 0
     distance: Optional[float] = 0.0
     measurement_number: Optional[int] = 0
 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -1,8 +1,6 @@
-import dataclasses
 from random import randint
 
 import numpy as np
-import pandas as pd
 import solara
 from cosmicds.widgets.table import Table
 from cosmicds.components import ScaffoldAlert, ViewerLayout

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -263,22 +263,32 @@ def Page():
                     { "text": "Distance (Mpc)", "value": "distance" },
                 ]
             if component_state.current_step.value.value < Marker.rep_rem1.value:
+                def update_example_galaxy(galaxy):
+                    flag = galaxy.get("value", True)
+                    value = galaxy["item"] if flag else None
+                    component_state.selected_example_galaxy.set(value)
+
                 DistanceToolComponent(component_state.selected_example_galaxy, example_data)
                 DataTable(
                     title="Example Galaxy",
                     headers=common_headers + [{ "text": "Measurement Number", "value": "measurement_number" }],
                     items=example_data.dict(exclude={'measurements': {'__all__': 'spectrum'}})["measurements"],
                     highlighted=False,  # TODO: Set the markers for this,
-                    event_on_row_selected=lambda galaxy: component_state.selected_example_galaxy.set(galaxy["item"])
+                    event_on_row_selected=update_example_galaxy
                 )
             else:
+                def update_galaxy(galaxy):
+                    flag = galaxy.get("value", True)
+                    value = galaxy["item"] if flag else None
+                    component_state.selected_galaxy.set(value)
+
                 DistanceToolComponent(component_state.selected_galaxy, student_data)
                 DataTable(
                     title="My Galaxies",
                     headers=common_headers,
                     items=student_data.dict(exclude={'measurements': {'__all__': 'spectrum'}})["measurements"],
                     highlighted=False,  # TODO: Set the markers for this,
-                    event_on_row_selected=lambda galaxy: component_state.selected_galaxy.set(galaxy["item"])
+                    event_on_row_selected=update_galaxy
                 )
 
     with solara.ColumnsResponsive(12, large=[4,8]):

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -3,7 +3,7 @@ from cosmicds.widgets.table import Table
 from cosmicds.components import ScaffoldAlert, StateEditor
 from cosmicds import load_custom_vue_components
 from glue_jupyter.app import JupyterApplication
-from reacton import ipyvuetify as rv
+from reacton import component, ipyvuetify as rv
 from pathlib import Path
 
 from hubbleds.widgets.distance_tool.distance_tool import DistanceTool
@@ -24,7 +24,7 @@ component_state = ComponentState()
 
 
 @solara.component
-def DistanceToolComponent(galaxy):
+def DistanceToolComponent(galaxy, data):
     tool = DistanceTool.element()
 
     def set_selected_galaxy():
@@ -36,7 +36,10 @@ def DistanceToolComponent(galaxy):
 
     def _define_callbacks():
         widget = solara.get_widget(tool)
-        widget.angular_height.observe(
+        widget.observe(
+            lambda size: data.update(galaxy.id, {"angular_size": size}),
+            ["angular_size"]
+        )
 
     solara.use_effect(_define_callbacks, [])
 
@@ -256,11 +259,11 @@ def Page():
                         "sortable": False,
                         "value": "name"
                     },
-                    { "text": "&theta; (arcsec)", "value": "theta" },
+                    { "text": "&theta; (arcsec)", "value": "angular_size" },
                     { "text": "Distance (Mpc)", "value": "distance" },
                 ]
             if component_state.current_step.value.value < Marker.rep_rem1.value:
-                DistanceToolComponent(component_state.selected_example_galaxy)
+                DistanceToolComponent(component_state.selected_example_galaxy, example_data)
                 DataTable(
                     title="Example Galaxy",
                     headers=common_headers + [{ "text": "Measurement Number", "value": "measurement_number" }],
@@ -269,7 +272,7 @@ def Page():
                     event_on_row_selected=lambda galaxy: component_state.selected_example_galaxy.set(galaxy["item"])
                 )
             else:
-                DistanceToolComponent(component_state.selected_galaxy)
+                DistanceToolComponent(component_state.selected_galaxy, student_data)
                 DataTable(
                     title="My Galaxies",
                     headers=common_headers,

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -44,9 +44,12 @@ class Marker(enum.Enum, MarkerBase):
 
 @dataclasses.dataclass
 class ComponentState(BaseComponentState):
+
     current_step: Reactive[Marker] = dataclasses.field(
         default=Reactive(Marker.ang_siz1)
     )
+    example_angular_sizes_total: Reactive[int] = dataclasses.field(default=Reactive(0))
+    angular_sizes_total: Reactive[int] = dataclasses.field(default=Reactive(0))
     dosdonts_tutorial_opened: Reactive[bool] = dataclasses.field(
         default=Reactive(False)
     )

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -1,16 +1,9 @@
 from solara import Reactive
-import solara
 import enum
 from ...decorators import computed_property
 from ...marker_base import MarkerBase
 import dataclasses
-from cosmicds.utils import API_URL
 from ...component_state_base import BaseComponentState
-from ...state import GLOBAL_STATE
-from ...data_models.student import example_data, StudentMeasurement, SpectrumData
-from contextlib import closing
-from io import BytesIO
-from astropy.io import fits
 
 
 ELEMENT_REST = {
@@ -57,6 +50,8 @@ class ComponentState(BaseComponentState):
     dosdonts_tutorial_opened: Reactive[bool] = dataclasses.field(
         default=Reactive(False)
     )
+    selected_galaxy: Reactive[dict] = dataclasses.field(default=Reactive({}))
+    selected_example_galaxy: Reactive[dict] = dataclasses.field(default=Reactive({}))
 
     def setup(self):
         pass

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -52,6 +52,7 @@ class ComponentState(BaseComponentState):
     )
     selected_galaxy: Reactive[dict] = dataclasses.field(default=Reactive({}))
     selected_example_galaxy: Reactive[dict] = dataclasses.field(default=Reactive({}))
+    show_ruler: Reactive[bool] = dataclasses.field(default=Reactive(False))
 
     def setup(self):
         pass

--- a/src/hubbleds/widgets/distance_tool/__init__.py
+++ b/src/hubbleds/widgets/distance_tool/__init__.py
@@ -1,0 +1,1 @@
+from .distance_tool import DistanceTool

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -27,7 +27,7 @@ class DistanceTool(v.VueTemplate):
     width = Int().tag(sync=True)
     view_changing = Bool(False).tag(sync=True)
     measuring_allowed = Bool(False).tag(sync=True)
-    show_ruler = Bool(True).tag(sync=True)
+    show_ruler = Bool(False).tag(sync=True)
     fov_text = Unicode().tag(sync=True)
     flagged = Bool(False).tag(sync=True)
     ruler_click_count = Int().tag(sync=True)

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -1,0 +1,174 @@
+from datetime import datetime
+
+import astropy.units as u
+import ipyvue as v
+from astropy.coordinates import Angle, SkyCoord
+from cosmicds.utils import RepeatedTimer, load_template
+from ipywidgets import DOMWidget, widget_serialization
+from ipywwt import WWTWidget
+from traitlets import Instance, Bool, Float, Int, Unicode, observe, Dict
+
+from ...utils import GALAXY_FOV, angle_to_json, \
+    angle_from_json
+
+
+class DistanceTool(v.VueTemplate):
+    template = load_template("distance_tool.vue", __file__, traitlet=True).tag(
+        sync=True)
+    widget = Instance(DOMWidget, allow_none=True).tag(sync=True,
+                                                      **widget_serialization)
+    measuring = Bool().tag(sync=True)
+    measuredDistance = Float().tag(sync=True)
+    angular_size = Instance(Angle).tag(sync=True, to_json=angle_to_json,
+                                       from_json=angle_from_json)
+    angular_height = Instance(Angle).tag(sync=True, to_json=angle_to_json,
+                                         from_json=angle_from_json)
+    height = Int().tag(sync=True)
+    width = Int().tag(sync=True)
+    view_changing = Bool(False).tag(sync=True)
+    measuring_allowed = Bool(False).tag(sync=True)
+    show_ruler = Bool(False).tag(sync=True)
+    fov_text = Unicode().tag(sync=True)
+    flagged = Bool(False).tag(sync=True)
+    ruler_click_count = Int().tag(sync=True)
+    measurement_count = Int().tag(sync=True)
+    galaxy_selected = Bool(False).tag(sync=True)
+    _ra = Angle(0 * u.deg)
+    _dec = Angle(0 * u.deg)
+    wwtStyle = Dict().tag(sync=True)
+    reset_style = Bool(False).tag(sync=True)
+    
+    # Guard
+    guard = Bool(False).tag(sync=True)
+    galaxy_max_size = Angle("60 arcmin") # 2 x Pinwheel galaxy (d = 7 Mpc, r = 1.7 Rmw)
+    galaxy_min_size = Angle("6 arcsec") # 3 x sdss resolution
+    bad_measurement = Bool(False).tag(sync=True)
+
+    UPDATE_TIME = 1  # seconds
+    START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame='icrs')
+
+    def __init__(self, *args, **kwargs):
+        self.widget = WWTWidget()
+        self._setup_widget()
+        self.measuring = kwargs.get('measuring', False)
+        self.guard = kwargs.get('guard', False)
+        self.angular_size = Angle(0, u.deg)
+        self.angular_height = Angle(60, u.deg)
+        self.widget._set_message_type_callback('wwt_view_state',
+                                               self._handle_view_message)
+        self.last_update = datetime.now()
+        self._rt = RepeatedTimer(self.UPDATE_TIME, self._check_view_changing)
+        self.update_text()
+        super().__init__(*args, **kwargs)
+
+    def _setup_widget(self):
+        # Temp update to set background to SDSS. Once we remove galaxies without SDSS WWT tiles from the catalog, make background DSS again, and set wwt.foreground_opacity = 0, per Peter Williams.
+        self.widget.background = 'SDSS: Sloan Digital Sky Survey (Optical)'
+        self.widget.foreground = 'SDSS: Sloan Digital Sky Survey (Optical)'
+        self.widget.center_on_coordinates(self.START_COORDINATES, fov= 42 * u.arcmin, #start in close enough to see galaxies
+                                          instant=True)
+
+    def reset_canvas(self):
+        self.send({"method": "reset", "args": []})
+
+    def update_text(self):
+        self.send({"method": "update_text", "args": []})
+
+    def _height_from_pixel_str(self, s):
+        return int(s[:-2])  # Remove the 'px' from the end
+
+    # We aren't always guaranteed to get an update from the WWT viewer
+    # so every second, if the view is marked as changing, 
+    # we check when the last update that we got is
+    # If it's more than a second old, mark the view as not changing
+    def _check_view_changing(self):
+        if self.view_changing:
+            delta = datetime.now() - self.last_update
+            if delta.total_seconds() >= self.UPDATE_TIME:
+                self.view_changing = False
+
+    def vue_toggle_measuring(self, _args=None):
+        self.measuring = not self.measuring
+        self.ruler_click_count += 1
+
+    @observe('measuredDistance')
+    def _on_measured_distance_changed(self, change):
+        fov = self.widget.get_fov()
+        widget_height = self._height_from_pixel_str(self.widget.layout.height)
+        ang_size = Angle(((change["new"] / widget_height) * fov))
+        valid = self.validate_angular_size(ang_size, True)
+        # print(ang_size, change["new"], valid)
+        # if valid:
+        #     print('valid measurement')
+        self.angular_size = ang_size
+        self.measurement_count += 1
+
+    @observe('measuring')
+    def _on_measuring_changed(self, measuring):
+        if not measuring["new"]:
+            self.reset_canvas()
+
+    @observe("angular_height")
+    def _on_fov_change(self, change):
+        d, m, s = change["new"].dms
+        m = m + s / 60
+        d = d + m / 60
+        s = int(s)
+        if d > 9.95:  # to avoid edge case where you can get 10 between 10 and 11 and 10.0 from 9.95-10
+            self.fov_text = f"{d:.0f}°"
+        elif d > 0.99:  # to avoid edge case where you can get 60.0 arcmin from 59.5-59.9 arcmin
+            self.fov_text = f"{d:.1f}°"
+        elif m > 9.95:
+            self.fov_text = f"{m:.0f}'"
+        elif m > 0.99:
+            self.fov_text = f"{m:.1f}'"
+        else:
+            self.fov_text = f"{s}\""
+        self.update_text()
+
+    def _handle_view_message(self, wwt, _updated):
+        fov = Angle(self.widget.get_fov())
+        center = self.widget.get_center()
+        ra = Angle(center.ra)
+        dec = Angle(center.dec)
+        changing = not u.allclose([fov, ra, dec],
+                                  [self.angular_height, self._ra, self._dec])
+        self.angular_height = fov
+        self._ra = ra
+        self._dec = dec
+        self.view_changing = changing
+        self.last_update = datetime.now()
+
+    def go_to_location(self, ra, dec, fov=GALAXY_FOV):
+        coordinates = SkyCoord(ra * u.deg, dec * u.deg, frame='icrs')
+        self.widget.center_on_coordinates(coordinates, fov=fov, instant=True)
+    
+    def reset_brightness_contrast(self):
+        self.wwtStyle = {}
+        # toggle reset style to trigger watch in vue
+        self.reset_style = True
+        self.reset_style = False
+    
+    def activate_guard(self):
+        self.guard = True
+        
+    def deactivate_guard(self):
+        self.guard = False
+        self.bad_measurement = False
+        
+    def set_guard(self, max = None, min = None):
+        self.activate_guard()
+        self.galaxy_max_size = Angle(max) if max is not None else self.galaxy_max_size
+        self.galaxy_min_size = Angle(min) if min is not None else  self.galaxy_min_size
+    
+    def validate_angular_size(self, angular_size, check = True):
+        if not self.guard:
+            return True
+        if not check:
+            return self.bad_measurement
+        max_wwt_size = Angle("60 deg")
+        c1 = (angular_size < max_wwt_size) 
+        c2 = (angular_size >= self.galaxy_min_size) 
+        c3 = (angular_size <= self.galaxy_max_size)
+        self.bad_measurement = not (c1 and c2 and c3)
+        return c1 and c2 and c3

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -55,11 +55,16 @@ class DistanceTool(v.VueTemplate):
         self.angular_size = Angle(0, u.deg)
         self.angular_height = Angle(60, u.deg)
         self.widget._set_message_type_callback('wwt_view_state',
-                                               self._handle_view_message)
+                                               self._update_wwt_state)
         self.last_update = datetime.now()
-        self._rt = RepeatedTimer(self.UPDATE_TIME, self._check_view_changing)
+        self._rt = RepeatedTimer(self.UPDATE_TIME, self._update_wwt_state)
+        self._rt.start()
         self.update_text()
         super().__init__(*args, **kwargs)
+
+    def __del__(self):
+        self._rt.stop()
+        super().__del__()
 
     def _setup_widget(self):
         # Temp update to set background to SDSS. Once we remove galaxies without SDSS WWT tiles from the catalog, make background DSS again, and set wwt.foreground_opacity = 0, per Peter Williams.
@@ -126,7 +131,7 @@ class DistanceTool(v.VueTemplate):
             self.fov_text = f"{s}\""
         self.update_text()
 
-    def _handle_view_message(self, wwt, _updated):
+    def _update_wwt_state(self, wwt=None, _updated=None):
         fov = Angle(self.widget.get_fov())
         center = self.widget.get_center()
         ra = Angle(center.ra)
@@ -159,7 +164,7 @@ class DistanceTool(v.VueTemplate):
     def set_guard(self, max = None, min = None):
         self.activate_guard()
         self.galaxy_max_size = Angle(max) if max is not None else self.galaxy_max_size
-        self.galaxy_min_size = Angle(min) if min is not None else  self.galaxy_min_size
+        self.galaxy_min_size = Angle(min) if min is not None else self.galaxy_min_size
     
     def validate_angular_size(self, angular_size, check = True):
         if not self.guard:

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -27,7 +27,7 @@ class DistanceTool(v.VueTemplate):
     width = Int().tag(sync=True)
     view_changing = Bool(False).tag(sync=True)
     measuring_allowed = Bool(False).tag(sync=True)
-    show_ruler = Bool(False).tag(sync=True)
+    show_ruler = Bool(True).tag(sync=True)
     fov_text = Unicode().tag(sync=True)
     flagged = Bool(False).tag(sync=True)
     ruler_click_count = Int().tag(sync=True)

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -129,7 +129,6 @@ class DistanceTool(v.VueTemplate):
             self.fov_text = f"{m:.1f}'"
         else:
             self.fov_text = f"{s}\""
-        self.update_text()
 
     def _update_wwt_state(self, wwt=None, _updated=None):
         fov = Angle(self.widget.get_fov())

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -470,6 +470,12 @@ export default {
     jupyter_update_text: function() {
       this.updateFOVText();
     }
+  },
+  watch: {
+    fov_text(text) {
+      console.log(`fov_text watcher: ${text}`);
+      this.updateFOVText();
+    }
   }
 }
 </script>

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -1,0 +1,542 @@
+<template>
+  <v-card
+    id="distance-root"
+  >
+    <v-toolbar
+      color="primary"
+      dense
+      dark
+      class="text-uppercase"
+    >
+      <v-toolbar-title>Cosmic Sky Viewer</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-tooltip top v-if=false>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn icon
+            v-bind="attrs"
+            v-on="on"
+            :disabled="!galaxy_selected" 
+            @click="flagged = true"
+          >
+            <v-icon>mdi-flag</v-icon>
+          </v-btn>
+        </template>
+        Flag galaxy as missing image
+      </v-tooltip>
+
+      <v-btn v-if="false" icon>
+        <v-icon>mdi-information-outline</v-icon>
+      </v-btn>
+    </v-toolbar>
+    <div class="distance-content">
+      <!-- <v-snackbar
+        v-model="bad_measurement"
+        transition="fab-transition"
+        timeout="5000"
+        top
+        right
+        color="warning lighten-2"
+        class="pa-4 black--text"
+        style="font-size: 1.25rem;"
+        multi-line
+        elevation="24"
+      >
+        You've measured an impossible size for the galaxy. Please try again.
+      </v-snackbar> -->
+      <canvas
+        v-show="measuring"
+        class="distance-canvas"
+        ref="canvas">
+      </canvas>
+      <canvas
+        class="fov-canvas"
+        ref="fovCanvas"
+      ></canvas>
+      <v-lazy>
+        <jupyter-widget
+          :widget="widget"
+          class="wwt-widget"
+          :style="wwtStyle"
+        />
+      </v-lazy>
+      <v-tooltip
+        top
+        class="fab-tooltip"
+        >
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            bottom
+            right
+            absolute
+            :color="measuring ? 'red' : '#00E676'"
+            class="measuring-fab black--text"
+            :ripple="false"
+            v-bind="attrs"
+            v-on="on"
+            v-show="measuring_allowed && !view_changing && show_ruler"
+            @click="toggle_measuring()">
+            <v-icon>{{ measuring ? 'mdi-stop' : 'mdi-ruler' }}</v-icon>
+          </v-btn>
+        </template>
+        {{ measuring ? 'Stop measuring' : 'Start measuring' }}
+      </v-tooltip>
+    </div>
+    <contrast-brightness-control 
+      inline-style="padding: 0.5em 0;"
+      :enabled=true  
+      :showContrast=false
+      :reset="reset_style"
+      @change-style="newStyle => this.wwtStyle = newStyle"
+      @change-brightness="(newBrightness) => $emit('brightness', newBrightness)"
+      @change-contrast="(newContrast) => $emit('contrast', newContrast)"
+    />
+        
+        <!-- add inline style to control using inline css like inlineStyle="border: 1px solid white" -->
+  </v-card>
+</template>
+
+<script>
+export default {
+    
+  mounted() {
+    this.setup();
+    this.reset();
+    this.ranIntersectObserver = false;
+    window.addEventListener('resize', this.handleResize);
+    // We don't get a Window resize event when the canvas first appears
+    // so we watch the canvas' dimensions instead
+    const resizeObserver = new ResizeObserver(_entries => {
+      this.handleResize();
+    });
+
+    // The two canvases have the same dimensions
+    // so we only need to observe one
+    resizeObserver.observe(this.canvas);
+  },
+
+  unmounted() {
+    window.removeEventListener('resize', this.handleResize);
+    resizeObserver.unobserve(this.canvas);
+  },
+
+  methods: {
+
+    setup: function() {
+      this.setupMeasuringCanvas();
+      this.setupFOVCanvas();
+    },
+
+    // This stuff only needs to be done once
+    setupMeasuringCanvas: function() {
+      // Constants
+      this.pointRadius = 2;
+      this.grabRadius = 4;
+      this.delta = 8;
+      this.pointerClass = "pointer";
+      this.grabClass = "grab";
+      this.grabbingClass = "grabbing";
+
+      // Get the canvas
+      this.canvas = this.$refs.canvas;
+      this.height = 400; // See the component CSS
+      this.width = this.canvas.width;
+      this.setupMeasuringCanvasContext();
+    },
+
+    setupFOVCanvas: function() {
+      this.fovCanvas = this.$refs.fovCanvas;
+      const parent = this.fovCanvas.parentElement;
+      this.fovCanvas.width = parent.clientWidth;
+      this.fovCanvas.height = parent.clientHeight;
+      this.fovContext = this.fovCanvas.getContext('2d');
+      this.fovContext.lineWidth = 3;
+      this.fovContext.strokeStyle = '#00B0FF';
+
+      const leftPadding = 5;
+      const verticalPadding = 5;
+      const endcapLength = 10;
+      const gapHeight = 26;
+      const fontSize = 18;
+      const font = `${fontSize}px monospace`;
+      const endcapEndX = leftPadding + endcapLength;
+
+      const verticalX = leftPadding + (endcapLength / 2);
+      const fracDown = 0.5;
+      const adjustY = 1;
+      const midYTop = this.fovCanvas.height * fracDown - (gapHeight / 2) - adjustY;
+      const midYBot = this.fovCanvas.height * fracDown + (gapHeight / 2) - adjustY;
+      const bottomEndcapY = this.fovCanvas.height - verticalPadding;
+      this.textCoordinates = [leftPadding, this.fovCanvas.height * fracDown + ((gapHeight - fontSize) / 2)];
+      this.textRect = [0, midYTop, this.fovCanvas.width, gapHeight];
+
+      this.fovContext.beginPath();
+      this.fovContext.moveTo(leftPadding, verticalPadding);
+      this.fovContext.lineTo(endcapEndX, verticalPadding);
+      this.fovContext.stroke();
+
+      this.fovContext.beginPath();
+      this.fovContext.moveTo(verticalX, verticalPadding);
+      this.fovContext.lineTo(verticalX, midYTop);
+      this.fovContext.stroke();
+
+      this.fovContext.beginPath();
+      this.fovContext.moveTo(verticalX, midYBot);
+      this.fovContext.lineTo(verticalX, bottomEndcapY);
+      this.fovContext.stroke();
+
+      this.fovContext.beginPath();
+      this.fovContext.moveTo(leftPadding, bottomEndcapY);
+      this.fovContext.lineTo(endcapEndX, bottomEndcapY);
+      this.fovContext.stroke();
+
+      this.fovContext.font = font;
+      this.fovContext.fillStyle = 'white';
+      if (this.fov_text) {
+        this.updateFOVText();
+      }
+    },
+
+    updateFOVText: function() {
+      this.fovContext.clearRect(...this.textRect);
+      this.fovContext.fillText(this.fov_text, ...this.textCoordinates);
+    },
+
+    // This needs to be done any time we want to reset the state
+    reset: function() {
+      this.startPoint = null;
+      this.endPoint = null;
+      this.onStart = false;
+      this.onEnd = false;
+      this.mouseDown = false;
+      this.mouseMoving = false;
+      this.shouldFollowMouse = false;
+      this.lineCreated = false;
+      this.measuredDistance = 0;
+      this.measuring = false;
+      this.hasMovedWhileDrawing = false;
+
+      // Set the canvas handlers
+      this.canvas.onmousemove = this.handleMouseMove;
+      this.canvas.onmousedown = this.addInitialPoint;
+      this.canvas.onmouseup = null;
+
+      // Clear the canvas, if necessary
+      this.clearCanvas();
+    },
+
+    setupMeasuringCanvasContext: function() {
+      this.context = this.canvas.getContext('2d');
+      this.context.lineWidth = 3;
+      this.context.strokeStyle = '#00e676';
+    },
+
+    addInitialPoint: function(event) {
+
+      // If we haven't put the first point down
+      const coordinates = this.position(event);
+      if (this.startPoint == null) {
+        this.startPoint = coordinates;
+        this.drawPoint(this.startPoint, 1);
+        this.canvas.onmousemove = (e) => this.lineFollow(e, false);
+
+      // If we haven't put the second point down
+      } else if (this.endPoint === null) {
+
+        // If we haven't moved since we put the first point down, do nothing
+        if (!this.hasMovedWhileDrawing) {
+          return;
+        }
+
+        this.endPoint = coordinates;
+        this.clearCanvas();
+        this.drawLine(this.startPoint, this.endPoint);
+        this.drawEndcaps(this.startPoint, this.endPoint);
+        this.updateMeasuredDistance();
+        this.canvas.onmousedown = this.handleMouseDown;
+        this.canvas.onmouseup = this.handleMouseUp;
+        this.canvas.onmousemove = this.handleMouseMove;
+      }
+      this.lineCreated = true;
+    },
+
+    handleMouseDown: function(event) {
+      this.mouseDown = true;
+
+      // If we aren't drawing the line
+      // and we aren't on one of the endpoints,
+      // then we're done here
+      if (!(this.onStart || this.onEnd || this.shouldFollowMouse)) {
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      // To make things easier, we define the point that
+      // isn't being modified as the 'start' point
+      if (!this.shouldFollowMouse && this.onStart) {
+        const tempPoint = this.startPoint;
+        this.startPoint = this.endPoint;
+        this.endPoint = tempPoint;
+      }
+      this.clearCanvas();
+      this.drawPoint(this.startPoint);
+      if (this.canvas.classList.contains(this.grabbingClass)) {
+        this.canvas.classList.remove(this.grabbingClass);
+      } else {
+        this.canvas.classList.add(this.grabbingClass);
+      }
+
+      if (this.shouldFollowMouse) {
+        this.endPoint = this.position(event);
+        this.clearCanvas();
+        this.drawLine(this.startPoint, this.endPoint);
+        this.drawEndcaps(this.startPoint, this.endPoint);
+        this.updateMeasuredDistance();
+      }
+      this.shouldFollowMouse = !this.shouldFollowMouse;
+
+      // To avoid the line 'vanishing' when we grab an endpoint
+      // we draw a line from the other point to where the mouse it
+      this.drawLine(this.startPoint, this.position(event));
+    },
+
+    handleMouseUp: function(event) {
+      this.mouseDown = false;
+      this.mouseMoving = false;
+    },
+
+    handleMouseMove: function(event) {
+      this.mouseMoving = true;
+      if (this.shouldFollowMouse) {
+        this.hasMovedWhileDrawing = true;
+        this.lineFollow(event, false);
+      } else if (this.startPoint && this.endPoint) {
+        this.lookForEndpoints(event);
+      }
+    },
+
+    rescalePoints: function(points, xRatio, yRatio) {
+      points.forEach(point => {
+        point[0] = point[0] * xRatio;
+        point[1] = point[1] * yRatio;
+      });
+    },
+
+    handleResize: function() {
+      const oldWidth = this.canvas.width;
+      const oldHeight = this.canvas.height;
+      const referenceElement = this.canvas.parentElement;
+      this.canvas.width = referenceElement.clientWidth;
+      this.canvas.height = referenceElement.clientHeight;
+      this.fovCanvas.width = referenceElement.clientWidth;
+      this.fovCanvas.height = referenceElement.clientHeight;
+      const newWidth = referenceElement.clientWidth;
+      const newHeight = referenceElement.clientHeight;
+      if (newWidth === 0 || newHeight === 0) {
+        this.canvas.width = oldWidth;
+        this.canvas.height = oldHeight;
+        this.fovCanvas.width = oldWidth;
+        this.fovCanvas.height = oldHeight;
+        return;
+      }
+      this.width = newWidth;
+      this.height = newHeight;
+
+      // Update the measuring canvas
+      this.setupMeasuringCanvasContext();
+      if (this.startPoint && this.endPoint) {
+        const xRatio = this.canvas.width / oldWidth;
+        const yRatio = this.canvas.height / oldHeight;
+        this.rescalePoints([this.startPoint, this.endPoint], xRatio, yRatio);
+        this.drawLine(this.startPoint, this.endPoint);
+        this.drawEndcaps(this.startPoint, this.endPoint);
+        this.updateMeasuredDistance();
+      }
+
+      // Update the FOV canvas
+      this.setupFOVCanvas();
+    },
+
+    position: function(event) {
+      return [event.offsetX, event.offsetY];
+    },
+
+    clearCanvas: function() {
+      this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    },
+
+    drawPoint: function(coordinates, radius=this.pointRadius) {
+      this.context.beginPath();
+      this.context.arc(...coordinates, radius, 0, 2*Math.PI);
+      this.context.fill();
+    },
+
+    drawLine: function(start, end) {
+      this.context.beginPath();
+      this.context.moveTo(...start);
+      this.context.lineTo(...end);
+      this.context.stroke();
+    },
+
+    lineFollow: function(event, requireMouseDown) {
+      this.mouseMoving = true;
+      this.hasMovedWhileDrawing = true;
+      if (requireMouseDown && !this.mouseDown) { return; }
+      const coordinates = this.position(event);
+      this.clearCanvas();
+      this.drawPoint(this.startPoint);
+      this.drawLine(this.startPoint, coordinates);
+    },
+
+    distanceSquared: function(p1, p2) {
+      return (p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2;
+    },
+
+    slope: function(p1=this.startPoint, p2=this.endPoint) {
+      if (!(p1 && p2)) { return undefined; }
+      return (p2[1] - p1[1]) / (p2[0] - p1[0]);
+    },
+
+    perpSlope: function(p1=this.startPoint, p2=this.endPoint) {
+      if (!(p1 && p2)) { return 1; }
+      return (p1[0] - p2[0]) / (p2[1] - p1[1]);
+    },
+
+    yIntercept: function(p1=this.startPoint, p2=this.endPoint) {
+      if (!(p1 && p2)) { return undefined; }
+      return p2[1] - this.slope(p1, p2) * p2[0];
+    },
+
+    drawEndcaps: function(p1, p2) {
+      const mPerp = this.perpSlope(p1, p2);
+      const endpts = [p1, p2];
+
+      // We have to handle this a bit differently if the line is horizontal
+      // since the perpendicular lines are of the form x=constant
+      if (Math.abs(mPerp) === Infinity) {
+        endpts.forEach(p => {
+          const [x, y] = p;
+          this.drawLine([x, y - this.delta], [x, y + this.delta]);
+        });
+        return;
+      }
+
+      // The points corresponding to x +/- d
+      // have a distance delta from the endpoints
+      const d = this.delta / Math.sqrt(1 + mPerp ** 2);
+
+      // Draw the endcap through each point
+      endpts.forEach(p => {
+        const [x, y] = p;
+        const nonXTerm = (y - mPerp * x);
+        const xp = x + d;
+        const yp = mPerp * xp + nonXTerm;
+        const xm = x - d;
+        const ym = mPerp * xm + nonXTerm;
+        this.drawLine([xm, ym], [xp, yp]);
+      });
+    },
+
+    lookForEndpoints: function(event) {
+      const coordinates = this.position(event);
+      const rsqStart = this.distanceSquared(coordinates, this.startPoint);
+      const rsqEnd = this.distanceSquared(coordinates, this.endPoint);
+      const grabRadiusSq = this.grabRadius ** 2;
+      this.onStart = rsqStart <= grabRadiusSq;
+      this.onEnd = rsqEnd <= grabRadiusSq;
+      if (this.onStart || this.onEnd) {
+        this.canvas.classList.add(this.grabClass);
+      } else {
+        this.canvas.classList.remove(this.grabClass);
+      }
+    },
+
+    distance: function(p1=this.startPoint, p2=this.endPoint) {
+      if (!(p1 && p2)) { return 0; }
+      return Math.sqrt(this.distanceSquared(p1, p2));
+    },
+
+    updateMeasuredDistance: function() {
+      this.measuredDistance = this.distance();
+    },
+
+    // Exposed to Jupyter
+
+    jupyter_reset: function() {
+      this.reset();
+    },
+
+    jupyter_update_text: function() {
+      this.updateFOVText();
+    }
+  }
+}
+</script>
+
+<style scoped>
+#selection-root {
+  --toolbar-height: 48px;
+  --widget-height: 400px;
+  height: calc(var(--toolbar-height) + var(--widget-height));
+  width: 100%;
+}
+
+.distance-content {
+  width: 100%;
+  height: 400px;
+}
+
+.wwt-widget, .distance-canvas, .fov-canvas {
+  height: 400px;
+  width: 100%;
+  position: absolute;
+}
+
+.wwt-widget .p-Widget, .wwt-widget iframe {
+  height: 400px !important;
+  width: 100% !important;
+  z-index: 3;
+}
+
+.distance-canvas {
+  background: transparent;
+  z-index: 4;
+  cursor: crosshair;
+}
+
+.fov-canvas {
+  background: transparent;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.pointer {
+  cursor: pointer;
+}
+
+.grab {
+  cursor: grab;
+}
+
+.grabbing {
+  cursor: grabbing;
+}
+
+.measuring-fab {
+  --margin: 15px;
+  --card-padding: 16px;
+  bottom: 0px !important;
+  margin-bottom: var(--margin);
+  margin-right: calc(var(--margin) - var(--card-padding));
+  z-index: 25 !important;
+}
+
+.measuring-fab:hover:before, .measuring-fab:focus:before {
+  display: none;
+}
+
+.fab-tooltip {
+  z-index: 25 !important;
+}
+</style>


### PR DESCRIPTION
This PR adds the distance tool to stage 3 of the story. This includes the hookups between the tool and the data tables - selecting a galaxy within the data table will send the WWT viewer to that galaxy, and making a distance measurement will update the current galaxy in the data model.

This depends on https://github.com/cosmicds/cosmicds/pull/286, as the contrast/brightness controls are used within the distance measuring tool