### PR TITLE
Line draw tool

### DIFF
--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -69,7 +69,7 @@ export default {
       element: null,
       lineDrawn: false,
       mouseDown: false,
-      movingLine: true,
+      movingLine: false,
       lastEndpoint: null,
       plotDataCount: 0,
       lineTraceIndex: 0,
@@ -105,7 +105,6 @@ export default {
         this.movingLine = false;
         this.drawEndpoint(event);
         this.lineDrawn = true;
-        this.setCursor("move");
         if (this.line_drawn) {
           this.line_drawn();
         }
@@ -132,7 +131,8 @@ export default {
     plotlyUnhoverHandler(event) {
       if (event.points[0].curveNumber === this.endpointTraceIndex) {
         this.hoveringEndpoint = false;
-        this.setCursor("crosshair");
+        const cursor = this.movingLine ? "grabbing" : "crosshair";
+        this.setCursor(cursor);
       }
     },
     setCursor(type) {
@@ -202,9 +202,14 @@ export default {
       );
     },
     active(value) {
+      this.movingLine = value && this.lastEndpoint === null;
       Plotly.update(this.chart.uuid, { visible: true }, {}, [this.lineTraceIndex]);
       this.setupMouseHandlers(value);
       this.setupPlotlyHandlers(value);
+    },
+    movingLine(value) {
+      const cursor = value ? "grabbing" : "move";
+      this.setCursor(cursor);
     }
   }
 }

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -26,6 +26,7 @@ export default {
       showgrid: false,
       showticklabels: true,
       autorange: false,
+      automargin: true,
     };
     const xaxis = { ...baseAxis, range: [0, 1] };
     const yaxis = { ...baseAxis, range: [0, 1] };
@@ -45,7 +46,7 @@ export default {
           }
         ],
         layout: { xaxis, yaxis, hovermode: "none", dragmode: false, showlegend: false },
-        config: { displayModeBar: false },
+        config: { displayModeBar: false, responsive: true },
       },
       element: null,
       lineDrawn: false,
@@ -85,6 +86,7 @@ export default {
         this.movingLine = false;
         this.drawEndpoint(event);
         this.lineDrawn = true;
+        this.setCursor("move");
         if (this.line_drawn) {
           this.line_drawn();
         }
@@ -105,17 +107,24 @@ export default {
     plotlyHoverHandler(event) {
       if (event.points[0].curveNumber === this.endpointTraceIndex) {
         this.hoveringEndpoint = true;
-        this.element.style.cursor = "move";
-        this.dragLayer.style.cursor = "move";
-        this.dragLayer.classList.remove("cursor-crosshair");
+        this.setCursor("move");
       }
     },
     plotlyUnhoverHandler(event) {
       if (event.points[0].curveNumber === this.endpointTraceIndex) {
         this.hoveringEndpoint = false;
-        this.element.style.cursor = "crosshair";
-        this.dragLayer.style.cursor = "crosshair";
+        this.setCursor("crosshair");
+      }
+    },
+    setCursor(type) {
+      this.element.style.cursor = type;
+      this.dragLayer.style.cursor = type;
+      // This class sets the cursor to be the crosshair on Plotly
+      // so we need a bit of special handling here
+      if (type === "crosshair") {
         this.dragLayer.classList.add("cursor-crosshair");
+      } else {
+        this.dragLayer.classList.remove("cursor-crosshair");
       }
     },
     clearEndpoint() {
@@ -193,7 +202,13 @@ export default {
 </template>
 
 <style>
-div.js-plotly-plot {
-  width: 100%;
+.svg-container {
+  width: 100% !important;
+}
+
+.main-svg {
+  width: 100% !important;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 </style>

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -1,9 +1,9 @@
 <script>
 export default {
-  name: "LineDrawViewer",
-  props: ["chart"],
+  name: "LineDrawPlot",
+  props: ["active", "line_drawn"],
   mounted() {
-    Plotly.newPlot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout)
+    Plotly.newPlot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout, this.chart.config)
       .then(() => {
         this.element = document.getElementById(this.chart.uuid);
         this.dragLayer = this.element.querySelector(".nsewdrag");
@@ -12,6 +12,18 @@ export default {
       });
   },
   data() {
+    const baseAxis = {
+      showspikes: false,
+      zeroline: false,
+      mirror: true,
+      ticks: "outside",
+      showline: true,
+      showgrid: false,
+      showticklabels: true,
+      autorange: false,
+    };
+    const xaxis = { ...baseAxis, range: [0, 1] };
+    const yaxis = { ...baseAxis, range: [0, 1] };
     return {
       chart: {
         uuid: "abcde",
@@ -27,9 +39,9 @@ export default {
             hoverinfo: "skip"
           }
         ],
-        layout: { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false }, hovermode: "none", dragmode: false, showlegend: false },
+        layout: { xaxis, yaxis, hovermode: "none", dragmode: false, showlegend: false },
+        config: { displayModeBar: false },
       },
-      active: true,
       element: null,
       lineDrawn: false,
       mouseDown: false,
@@ -67,6 +79,10 @@ export default {
         this.movingLine = false;
         this.drawEndpoint(event);
         this.lineDrawn = true;
+        console.log(this.line_drawn);
+        if (this.line_drawn) {
+          this.line_drawn();
+        }
       }
     },
     mouseUpHandler(_event) {
@@ -162,3 +178,9 @@ export default {
   :class="active ? ['active'] : []"
 ></div>
 </template>
+
+<style>
+div.js-plotly-plot {
+  width: 100%;
+}
+</style>

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -2,7 +2,8 @@
 export default {
   name: "LineDrawPlot",
   props: ["active", "line_drawn", "plot_data"],
-  mounted() {
+  async mounted() {
+    await window.plotlyPromise;
     Plotly.newPlot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout, this.chart.config)
       .then(() => {
         this.element = document.getElementById(this.chart.uuid);

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -131,7 +131,12 @@ export default {
     plotlyUnhoverHandler(event) {
       if (event.points[0].curveNumber === this.endpointTraceIndex) {
         this.hoveringEndpoint = false;
-        const cursor = this.movingLine ? "grabbing" : "crosshair";
+        let cursor;
+        if (this.movingLine) {
+          cursor = this.lineDrawn ? "grabbing" : "default";
+        } else {
+          cursor = "crosshair";
+        }
         this.setCursor(cursor);
       }
     },
@@ -208,7 +213,12 @@ export default {
       this.setupPlotlyHandlers(value);
     },
     movingLine(value) {
-      const cursor = value ? "grabbing" : "move";
+      let cursor;
+      if (value) {
+        cursor = this.lineDrawn ? "grabbing" : "default";
+      } else {
+        cursor = "move";
+      }
       this.setCursor(cursor);
     }
   }

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -33,8 +33,8 @@ export default {
         uuid: "abcde",
         traces: [
           {
-            x: [0, 1],
-            y: [0, 1],
+            x: [0, 0],
+            y: [0, 0],
             line: {
               color: "#000000",
               width: 4,

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -125,7 +125,7 @@ export default {
     plotlyHoverHandler(event) {
       if (event.points[0].curveNumber === this.endpointTraceIndex) {
         this.hoveringEndpoint = true;
-        this.setCursor("move");
+        this.setCursor("grab");
       }
     },
     plotlyUnhoverHandler(event) {
@@ -217,7 +217,7 @@ export default {
       if (value) {
         cursor = this.lineDrawn ? "grabbing" : "default";
       } else {
-        cursor = "move";
+        cursor = "grab";
       }
       this.setCursor(cursor);
     }

--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -167,7 +167,6 @@ export default {
       // For some reason, mousedown works fine on the Plotly graph, but not mouseup
       // Any ideas on how to not need to do this would be great!
       if (active) {
-        this.clearEndpoint();
         this.element.addEventListener("mousemove", this.mouseMoveHandler);
         this.element.addEventListener("mousedown", this.mouseDownHandler);
         document.addEventListener("mouseup", this.mouseUpHandler);

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -3,46 +3,59 @@ export default {
   name: "LineDrawViewer",
   props: ["chart"],
   mounted() {
-    Plotly.plot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout)
-      .then(function() {
+    Plotly.newPlot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout)
+      .then(() => {
         const div = document.getElementById(this.chart.uuid);
         const chart = this.$refs[this.chart.uuid];
-        const layout = chart._fullLayout;
-        div.addEventListener("mousemove", function (event) {
-          const xWorld = layout.xaxis.p2c(event.x - layout.margin.l);
-          const yWorld = layout.yaxis.p2c(event.y - layout.margin.t);
-          const line = chart.data[0];
+        div.addEventListener("mousemove", (event) => {
+          console.log("mousemove");
+          const layout = chart._fullLayout;
+          const rect = div.getBoundingClientRect();
+          const x = event.clientX - rect.left;
+          const y = event.clientY - rect.top;
+          const xWorld = layout.xaxis.p2c(x - layout.margin.l);
+          const yWorld = layout.yaxis.p2c(y - layout.margin.t);
+          const baseLine = this.chart.traces[0];
+          const baseLineData = baseLine.line;
+          const lineData = { color: baseLineData.color, shape: baseLineData.shape, width: baseLineData.width };
+          const line = { x: [...baseLine.x], y: [...baseLine.y], line: lineData };
+          const newLayout = { xaxis: layout.xaxis, yaxis: layout.yaxis };
           line.x[1] = xWorld;
           line.y[1] = yWorld;
-          Plotly.react(
+          console.log(chart);
+          console.log(newLayout);
+          Plotly.restyle(
             chart,
             [line],
-            chart.layout
+            newLayout,
           );
         });
       });
   },
-  data: () => ({
-    chart: {
-      uuid: "abcde",
-      traces: [
-        {
-          y: [],
-          line: {
-            color: "#5e9e7e",
-            width: 4,
-            shape: "line"
+  data() {
+    return {
+      chart: {
+        uuid: "abcde",
+        traces: [
+          {
+            x: [0, 1],
+            y: [0, 1],
+            line: {
+              color: "#5e9e7e",
+              width: 4,
+              shape: "line"
+            }
           }
-        }
-      ],
-      layout: {}
-    }
-  }),
+        ],
+        layout: {}
+      }
+    };
+  },
   watch: {
     chart: {
       handler: function() {
         Plotly.react(
-          this.$refs[this.chart.uuid],
+          this.$refs["chart"],
           this.chart.traces,
           this.chart.layout
         );

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -8,6 +8,8 @@ export default {
         this.element = document.getElementById(this.chart.uuid);
         this.setupMouseHandlers(this.active);
         this.element.on("plotly_click", this.plotlyClickHandler);
+        this.element.on("plotly_hover", this.plotlyHoverHandler);
+        this.element.on("plotly_unhover", this.plotlyUnhoverHandler);
       });
   },
   data() {
@@ -55,25 +57,44 @@ export default {
       if (this.active) {
         this.active = false;
         const [x, y] = this.screenToWorld(event);
-        Plotly.addTraces(this.chart.uuid, { x: [x], y: [y], type: "scatter", mode: "markers", marker: { size: 15, color: "red" }, meta: "endcap" });
+        Plotly.addTraces(this.chart.uuid, { x: [x], y: [y], type: "scatter", mode: "markers", marker: { size: 10, color: "red" }, meta: "endcap" });
       }
     },
     plotlyClickHandler(event) {
-      console.log(event);
-      console.log(event.points.data);
+      console.log(!this.active);
+      console.log(event.points[0].curveNumber === 1);
       if (!this.active && event.points[0].curveNumber === 1) {
+        console.log("HERE");
         this.active = true; 
         Plotly.update(
           this.chart.uuid,
           {},
-          { hovermode: "closest" }
+          { hovermode: "x" }
         );
+      }
+    },
+    plotlyHoverHandler(event) {
+      console.log("hover");
+      console.log(event.points[0].curveNumber);
+      if (!this.active && event.points[0].curveNumber === 1) {
+        this.element.style.cursor = "grab";
+      }
+    },
+    plotlyUnhoverHandler(event) {
+      console.log("unhover");
+      console.log(event.points[0].curveNumber);
+      if (!this.active && event.points[0].curveNumber === 1) {
+        this.element.style.cursor = "crosshair";
       }
     },
     setupMouseHandlers(active) {
       if (active) {
         if (this.element.data.length > 1) {
-          Plotly.deleteTraces(this.chart.uuid, 1);
+          try {
+            Plotly.deleteTraces(this.chart.uuid, 1);
+          } catch (e) {
+            console.log(e);
+          }
         }
         this.element.addEventListener("mousemove", this.mouseMoveHandler);
         this.element.addEventListener("mousedown", this.clickHandler);
@@ -99,5 +120,9 @@ export default {
 </script>
 
 <template>
-<div :ref="chart.uuid" :id="chart.uuid"></div>
+<div
+  :ref="chart.uuid"
+  :id="chart.uuid"
+  :class="active ? ['active'] : []"
+></div>
 </template>

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -8,24 +8,16 @@ export default {
         const div = document.getElementById(this.chart.uuid);
         const chart = this.$refs[this.chart.uuid];
         div.addEventListener("mousemove", (event) => {
-          console.log("mousemove");
           const layout = chart._fullLayout;
           const rect = div.getBoundingClientRect();
           const x = event.clientX - rect.left;
           const y = event.clientY - rect.top;
           const xWorld = layout.xaxis.p2c(x - layout.margin.l);
           const yWorld = layout.yaxis.p2c(y - layout.margin.t);
-          const baseLine = this.chart.traces[0];
-          const baseLineData = baseLine.line;
-          const lineData = { color: baseLineData.color, shape: baseLineData.shape, width: baseLineData.width };
-          const line = { x: [...baseLine.x], y: [...baseLine.y], line: lineData };
-          const newLayout = { xaxis: layout.xaxis, yaxis: layout.yaxis };
-          line.x[1] = xWorld;
-          line.y[1] = yWorld;
-          console.log(chart);
-          console.log(newLayout);
-          Plotly.restyle(
-            chart,
+          const line = { x: [0, xWorld], y: [0, yWorld], line: { color: "red" } };
+          const newLayout = { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false } };
+          Plotly.react(
+            this.chart.uuid,
             [line],
             newLayout,
           );
@@ -47,7 +39,7 @@ export default {
             }
           }
         ],
-        layout: {}
+        layout: { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false } },
       }
     };
   },

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -1,0 +1,58 @@
+<script>
+export default {
+  name: "LineDrawViewer",
+  props: ["chart"],
+  mounted() {
+    Plotly.plot(this.$refs[this.chart.uuid], this.chart.traces, this.chart.layout)
+      .then(function() {
+        const div = document.getElementById(this.chart.uuid);
+        const chart = this.$refs[this.chart.uuid];
+        const layout = chart._fullLayout;
+        div.addEventListener("mousemove", function (event) {
+          const xWorld = layout.xaxis.p2c(event.x - layout.margin.l);
+          const yWorld = layout.yaxis.p2c(event.y - layout.margin.t);
+          const line = chart.data[0];
+          line.x[1] = xWorld;
+          line.y[1] = yWorld;
+          Plotly.react(
+            chart,
+            [line],
+            chart.layout
+          );
+        });
+      });
+  },
+  data: () => ({
+    chart: {
+      uuid: "abcde",
+      traces: [
+        {
+          y: [],
+          line: {
+            color: "#5e9e7e",
+            width: 4,
+            shape: "line"
+          }
+        }
+      ],
+      layout: {}
+    }
+  }),
+  watch: {
+    chart: {
+      handler: function() {
+        Plotly.react(
+          this.$refs[this.chart.uuid],
+          this.chart.traces,
+          this.chart.layout
+        );
+      },
+      deep: true
+    }
+  }
+}
+</script>
+
+<template>
+<div :ref="chart.uuid" :id="chart.uuid"></div>
+</template>

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -20,14 +20,14 @@ export default {
             x: [0, 1],
             y: [0, 1],
             line: {
-              color: "#5e9e7e",
+              color: "#000000",
               width: 4,
               shape: "line"
             },
             hoverinfo: "skip"
           }
         ],
-        layout: { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false }, hovermode: "none", dragmode: false },
+        layout: { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false }, hovermode: "none", dragmode: false, showlegend: false },
       },
       active: true,
       element: null,
@@ -58,7 +58,6 @@ export default {
     },
     mouseMoveHandler(event) {
       if (this.movingLine) {
-        console.log("Updating line");
         this.updateLine(event);
       }
     },
@@ -79,11 +78,7 @@ export default {
       this.mouseDown = false;
     },
     plotlyHoverHandler(event) {
-      console.log("hover");
-      console.log(event.points[0].curveNumber);
       if (event.points[0].curveNumber === 1) {
-        console.log("Hovering");
-        console.log(this.dragLayer);
         this.hoveringEndpoint = true;
         this.element.style.cursor = "move";
         this.dragLayer.style.cursor = "move";
@@ -91,8 +86,6 @@ export default {
       }
     },
     plotlyUnhoverHandler(event) {
-      console.log("unhover");
-      console.log(event.points[0].curveNumber);
       if (event.points[0].curveNumber === 1) {
         this.hoveringEndpoint = false;
         this.element.style.cursor = "crosshair";
@@ -111,7 +104,7 @@ export default {
     },
     drawEndpoint(event) {
       const [x, y] = this.screenToWorld(event);
-      Plotly.addTraces(this.chart.uuid, { x: [x], y: [y], type: "scatter", mode: "markers", marker: { size: 10, color: "red" }, meta: "endcap" });
+      Plotly.addTraces(this.chart.uuid, { x: [x], y: [y], type: "scatter", mode: "markers", marker: { size: 10, color: "#000000" }, hoverinfo: "none" });
       this.lastEndpoint = [x, y];
     },
     setupMouseHandlers(active) {

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -62,20 +62,24 @@ export default {
       }
     },
     mouseDownHandler(event) {
-      console.log("mousedown");
       this.mouseDown = true;
       if (this.movingLine) {
         this.movingLine = false;
         this.drawEndpoint(event);
         this.lineDrawn = true;
       }
-      if (this.hoveringEndpoint) {
-        this.movingLine = true;
-        this.clearEndpoint();
-      }
     },
     mouseUpHandler(_event) {
       this.mouseDown = false;
+    },
+    plotlyClickHandler(event) {
+      if (event.points[0].curveNumber === 1) {
+        if (this.hoveringEndpoint) {
+          this.hoveringEndpoint = false;
+          this.movingLine = true;
+          this.clearEndpoint();
+        }
+      }
     },
     plotlyHoverHandler(event) {
       if (event.points[0].curveNumber === 1) {
@@ -125,9 +129,11 @@ export default {
     },
     setupPlotlyHandlers(active) {
       if (active) {
+        this.element.on("plotly_click", this.plotlyClickHandler);
         this.element.on("plotly_hover", this.plotlyHoverHandler);
         this.element.on("plotly_unhover", this.plotlyUnhoverHandler);
       } else {
+        this.element.removeListener("plotly_click", this.plotlyClickHandler);
         this.element.removeListener("plotly_hover", this.plotlyHoverHandler);
         this.element.removeListener("plotly_unhover", this.plotlyUnhoverHandler);
       }

--- a/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawViewer.vue
@@ -14,12 +14,12 @@ export default {
           const y = event.clientY - rect.top;
           const xWorld = layout.xaxis.p2c(x - layout.margin.l);
           const yWorld = layout.yaxis.p2c(y - layout.margin.t);
-          const line = { x: [0, xWorld], y: [0, yWorld], line: { color: "red" } };
           const newLayout = { xaxis: { range: [0, 1], autorange: false }, yaxis: { range: [0, 1], autorange: false } };
-          Plotly.react(
+          Plotly.update(
             this.chart.uuid,
-            [line],
-            newLayout,
+            { 'x.1': xWorld, 'y.1': yWorld },
+            {},
+            [0]
           );
         });
       });
@@ -51,8 +51,7 @@ export default {
           this.chart.traces,
           this.chart.layout
         );
-      },
-      deep: true
+      }
     }
   }
 }

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -1,6 +1,7 @@
 import reacton.ipyvuetify as rv
 import solara
 
+
 @solara.component_vue("LineDrawPlot.vue")
 def LineDrawPlot(active, event_line_drawn=None, plot_data=None):
     pass
@@ -14,6 +15,8 @@ def LineDrawViewer(plot_data=None):
     def on_draw_clicked():
         active.set(not active.value)
 
+    # If we want to disable the tool after finishing a line draw
+    # pass this function to `LineDrawPlot` as `event_line_drawn`
     # def disable(*args):
     #     active.set(False)
 

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -1,5 +1,30 @@
+import reacton.ipyvuetify as rv
 import solara
 
-@solara.component_vue("LineDrawViewer.vue")
-class LineDrawViewer():
+@solara.component_vue("LineDrawPlot.vue")
+def LineDrawPlot(active, event_line_drawn=None):
     pass
+
+
+@solara.component
+def LineDrawViewer():
+
+    active = solara.use_reactive(False)
+
+    def on_draw_clicked():
+        active.set(not active.value)
+
+    # def disable(*args):
+    #     active.set(False)
+
+    with rv.Card():
+        with rv.Toolbar(color="primary", dense=True):
+            with rv.ToolbarTitle():
+                solara.Text("LINE DRAW VIEWER")
+
+            rv.Spacer()
+
+            draw_button = solara.IconButton(icon_name="mdi-message-draw", on_click=on_draw_clicked)
+            rv.BtnToggle(v_model="selected", children=[draw_button], background_color="primary", borderless=True)
+
+        LineDrawPlot(active=active.value, event_line_drawn=None)

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -1,0 +1,5 @@
+import solara
+
+@solara.component_vue("LineDrawViewer.vue")
+class LineDrawViewer():
+    pass

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -2,12 +2,12 @@ import reacton.ipyvuetify as rv
 import solara
 
 @solara.component_vue("LineDrawPlot.vue")
-def LineDrawPlot(active, event_line_drawn=None):
+def LineDrawPlot(active, event_line_drawn=None, plot_data=None):
     pass
 
 
 @solara.component
-def LineDrawViewer():
+def LineDrawViewer(plot_data=None):
 
     active = solara.use_reactive(False)
 
@@ -27,4 +27,4 @@ def LineDrawViewer():
             draw_button = solara.IconButton(icon_name="mdi-message-draw", on_click=on_draw_clicked)
             rv.BtnToggle(v_model="selected", children=[draw_button], background_color="primary", borderless=True)
 
-        LineDrawPlot(active=active.value, event_line_drawn=None)
+        LineDrawPlot(active=active.value, event_line_drawn=None, plot_data=plot_data)

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -12,6 +12,8 @@ from solara import Reactive
 from pathlib import Path
 from astropy.table import Table
 
+from hubbleds.components.line_draw_viewer.line_draw_viewer import LineDrawViewer
+
 from ...components import DataTable, HubbleExpUniverseSlideshow
 from ...data_management import *
 from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score
@@ -57,6 +59,7 @@ def _on_galaxy_table_row_selected(row):
 
 @solara.component
 def Page():
+
     # Custom vue-only components have to be registered in the Page element
     #  currently, otherwise they will not be available in the front-end
     load_custom_vue_components()
@@ -69,6 +72,8 @@ def Page():
     mc_scoring, set_mc_scoring  = solara.use_state(LOCAL_STATE.mc_scoring.value)
 
     StateEditor(Marker, component_state)
+    
+    ldv = LineDrawViewer()
 
     # if LOCAL_STATE.debug_mode:
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -74,7 +74,7 @@ def Page():
     StateEditor(Marker, component_state)
     
     x = [0.1 * i for i in range(1, 11)]
-    plot_data = [{ "x": x, "y": [1 / (1 + ((1-t)/t)**2) for t in x], "color": "red", "hoverinfo": "none" }]
+    plot_data = [{ "x": x, "y": [1 / (1 + ((1-t)/t)**2) for t in x], "line": { "color": "red" }, "hoverinfo": "none" }]
     LineDrawViewer(plot_data)
 
     # if LOCAL_STATE.debug_mode:

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -74,7 +74,7 @@ def Page():
     StateEditor(Marker, component_state)
     
     x = [0.1 * i for i in range(1, 11)]
-    plot_data = [{ "x": x, "y": [1 / (1 + ((1-t)/t)**2) for t in x], "line": { "color": "red" }, "hoverinfo": "none" }]
+    plot_data = [{ "x": x, "y": [1 / (1 + ((1-t)/t)**2) for t in x], "mode": "markers", "marker": { "color": "red", "size": 12 }, "hoverinfo": "none" }]
     LineDrawViewer(plot_data)
 
     # if LOCAL_STATE.debug_mode:

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -73,7 +73,7 @@ def Page():
 
     StateEditor(Marker, component_state)
     
-    ldv = LineDrawViewer()
+    LineDrawViewer()
 
     # if LOCAL_STATE.debug_mode:
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -73,7 +73,9 @@ def Page():
 
     StateEditor(Marker, component_state)
     
-    LineDrawViewer()
+    x = [0.1 * i for i in range(1, 11)]
+    plot_data = [{ "x": x, "y": [1 / (1 + ((1-t)/t)**2) for t in x], "color": "red", "hoverinfo": "none" }]
+    LineDrawViewer(plot_data)
 
     # if LOCAL_STATE.debug_mode:
 

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from ...data_management import *
 from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score
 # import for type definitions
-from typing import cast
+from typing import cast, Tuple
 
 from .component_state import ComponentState, Marker
 
@@ -54,14 +54,14 @@ def Page():
     component_state.setup()
     
     # create glue app with the global data collection and session
-    def glue_setup() -> JupyterApplication:
+    def glue_setup() -> Tuple[JupyterApplication, HubbleFitView]:
         gjapp = JupyterApplication(GLOBAL_STATE.data_collection, GLOBAL_STATE.session)
         viewer = gjapp.new_data_viewer(HubbleFitView, show=False)
         viewer.state.title = "Professional Data"
         viewer.figure.update_xaxes(showline=True, mirror=False)
         viewer.figure.update_yaxes(showline=True, mirror=False)
-        return gjapp, viewer
-    gjapp, viewer = cast(JupyterApplication, solara.use_memo(glue_setup,[]))
+        return gjapp, cast(HubbleFitView, viewer)
+    gjapp, viewer = solara.use_memo(glue_setup,[])
     
     # TODO: Should viewer creation happen somewhere else?
     


### PR DESCRIPTION
This PR resolves #391 by implementing the line drawing functionality in Plotly. This requires https://github.com/cosmicds/cosmicds/pull/289 as the bulk of the work here is done using JavaScript. This PR also contains a quick example of passing in some sample data to this viewer as Plotly traces; this still needs to be updated to be the actual data that we want at this point in the story. I just wanted to post this as a PR so that it can be experimented with and we can decide whether we like the UX and interactions.

Here's a quick demo below of this in action. You can only interact with the line when the drawing "tool" is active. The flow is similar to the old bqplot-based tool - first draw a line, and then you can click on the endpoint to make that line movable again.

https://github.com/cosmicds/hubbleds/assets/14281631/b6d4b3ac-88b4-40da-bbcd-28fa20bec743
