### PR TITLE
implement free-response questions

### DIFF
--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -136,7 +136,7 @@
                   <p class="StudentResponses">
                     TODO: add free response box
                 </p>
-                  <!-- <free-response
+                  <free-response
                     outlined
                     auto-grow
                     rows="2"
@@ -144,7 +144,10 @@
                     hint="(if you can think of any more)"
                     tag="shortcoming-4"
                     allow-empty="true"
-                  ></free-response> -->
+                    :initial-response="state_view.free_response_a.response"
+                    :initialized="state_view.free_response_a.initialized"
+                    @fr-emit="fr_callback($event)"
+                  ></free-response>
                 </v-col>
               </v-row>
             </v-container>
@@ -252,14 +255,17 @@
                   <p class="StudentResponses">
                     TODO: add free response box
                   </p>
-                  <!-- <free-response
+                  <free-response
                     outlined
                     auto-grow
                     rows="2"
                     label="Problems in Our Methods"
                     hint="(problems that might lead to systematic uncertainty)"
                     tag="systematic-uncertainty"
-                  ></free-response> -->
+                    :initial-response="state_view.free_response_b.response"
+                    :initialized="state_view.free_response_b.initialized"
+                    @fr-emit="fr_callback($event)"
+                  ></free-response>
                 </v-col>
                 <v-col
                   cols="5"
@@ -407,6 +413,7 @@
     </v-card>
   </v-dialog>
 </template>
+
 
 <style>
   .StudentResponses {

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -143,7 +143,7 @@
                     label="Shortcoming #4"
                     hint="(if you can think of any more)"
                     tag="shortcoming-4"
-                    allow-empty="true"
+                    :allow-empty="true"
                     :initial-response="free_responses[0].response"
                     :initialized="free_responses[0].initialized"
                     @fr-emit="fr_callback($event)"

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -144,8 +144,8 @@
                     hint="(if you can think of any more)"
                     tag="shortcoming-4"
                     allow-empty="true"
-                    :initial-response="state_view.free_response_a.response"
-                    :initialized="state_view.free_response_a.initialized"
+                    :initial-response="free_responses[0].response"
+                    :initialized="free_responses[0].initialized"
                     @fr-emit="fr_callback($event)"
                   ></free-response>
                 </v-col>
@@ -262,8 +262,8 @@
                     label="Problems in Our Methods"
                     hint="(problems that might lead to systematic uncertainty)"
                     tag="systematic-uncertainty"
-                    :initial-response="state_view.free_response_b.response"
-                    :initialized="state_view.free_response_b.initialized"
+                    :initial-response="free_responses[1].response"
+                    :initialized="free_responses[1].initialized"
                     @fr-emit="fr_callback($event)"
                   ></free-response>
                 </v-col>

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -144,8 +144,8 @@
                     hint="(if you can think of any more)"
                     tag="shortcoming-4"
                     :allow-empty="true"
-                    :initial-response="free_responses[0].response"
-                    :initialized="free_responses[0].initialized"
+                    :initial-response="free_responses[0]?.response"
+                    :initialized="free_responses[0]?.initialized"
                     @fr-emit="fr_callback($event)"
                   ></free-response>
                 </v-col>
@@ -262,8 +262,8 @@
                     label="Problems in Our Methods"
                     hint="(problems that might lead to systematic uncertainty)"
                     tag="systematic-uncertainty"
-                    :initial-response="free_responses[1].response"
-                    :initialized="free_responses[1].initialized"
+                    :initial-response="free_responses[1]?.response"
+                    :initialized="free_responses[1]?.initialized"
                     @fr-emit="fr_callback($event)"
                   ></free-response>
                 </v-col>

--- a/src/hubbleds/components/uncertainty_slideshow/uncertainty_slideshow.py
+++ b/src/hubbleds/components/uncertainty_slideshow/uncertainty_slideshow.py
@@ -11,6 +11,8 @@ def UncertaintySlideshow(
     dialog=False,
     image_location=f"{IMAGE_BASE_URL}/stage_five",
     event_on_slideshow_finished=None,
+    event_fr_callback=None,
+    free_responses=[],
     titles = [
                 'What is the true age of the universe?',
                 "Shortcomings in our measurements",

--- a/src/hubbleds/free_response.py
+++ b/src/hubbleds/free_response.py
@@ -38,6 +38,10 @@ class FreeResponse:
 class FreeResponseDict:
     responses: Reactive[Dict[str, FreeResponse]] = dataclasses.field(default_factory=lambda: Reactive({}))
     
+    def __repr__(self) -> str:
+        formatted_responses = {tag: response.toJsonSerializable() for tag, response in self.responses.value.items()}
+        return f"FreeResponseDict({formatted_responses})"
+    
     def add_free_response_question(self, tag):
         """Add a new free response question with the given tag."""
         if tag in self.responses.value:

--- a/src/hubbleds/free_response.py
+++ b/src/hubbleds/free_response.py
@@ -1,0 +1,133 @@
+
+# ==== Free Response State ====
+
+import dataclasses
+from solara import Reactive
+from hubbleds.decorators import computed_property
+
+from typing import Union, Dict
+
+
+@dataclasses.dataclass
+class FreeResponse:
+    tag: str = dataclasses.field(init=True)
+    _response: Reactive[str] = dataclasses.field(default_factory = lambda: Reactive(""))
+    _initialized: Reactive[bool] = dataclasses.field(default_factory = lambda: Reactive(True))
+    
+    def update(self, response: str = ''):
+        # self._response.set(response)
+        self._response.value = response
+    
+    def toJsonSerializable(self):
+        """Convert FreeResponse to a JSON-serializable dictionary."""
+        return {
+            'tag': self.tag,
+            'response': self._response.value,
+            'initialized': self._initialized.value
+        }
+    
+    def __repr__(self):
+        return f"FreeResponse({self.toJsonSerializable()})"
+    
+    @computed_property
+    def completed(self):
+        return self._response.value is not None
+    
+    
+@dataclasses.dataclass
+class FreeResponseDict:
+    responses: Reactive[Dict[str, FreeResponse]] = dataclasses.field(default_factory=lambda: Reactive({}))
+    
+    def add_free_response_question(self, tag):
+        """Add a new free response question with the given tag."""
+        if tag in self.responses.value:
+            raise ValueError(f"Question with tag {tag} already exists")
+        
+        print(f"Adding free response question with tag {tag}")
+        old_responses = self.responses.value
+        old_responses[tag] = FreeResponse(tag)
+        # self.responses.set(old_responses)
+
+            
+    
+    def update_free_response_question(self, tag: str, response: str):
+        if tag not in self.responses.value:
+            raise ValueError(f"Question with tag {tag} does not exist")
+        else:
+            old_responses = self.responses.value
+            # calling update should cause a render as it sets a new value
+            old_responses[tag].update(response = response)
+            
+            # We don't actually need to set the responses, as the FreeResponse contained
+            # is updated in place & we don't need to trigger anything
+            # self.responses.set(old_responses)
+
+
+# Free Response Action Handlers  
+
+def initialize_free_response(free_responses: Union[FreeResponseDict, Reactive[FreeResponseDict]], tag: str):
+    """
+    Initializes the free response feature by adding a free response question to the given `free_responses` object.
+    """
+    print("initializing free response", tag)
+    if isinstance(free_responses, Reactive):
+        free_responses = free_responses.value
+    free_responses.add_free_response_question(tag)
+
+
+def get_free_response(free_responses: Union[FreeResponseDict, Reactive[FreeResponseDict]], tag: str) -> Dict[str, Union[str, bool]]:
+    """
+    `get_free_response` 
+    Retrieves the free response associated with the given tag from the free_responses dictionary.
+    Will create the corresponding free response question if it does not exist.
+
+    Parameters
+    ----------
+    free_responses : FreeResponseDict | Reactive[FreeResponseDict]
+        The free response dictionary or its reactive wrapper.
+    tag : str
+        The tag associated with the free response question.
+
+    Returns
+    -------
+    dictionary
+        {'tag': str, 'response': str, 'initialized': bool}
+    """    
+
+    print("getting free response", tag)
+    if isinstance(free_responses, Reactive):
+        free_responses = free_responses.value
+    
+    if tag not in free_responses.responses.value:
+        print("Need to create it now!")
+        free_responses.add_free_response_question(tag)
+        
+    return free_responses.responses.value[tag].toJsonSerializable()
+    
+    
+def update_free_response(free_responses: Union[FreeResponseDict, Reactive[FreeResponseDict]], tag: str, response: str):
+    """
+    Update the free response for a given tag.
+
+    Parameters
+    ----------
+    free_responses : FreeResponseDict | Reactive[FreeResponseDict]
+        The free response dictionary or its reactive wrapper.
+    tag : str
+        The tag of the free response question to update.
+    response : str
+        The new response to set.
+    """
+    
+    print("updating free response", tag, response)
+    if isinstance(free_responses, Reactive):
+        free_responses = free_responses.value
+    
+    if tag not in free_responses.responses.value:
+        raise ValueError(f"Free response question with tag {tag} does not exist")
+    
+    # this will trigger a render from within the FreeResponse class
+    free_responses.update_free_response_question(tag, response)
+
+        
+    

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 
 from ...components import DataTable, HubbleExpUniverseSlideshow
 from ...data_management import *
-from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score
+from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score, get_free_response, fr_callback
 from ...utils import AGE_CONSTANT
 from ...widgets.selection_tool import SelectionTool
 from ...data_models.student import student_data, StudentMeasurement, example_data
@@ -237,6 +237,12 @@ def Page():
                 event_back_callback=lambda *args: component_state.transition_previous(),
                 can_advance=component_state.can_transition(next=True),
                 show=component_state.is_current_step(Marker.sho_est1),
+                event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                state_view={
+                    'free_response_a': get_free_response(LOCAL_STATE.free_responses,'shortcoming-1'),
+                    'free_response_b': get_free_response(LOCAL_STATE.free_responses,'shortcoming-2'),
+                    'free_response_c': get_free_response(LOCAL_STATE.free_responses,'other-shortcomings'),
+                }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineShortcomingsEst2.vue",

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineShortcomingsEstReflect1.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineShortcomingsEstReflect1.vue
@@ -41,7 +41,7 @@
         :initial-response="state_view.free_response_c.response"
         :initialized="state_view.free_response_c.initialized"
         @fr-emit="fr_callback($event)"
-        allow-empty="true"
+        :allow-empty="true"
       ></free-response>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineShortcomingsEstReflect1.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineShortcomingsEstReflect1.vue
@@ -17,6 +17,9 @@
         rows="2"
         label="Shortcoming #1"
         tag="shortcoming-1"
+        :initial-response="state_view.free_response_a.response"
+        :initialized="state_view.free_response_a.initialized"
+        @fr-emit="fr_callback($event)"
       ></free-response>
       <free-response
         outlined
@@ -24,6 +27,9 @@
         rows="2"
         label="Shortcoming #2"
         tag="shortcoming-2"
+        :initial-response="state_view.free_response_b.response"
+        :initialized="state_view.free_response_b.initialized"
+        @fr-emit="fr_callback($event)"
       ></free-response>
       <free-response
         outlined
@@ -32,8 +38,13 @@
         label="Other Shortcomings"
         hint="(if you can think of any more)"
         tag="other-shortcomings"
+        :initial-response="state_view.free_response_c.response"
+        :initialized="state_view.free_response_c.initialized"
+        @fr-emit="fr_callback($event)"
         allow-empty="true"
       ></free-response>
     </div>
   </scaffold-alert>
 </template>
+<script>
+</script>

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -12,7 +12,7 @@ from hubbleds.components.id_slider import IdSlider
 from hubbleds.marker_base import MarkerBase
 from ...components import UncertaintySlideshow
 
-from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score
+from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score, get_free_response, fr_callback
 from .component_state import ComponentState, Marker
 
 
@@ -366,8 +366,11 @@ def Page():
         event_back_callback=transition_previous,
         can_advance=component_state.can_transition(next=True),
         show=component_state.is_current_step(Marker.mos_lik4),
+        event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
         state_view={
-            "hint1_dialog": component_state.age_calc_state.hint1_dialog.value
+            "hint1_dialog": component_state.age_calc_state.hint1_dialog.value,
+            'free_response_a': get_free_response(LOCAL_STATE.free_responses,'best-guess-age'),
+            'free_response_b': get_free_response(LOCAL_STATE.free_responses,'my-reasoning')
         }
     )
 
@@ -377,8 +380,12 @@ def Page():
         event_back_callback=transition_previous,
         can_advance=component_state.can_transition(next=True),
         show=component_state.is_current_step(Marker.con_int3),
+        event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
         state_view={
-            "hint2_dialog": component_state.age_calc_state.hint2_dialog.value
+            "hint2_dialog": component_state.age_calc_state.hint2_dialog.value,
+            'free_response_a': get_free_response(LOCAL_STATE.free_responses,'likely-low-age'),
+            'free_response_b': get_free_response(LOCAL_STATE.free_responses,'likely-high-age'),
+            'free_response_c': get_free_response(LOCAL_STATE.free_responses,'my-reasoning-2'),
         }
     )
 
@@ -440,6 +447,10 @@ def Page():
                     event_back_callback=transition_previous,
                     can_advance=component_state.can_transition(next=True),
                     show=component_state.is_current_step(Marker.two_his5),
+                    event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                    state_view={
+                        'free_response': get_free_response(LOCAL_STATE.free_responses,'unc-range-change-reasoning'),
+                    }
                 )
                 ScaffoldAlert(
                     # TODO: event_next_callback should go to next stage but I don't know how to set that up.
@@ -463,11 +474,16 @@ def Page():
             event_back_callback=transition_previous,
             can_advance=component_state.can_transition(next=True),
             show=component_state.is_current_step(Marker.con_int2c),
+            event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
             state_view={
                 "hint1_dialog": component_state.age_calc_state.hint1_dialog.value,
                 "hint2_dialog": component_state.age_calc_state.hint2_dialog.value,
                 "low_guess": component_state.age_calc_state.low_guess.value,
                 "high_guess": component_state.age_calc_state.high_guess.value,
                 "best_guess": component_state.age_calc_state.best_guess.value,
+                'free_response_a': get_free_response(LOCAL_STATE.free_responses,'new-most-likely-age'),
+                'free_response_b': get_free_response(LOCAL_STATE.free_responses,'new-likely-low-age'),
+                'free_response_c': get_free_response(LOCAL_STATE.free_responses,'new-likely-high-age'),
+                'free_response_d': get_free_response(LOCAL_STATE.free_responses,'my-updated-reasoning'),
             }
         )       

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -302,7 +302,10 @@ def Page():
                     step=component_state.uncertainty_state.step.value,
                     age_calc_short1=component_state.age_calc_state.short_one.value,
                     age_calc_short2=component_state.age_calc_state.short_two.value,
-                    age_calc_short_other=component_state.age_calc_state.short_other.value,                    
+                    age_calc_short_other=component_state.age_calc_state.short_other.value,  
+                    event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                    free_responses=[get_free_response(LOCAL_STATE.free_responses,'shortcoming-4'),
+                                    get_free_response(LOCAL_STATE.free_responses,'systematic-uncertainty')]               
                 )
 
     

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
@@ -79,13 +79,16 @@
           <p class="StudentResponses">
             TODO: add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             rows="1"
             label="New Most Likely Age"
             tag="new-most-likely-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_a.response"
+            :initialized="state_view.free_response_a.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col>
           Gyr
@@ -160,13 +163,16 @@
           <p class="StudentResponses">
             TODO: add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             rows="1"
             label="New Likely Low Age"
             tag="new-likely-low-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_b.response"
+            :initialized="state_view.free_response_b.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col
           lg="2">
@@ -178,13 +184,16 @@
           <p class="StudentResponses">
             TODO: add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             rows="1"
             label="New Likely High Age"
             tag="new-likely-high-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_c.response"
+            :initialized="state_view.free_response_c.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col
           lg="2">
@@ -198,13 +207,17 @@
       <p class="StudentResponses">
             TODO: add free response box
           </p>
-      <!-- <free-response
+      <free-response
         outlined
         rows="1"
         label="My Updated Reasoning"
         tag="my-updated-reasoning"
-      ></free-response> -->
+        :initial-response="state_view.free_response_d.response"
+        :initialized="state_view.free_response_d.initialized"
+        @fr-emit="fr_callback($event)"
+      ></free-response>
     </div>
   </scaffold-alert>
 </template>
-
+<script>
+</script>

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
@@ -91,13 +91,16 @@
           <p class="StudentResponses">
             add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             rows="1"
             label="Likely Low Age"
             tag="likely-low-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_a.response"
+            :initialized="state_view.free_response_a.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col
           lg="2">
@@ -109,13 +112,16 @@
           <p class="StudentResponses">
             TODO: add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             rows="1"
             label="Likely High Age"
             tag="likely-high-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_b.response"
+            :initialized="state_view.free_response_b.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col
           lg="2">
@@ -137,13 +143,16 @@
           <p class="StudentResponses">
             TODO: add free response box
           </p>
-          <!-- <free-response
+          <free-response
             outlined
             auto-grow
             rows="2"
             label="My Reasoning"
             tag="my-reasoning-2"
-          ></free-response> -->
+            :initial-response="state_view.free_response_c.response"
+            :initialized="state_view.free_response_c.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
       </v-row>
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
@@ -83,13 +83,16 @@
         <p class="StudentResponses">
             TODO: add free response box
         </p>
-        <!-- <free-response
+        <free-response
             outlined
             rows="1"
             label="Most Likely Age"
             tag="best-guess-age"
             type="float"
-          ></free-response> -->
+            :initial-response="state_view.free_response_a.response"
+            :initialized="state_view.free_response_a.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
         <v-col>
           Gyr
@@ -112,13 +115,16 @@
             TODO: add free response box
           </p>
 
-          <!-- <free-response
+          <free-response
             outlined
             auto-grow
             rows="2"
             label="My Reasoning"
             tag="my-reasoning"
-          ></free-response> -->
+            :initial-response="state_view.free_response_b.response"
+            :initialized="state_view.free_response_b.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
         </v-col>
       </v-row>
     </div>

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
@@ -17,14 +17,17 @@
       <p class="StudentResponses">
           TODO: add free response box
       </p>
-<!-- 
+
           <free-response
             outlined
             auto-grow
             rows="2"
             label="My Reasoning"
-            tag="unc-range-change-reasoning"
-          ></free-response> -->
+            :tag="state_view.free_response.tag"
+            :initial-response="state_view.free_response.response"
+            :initialized="state_view.free_response.initialized"
+            @fr-emit="fr_callback($event)"
+          ></free-response>
     </div>
     <v-btn
       color="secondary lighten-1"

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -18,7 +18,7 @@ from solara import Reactive
 from pathlib import Path
 
 from ...data_management import *
-from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score
+from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score, get_free_response, fr_callback
 # import for type definitions
 from typing import cast
 
@@ -81,6 +81,8 @@ def Page():
 
         mc-scoring: {mc_scoring}  
 
+        free-responses: {LOCAL_STATE.free_responses.value}
+
         """
     )
     
@@ -130,7 +132,10 @@ def Page():
                 can_advance=component_state.can_transition(next=True),
                 show=component_state.is_current_step(Marker.pro_dat4),
                 event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat4')), 'score_tag': 'pro-dat4'}
+                event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat4')), 'score_tag': 'pro-dat4',
+                            'free_response': get_free_response(LOCAL_STATE.free_responses,'prodata-free-4')
+                            }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData5.vue",
@@ -160,7 +165,9 @@ def Page():
                 can_advance=component_state.can_transition(next=True),
                 show=component_state.is_current_step(Marker.pro_dat7),
                 event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat7')), 'score_tag': 'pro-dat7'}
+                event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat7')), 'score_tag': 'pro-dat7', 
+                            'free_response': get_free_response(LOCAL_STATE.free_responses,'prodata-free-7')}
                 
             )
             ScaffoldAlert(
@@ -169,6 +176,12 @@ def Page():
                 event_back_callback=lambda *args: component_state.transition_previous(),
                 can_advance=component_state.can_transition(next=True),
                 show=component_state.is_current_step(Marker.pro_dat8),
+                event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                state_view={
+                    'free_response_a': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8a'),
+                    'free_response_b': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8b'),
+                    'free_response_c': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8c'),
+                }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData9.vue",

--- a/src/hubbleds/pages/06-prodata/component_state.py
+++ b/src/hubbleds/pages/06-prodata/component_state.py
@@ -31,7 +31,7 @@ class Marker(enum.Enum, MarkerBase):
     
 @dataclasses.dataclass
 class ComponentState(BaseComponentState):
-    current_step: Reactive[Marker] = dataclasses.field(default=Reactive(Marker.pro_dat0))
+    current_step: Reactive[Marker] = dataclasses.field(default=Reactive(Marker.pro_dat7))
     
     hst_age: float = dataclasses.field(default=HST_KEY_AGE) # a constant value
     

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
@@ -40,7 +40,7 @@
         :tag="state_view.free_response.tag"
         :initial-response="state_view.free_response.response"
         :initialized="state_view.free_response.initialized"
-        @fr-update="fr_callback(['fr-update',$event])"
+        @fr-emit="fr_callback($event)"
         v-if="question_completed"
       ></free-response>
     </div>

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
@@ -37,6 +37,10 @@
         rows="2"
         label="Why?"
         tag="prodata-free-4"
+        :tag="state_view.free_response.tag"
+        :initial-response="state_view.free_response.response"
+        :initialized="state_view.free_response.initialized"
+        @fr-update="fr_callback(['fr-update',$event])"
         v-if="question_completed"
       ></free-response>
     </div>

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
@@ -31,9 +31,12 @@
       <free-response
         outlined
         auto-grow
-        rows="2"
+        :rows="2"
         label="Why?"
-        tag="prodata-free-7"
+        :tag="state_view.free_response.tag"
+        :initial-response="state_view.free_response.response"
+        :initialized="state_view.free_response.initialized"
+        @fr-update="fr_callback(['fr-update',$event])"
         v-if="question_completed"
       ></free-response>
     </div>

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
@@ -36,7 +36,7 @@
         :tag="state_view.free_response.tag"
         :initial-response="state_view.free_response.response"
         :initialized="state_view.free_response.initialized"
-        @fr-update="fr_callback(['fr-update',$event])"
+        @fr-emit="fr_callback($event)"
         v-if="question_completed"
       ></free-response>
     </div>

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
@@ -28,7 +28,7 @@
         :tag="state_view.free_response_a.tag"
         :initial-response="state_view.free_response_a.response"
         :initialized="state_view.free_response_a.initialized"
-        @fr-update="fr_callback(['fr-update',$event])"
+        @fr-emit="fr_callback($event)"
       ></free-response>
       
       <p>What age of the universe can be obtained from Edwin Hubble's data (in Gyr)?</p>
@@ -42,7 +42,7 @@
         :tag="state_view.free_response_b.tag"
         :initial-response="state_view.free_response_b.response"
         :initialized="state_view.free_response_b.initialized"
-        @fr-update="fr_callback(['fr-update',$event])"
+        @fr-emit="fr_callback($event)"
       ></free-response>
       
     <p>What age of the universe can be obtained from the HST Key project's data (in Gyr)?</p>
@@ -56,7 +56,7 @@
         :tag="state_view.free_response_c.tag"
         :initial-response="state_view.free_response_c.response"
         :initialized="state_view.free_response_c.initialized"
-        @fr-update="fr_callback(['fr-update',$event])"
+        @fr-emit="fr_callback($event)"
       ></free-response>
       </v-container>
     </div>

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
@@ -25,6 +25,10 @@
         rows="2"
         label="Reflection #1"
         tag="prodata-reflect-8a"
+        :tag="state_view.free_response_a.tag"
+        :initial-response="state_view.free_response_a.response"
+        :initialized="state_view.free_response_a.initialized"
+        @fr-update="fr_callback(['fr-update',$event])"
       ></free-response>
       
       <p>What age of the universe can be obtained from Edwin Hubble's data (in Gyr)?</p>
@@ -35,6 +39,10 @@
         label="Age from Edwin Hubble"
         tag="prodata-reflect-8b"
         type="float"
+        :tag="state_view.free_response_b.tag"
+        :initial-response="state_view.free_response_b.response"
+        :initialized="state_view.free_response_b.initialized"
+        @fr-update="fr_callback(['fr-update',$event])"
       ></free-response>
       
     <p>What age of the universe can be obtained from the HST Key project's data (in Gyr)?</p>
@@ -45,6 +53,10 @@
         label="Age from HST Key Project"
         tag="prodata-reflect-8c"
         type="float"
+        :tag="state_view.free_response_c.tag"
+        :initial-response="state_view.free_response_c.response"
+        :initialized="state_view.free_response_c.initialized"
+        @fr-update="fr_callback(['fr-update',$event])"
       ></free-response>
       </v-container>
     </div>

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -131,13 +131,23 @@ def mc_serialize_score(mc_score = None):
 
     
 
-def fr_callback(event: Tuple[str,dict[str,str]], local_state: LocalState, callback: Optional[Callable] = None):
+def fr_callback(event: Tuple[str,dict[str,str]], local_state: LocalState, response_callback: Optional[Callable] = None):
+    """
+    Free Response callback function
+    
+    response_callback: Optional callback that takes in the response as an argument
+        An example would be to set a value 
+    
+    """
     print("fr_callback", event)
     if event[0] == 'fr-initialize':
         # by using get_free_response in the Page, we can avoid separetely initializing the free response
         # initialize_free_response(local_state.free_responses, tag=event[1]['tag'])
         pass
     elif event[0] == 'fr-update':
-        return update_free_response(local_state.free_responses, tag=event[1]['tag'], response=event[1]['response'])
+        update_free_response(local_state.free_responses, tag=event[1]['tag'], response=event[1]['response'])
+        if response_callback is not None:
+            if (len(event)> 1) and ('response' in event[1]):
+                response_callback(event[1]['response'])
     else:
         raise ValueError(f"Unknown event in fr_callback: <<{event}>> ")


### PR DESCRIPTION
This implements the free response component (in combination with https://github.com/cosmicds/cosmicds/pull/290). This uses `get_free_response` to initialize and pass values to the free-response and `fr_callback` to handle events. 

There are two issues:

**Flickering** One issue, is that it flickers each time we remove focus from the text element. The reason is that the entered value is sent to the backend when the text element is defocused. This triggers a render. This is a problem if the user clicks "next" right after entering their value, as the "blur" event occurs first, followed by re-rendering, and so the "next" is not completed. Then "next" must be pressed again. I am not quite sure the best way around this. 

**Error state doesn't persist** after text box loses focus. The error state (check `pro_dat8`) goes away when not focused and then is inconsistent if you enter/leave it