### PR TITLE
Fix free response reactives

### DIFF
--- a/src/hubbleds/free_response.py
+++ b/src/hubbleds/free_response.py
@@ -11,8 +11,8 @@ from typing import Union, Dict
 @dataclasses.dataclass
 class FreeResponse:
     tag: str = dataclasses.field(init=True)
-    _response: str = dataclasses.field(default_factory = lambda: "")
-    _initialized: bool = dataclasses.field(default_factory = lambda: True)
+    _response: str = dataclasses.field(default = "")
+    _initialized: bool = dataclasses.field(default = True)
     
     def update(self, response: str = ''):
         # self._response.set(response)

--- a/src/hubbleds/free_response.py
+++ b/src/hubbleds/free_response.py
@@ -36,7 +36,7 @@ class FreeResponse:
     
 @dataclasses.dataclass
 class FreeResponseDict:
-    responses: Reactive[Dict[str, FreeResponse]] = dataclasses.field(default_factory=lambda: Reactive({}))
+    responses: Reactive[Dict[str, FreeResponse]] = dataclasses.field(default = Reactive({}))
     
     def __repr__(self) -> str:
         formatted_responses = {tag: response.toJsonSerializable() for tag, response in self.responses.value.items()}

--- a/src/hubbleds/free_response.py
+++ b/src/hubbleds/free_response.py
@@ -11,19 +11,19 @@ from typing import Union, Dict
 @dataclasses.dataclass
 class FreeResponse:
     tag: str = dataclasses.field(init=True)
-    _response: Reactive[str] = dataclasses.field(default_factory = lambda: Reactive(""))
-    _initialized: Reactive[bool] = dataclasses.field(default_factory = lambda: Reactive(True))
+    _response: str = dataclasses.field(default_factory = lambda: "")
+    _initialized: bool = dataclasses.field(default_factory = lambda: True)
     
     def update(self, response: str = ''):
         # self._response.set(response)
-        self._response.value = response
+        self._response = response
     
     def toJsonSerializable(self):
         """Convert FreeResponse to a JSON-serializable dictionary."""
         return {
             'tag': self.tag,
-            'response': self._response.value,
-            'initialized': self._initialized.value
+            'response': self._response,
+            'initialized': self._initialized
         }
     
     def __repr__(self):
@@ -31,7 +31,7 @@ class FreeResponse:
     
     @computed_property
     def completed(self):
-        return self._response.value is not None
+        return self._response is not ""
     
     
 @dataclasses.dataclass

--- a/src/hubbleds/pages/06-prodata/component_state.py
+++ b/src/hubbleds/pages/06-prodata/component_state.py
@@ -31,7 +31,7 @@ class Marker(enum.Enum, MarkerBase):
     
 @dataclasses.dataclass
 class ComponentState(BaseComponentState):
-    current_step: Reactive[Marker] = dataclasses.field(default=Reactive(Marker.pro_dat7))
+    current_step: Reactive[Marker] = dataclasses.field(default=Reactive(Marker.pro_dat0))
     
     hst_age: float = dataclasses.field(default=HST_KEY_AGE) # a constant value
     


### PR DESCRIPTION
The cause of the need to double-click the next button (#409) to advance was due to `FreeResponse` having reactive variables. The response does not have to be reactive. All error state handling is done on the front end, and the  Free Response dataclass just stores the answers. This should fix #409