### PR TITLE
Connect free response inputs to guidelines

### DIFF
--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -133,9 +133,6 @@
                   <p class="mt-10">
                     Is there anything more you would like to add now that you’ve seen more data? (It’s OK if not.)
                   </p>
-                  <p class="StudentResponses">
-                    TODO: add free response box
-                </p>
                   <free-response
                     outlined
                     auto-grow
@@ -251,9 +248,6 @@
                   </p>
                   <p>
                     Can you think of any problems in our methods that could bias everyone’s results in the same direction?
-                  </p>
-                  <p class="StudentResponses">
-                    TODO: add free response box
                   </p>
                   <free-response
                     outlined

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -133,9 +133,9 @@ def Page():
                     can_advance=component_state.can_transition(next=True),
                     show=component_state.is_current_step(Marker.you_age1c),
                     state_view={
-                        "low_guess": component_state.age_calc_state.low_guess.value,
-                        "high_guess": component_state.age_calc_state.high_guess.value,
-                        "best_guess": component_state.age_calc_state.best_guess.value,
+                        "low_guess": get_free_response(LOCAL_STATE.free_responses, "likely-low-age").get("response"),
+                        "high_guess": get_free_response(LOCAL_STATE.free_responses, "likely-high-age").get("response"),
+                        "best_guess": get_free_response(LOCAL_STATE.free_responses, "best-guess-age").get("response"),
                     }                    
                 )
 
@@ -486,9 +486,9 @@ def Page():
             state_view={
                 "hint1_dialog": component_state.age_calc_state.hint1_dialog.value,
                 "hint2_dialog": component_state.age_calc_state.hint2_dialog.value,
-                "low_guess": component_state.age_calc_state.low_guess.value,
-                "high_guess": component_state.age_calc_state.high_guess.value,
-                "best_guess": component_state.age_calc_state.best_guess.value,
+                "low_guess": get_free_response(LOCAL_STATE.free_responses, "likely-low-age").get("response"),
+                "high_guess": get_free_response(LOCAL_STATE.free_responses, "likely-high-age").get("response"),
+                "best_guess": get_free_response(LOCAL_STATE.free_responses, "best-guess-age").get("response"),
                 'free_response_a': get_free_response(LOCAL_STATE.free_responses,'new-most-likely-age'),
                 'free_response_b': get_free_response(LOCAL_STATE.free_responses,'new-likely-low-age'),
                 'free_response_c': get_free_response(LOCAL_STATE.free_responses,'new-likely-high-age'),

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -15,6 +15,9 @@ from ...components import UncertaintySlideshow
 from ...state import GLOBAL_STATE, LOCAL_STATE, mc_callback, mc_serialize_score, get_free_response, fr_callback
 from .component_state import ComponentState, Marker
 
+from cosmicds.components import MathJaxSupport, PlotlySupport
+
+
 
 GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 
@@ -50,6 +53,13 @@ def Page():
 
 
     gjapp, viewer, test_data, test_subset = solara.use_memo(glue_setup, [])
+    
+    # Mount external javascript libraries
+    def _load_math_jax():
+        MathJaxSupport()
+        PlotlySupport()
+
+    solara.use_memo(_load_math_jax, dependencies=[])
 
     mc_scoring, set_mc_scoring = solara.use_state(LOCAL_STATE.mc_scoring.value)
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -257,15 +257,22 @@ def Page():
                         )
                     solara.Button("test slider viewer", on_click=toggle_viewer)
 
-                if component_state.current_step_between(Marker.lea_unc1, Marker.you_age1c):
+    if component_state.current_step_between(Marker.lea_unc1, Marker.you_age1c):
+        with solara.ColumnsResponsive(12, large=[5,7]):
+            with rv.Col():
+                pass
+            with rv.Col():
+                with rv.Col(cols=10, offset=1):
                     UncertaintySlideshow(
                         event_on_slideshow_finished=lambda *args: component_state.uncertainty_slideshow_finished.set(
                             True
                         ),
                         step=component_state.uncertainty_state.step.value,
-                        age_calc_short1=component_state.age_calc_state.short_one.value,
-                        age_calc_short2=component_state.age_calc_state.short_two.value,
-                        age_calc_short_other=component_state.age_calc_state.short_other.value,                    
+                        age_calc_short1=get_free_response(LOCAL_STATE.free_responses, "shortcoming-1").get("response"),
+                        age_calc_short2=get_free_response(LOCAL_STATE.free_responses, "shortcoming-2").get("response"),
+                        age_calc_short_other=get_free_response(LOCAL_STATE.free_responses, "other-shortcomings").get("response"),    
+                        event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                        free_responses=[get_free_response(LOCAL_STATE.free_responses,'shortcoming-4'), get_free_response(LOCAL_STATE.free_responses,'systematic-uncertainty')]   
                     )
 
     #--------------------- Row 3: ALL DATA HUBBLE VIEWER - during class sequence -----------------------
@@ -295,20 +302,18 @@ def Page():
                 with solara.Card(style="background-color: #F06292;"):
                     solara.Markdown("All viewer with slider goes here")
 
-                UncertaintySlideshow(
-                    event_on_slideshow_finished=lambda *args: component_state.uncertainty_slideshow_finished.set(
-                        True
-                    ),
-                    step=component_state.uncertainty_state.step.value,
-                    age_calc_short1=component_state.age_calc_state.short_one.value,
-                    age_calc_short2=component_state.age_calc_state.short_two.value,
-                    age_calc_short_other=component_state.age_calc_state.short_other.value,  
-                    event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
-                    free_responses=[get_free_response(LOCAL_STATE.free_responses,'shortcoming-4'),
-                                    get_free_response(LOCAL_STATE.free_responses,'systematic-uncertainty')]               
-                )
-
-    
+                with rv.Col(cols=10, offset=1):
+                    UncertaintySlideshow(
+                        event_on_slideshow_finished=lambda *args: component_state.uncertainty_slideshow_finished.set(
+                            True
+                        ),
+                        step=component_state.uncertainty_state.step.value,
+                        age_calc_short1=get_free_response(LOCAL_STATE.free_responses, "shortcoming-1").get("response"),
+                        age_calc_short2=get_free_response(LOCAL_STATE.free_responses, "shortcoming-2").get("response"),
+                        age_calc_short_other=get_free_response(LOCAL_STATE.free_responses, "other-shortcomings").get("response"),  
+                        event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                        free_responses=[get_free_response(LOCAL_STATE.free_responses,'shortcoming-4'), get_free_response(LOCAL_STATE.free_responses,'systematic-uncertainty')]               
+                    )
 
     #--------------------- Row 4: OUR CLASS HISTOGRAM VIEWER -----------------------
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -69,9 +69,6 @@ class AgeCalcState:
     hint1_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
     hint2_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
     hint3_dialog: Reactive[bool] = dataclasses.field(default=Reactive(False))
-    best_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
-    low_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
-    high_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
 
 @dataclasses.dataclass
 class ComponentState(BaseComponentState):

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -72,10 +72,6 @@ class AgeCalcState:
     best_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
     low_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
     high_guess: Reactive[int] = dataclasses.field(default=Reactive(0))
-    short_one: Reactive[str] = dataclasses.field(default=Reactive("dummy shortcoming 1"))
-    short_two: Reactive[str] = dataclasses.field(default=Reactive("dummy shortcoming 2"))
-    short_other: Reactive[str] = dataclasses.field(default=Reactive("dummy shortcoming other"))
-
 
 @dataclasses.dataclass
 class ComponentState(BaseComponentState):

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
@@ -76,9 +76,6 @@
           cols="12"
           lg="3"
         >
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
           <free-response
             outlined
             rows="1"
@@ -160,9 +157,6 @@
         <v-col
           cols="12"
           lg="3">
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
           <free-response
             outlined
             rows="1"
@@ -181,9 +175,6 @@
               <v-col
           cols="12"
           lg="3">
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
           <free-response
             outlined
             rows="1"
@@ -204,9 +195,6 @@
       <p class="mt-4">
         3. Explain why you chose these new values based on the All Classes data:
       </p>
-      <p class="StudentResponses">
-            TODO: add free response box
-          </p>
       <free-response
         outlined
         rows="1"

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
@@ -88,9 +88,6 @@
         <v-col
           cols="12"
           lg="3">
-          <p class="StudentResponses">
-            add free response box
-          </p>
           <free-response
             outlined
             rows="1"
@@ -109,9 +106,6 @@
               <v-col
           cols="12"
           lg="3">
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
           <free-response
             outlined
             rows="1"
@@ -140,9 +134,6 @@
         v-if="revealIter >= 1"
       >
         <v-col>
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
           <free-response
             outlined
             auto-grow

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
@@ -80,10 +80,7 @@
           cols="12"
           lg="3"
         >
-        <p class="StudentResponses">
-            TODO: add free response box
-        </p>
-        <free-response
+          <free-response
             outlined
             rows="1"
             label="Most Likely Age"
@@ -111,10 +108,6 @@
         v-if="revealIter >= 1"
       >
         <v-col>
-          <p class="StudentResponses">
-            TODO: add free response box
-          </p>
-
           <free-response
             outlined
             auto-grow

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
@@ -14,20 +14,16 @@
       <p>
         Explain why you think this might be true.
       </p>
-      <p class="StudentResponses">
-          TODO: add free response box
-      </p>
-
-          <free-response
-            outlined
-            auto-grow
-            rows="2"
-            label="My Reasoning"
-            :tag="state_view.free_response.tag"
-            :initial-response="state_view.free_response.response"
-            :initialized="state_view.free_response.initialized"
-            @fr-emit="fr_callback($event)"
-          ></free-response>
+      <free-response
+        outlined
+        auto-grow
+        rows="2"
+        label="My Reasoning"
+        :tag="state_view.free_response.tag"
+        :initial-response="state_view.free_response.response"
+        :initialized="state_view.free_response.initialized"
+        @fr-emit="fr_callback($event)"
+      ></free-response>
     </div>
     <v-btn
       color="secondary lighten-1"

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
@@ -18,46 +18,46 @@
         fluid
       >
       
-      <p> What did astronomers in the early 1920's believe about the universe before Edwin Hubble's discovery?</p>
-      <free-response
-        outlined
-        auto-grow
-        rows="2"
-        label="Reflection #1"
-        tag="prodata-reflect-8a"
-        :tag="state_view.free_response_a.tag"
-        :initial-response="state_view.free_response_a.response"
-        :initialized="state_view.free_response_a.initialized"
-        @fr-emit="fr_callback($event)"
-      ></free-response>
-      
-      <p>What age of the universe can be obtained from Edwin Hubble's data (in Gyr)?</p>
-      <free-response
-        outlined
-        auto-grow
-        rows="2"
-        label="Age from Edwin Hubble"
-        tag="prodata-reflect-8b"
-        type="float"
-        :tag="state_view.free_response_b.tag"
-        :initial-response="state_view.free_response_b.response"
-        :initialized="state_view.free_response_b.initialized"
-        @fr-emit="fr_callback($event)"
-      ></free-response>
-      
-    <p>What age of the universe can be obtained from the HST Key project's data (in Gyr)?</p>
-      <free-response
-        outlined
-        auto-grow
-        rows="2"
-        label="Age from HST Key Project"
-        tag="prodata-reflect-8c"
-        type="float"
-        :tag="state_view.free_response_c.tag"
-        :initial-response="state_view.free_response_c.response"
-        :initialized="state_view.free_response_c.initialized"
-        @fr-emit="fr_callback($event)"
-      ></free-response>
+        <p> What did astronomers in the early 1920's believe about the universe before Edwin Hubble's discovery?</p>
+        <free-response
+          outlined
+          auto-grow
+          rows="2"
+          label="Reflection #1"
+          tag="prodata-reflect-8a"
+          :tag="state_view.free_response_a.tag"
+          :initial-response="state_view.free_response_a.response"
+          :initialized="state_view.free_response_a.initialized"
+          @fr-emit="fr_callback($event)"
+        ></free-response>
+        
+        <p>What age of the universe can be obtained from Edwin Hubble's data (in Gyr)?</p>
+        <free-response
+          outlined
+          auto-grow
+          rows="2"
+          label="Age from Edwin Hubble"
+          tag="prodata-reflect-8b"
+          type="float"
+          :tag="state_view.free_response_b.tag"
+          :initial-response="state_view.free_response_b.response"
+          :initialized="state_view.free_response_b.initialized"
+          @fr-emit="fr_callback($event)"
+        ></free-response>
+        
+        <p>What age of the universe can be obtained from the HST Key project's data (in Gyr)?</p>
+        <free-response
+          outlined
+          auto-grow
+          rows="2"
+          label="Age from HST Key Project"
+          tag="prodata-reflect-8c"
+          type="float"
+          :tag="state_view.free_response_c.tag"
+          :initial-response="state_view.free_response_c.response"
+          :initialized="state_view.free_response_c.initialized"
+          @fr-emit="fr_callback($event)"
+        ></free-response>
       </v-container>
     </div>
   </scaffold-alert>


### PR DESCRIPTION
This PR fixes the guidelines that display the free responses the user input in earlier guidelines. We are now reading the responses directly from `LOCAL_STATE.free_responses` so we don't need to include duplicate reactive variables in the component_state.

I also fixed a minor layout issue in Stage 5 where the uncertainty slideshow button was disappearing when it wasn't supposed to.