### PR TITLE
Fix update galaxy reference

### DIFF
--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -318,7 +318,7 @@ def Page():
             if component_state.current_step_at_or_before(Marker.dot_seq7):
                 def update_example_galaxy(galaxy):
                     flag = galaxy.get("value", True)
-                    value = galaxy["item"] if flag else None
+                    value = galaxy["item"]["galaxy"] if flag else None
                     component_state.selected_example_galaxy.set(value)
 
                 @solara.lab.computed
@@ -337,7 +337,7 @@ def Page():
             else:
                 def update_galaxy(galaxy):
                     flag = galaxy.get("value", True)
-                    value = galaxy["item"] if flag else None
+                    value = galaxy["item"]["galaxy"] if flag else None
                     component_state.selected_galaxy.set(value)
 
                 @solara.lab.computed


### PR DESCRIPTION
fixes an error where `galaxy["ra"]` raised an error because the `example_galaxy` data model had changed. Galaxy info like `ra`, `decl`, etc are in `galaxy["item"]["galaxy"]` rather than `galaxy["item"]`