### PR TITLE
Improve light/dark theme functionality

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -1,68 +1,78 @@
 :root {
-    /* define light material desing them */
-    --primary-light: #1565C0 ;
-    --secondary-light: #006064 ;
-    --accent-light: #FFD740 ;
-    --error-light: #F06292 ;
-    --info-light: #FF7043 ;
-    --success-light: #388E3C  ;
-    --warning-light: #DD2C00 ;
+    --primary-dark: #0D47A1;
+    --secondary-dark: #00838F;
+    --accent-dark: #FFC400;
+    --error-dark: #D81B60;
+    --info-dark: #BF360C;
+    --success-dark: #00E676;
+    --warning-dark: #DD2C00;
     
-    /* define dark material desing them */
-    --primary-dark: #0D47A1 ;
-    --secondary-dark: #00838F ;
-    --accent-dark: #FFC400 ;
-    --error-dark: #D81B60 ;
-    --info-dark: #BF360C ;
-    --success-dark: #00E676 ;
-    --warning-dark: #DD2C00 ;
+    --primary-light: #1565C0;
+    --secondary-light: #006064;
+    --accent-light: #FFD740;
+    --error-light: #F06292;
+    --info-light: #FF7043;
+    --success-light: #388E3C;
+    --warning-light: #DD2C00;
     
-    --cosmic-red: #e60001 ;
-    --cosmic-blue: #0e397e ;
-    
-    --cosmic-red-lighter: #ff4d4d ;
-    --cosmic-blue-lighter: #1861d8 ;
-    
-    --cosmic-red-darker: #800000 ;
-    --cosmic-blue-darker: #09234e ;
-    
-    
+    --cosmicds-red: #E60001;
+    --cosmicds-blue: #0F3A7E;
+
+    --cosmicds-red-lighter: #ff4e4e;
+    --cosmicds-blue-lighter: #1a63d9;
 }
 
-/* media query preferes light color scheme */
-@media (prefers-color-scheme: light) {
-    :root {
-        --primary: var(--primary-light);
-        --secondary: var(--secondary-light);
-        --accent: var(--accent-light);
-        --error: var(--error-light);
-        --info: var(--info-light);
-        --success: var(--success-light);
-        --warning: var(--warning-light);
-    }
-}
-
-/* media query prefers dark color scheme */
-@media (prefers-color-scheme: dark) {
-    :root {
-        --primary: var(--primary-dark);
-        --secondary: var(--secondary-dark);
-        --accent: var(--accent-dark);
-        --error: var(--error-dark);
-        --info: var(--info-dark);
-        --success: var(--success-dark);
-        --warning: var(--warning-dark);
-    }
-}
-
-
-.theme--dark.v-sheet {
+.theme--dark .v-sheet {
+    color: white;
     background-color: #121212;
 }
 
+.theme--light .v-sheet {
+    color: black;
+    background-color: #FAFAFA;
+}
+
+/* This removes the solara watermark */
 .v-application--wrap > div:nth-child(2) > div:nth-child(2){
     display: none !important;
 }
+
+.theme--dark .toolbar {
+    background-color: var(--primary-dark) !important;    
+}
+.theme--light .toolbar {
+    color: white !important;
+    background-color: var(--primary-light) !important;    
+}
+
+.theme--dark .tutorial {
+    background-color: var(--secondary-dark) !important;
+}
+
+.theme--light .tutorial {
+    background-color: var(--secondary-light) !important;
+}
+
+.inline-guideline-button {
+    color:white !important;
+    border-radius: 5px; 
+    padding: 3px; 
+}
+
+
+/* TODO: For some reason, the .v-application .legend css only works when it's placed in a vue file. Don't know why; and it won't honor the light/dark theme, so I've left this redundantly in all the vue files where it is relevant. (If the user starts at a later guideline, the css won't have loaded, so it needs to be on every vue file). */
+
+/* .theme--dark .v-application .legend {
+    border: 1px solid white !important;
+}
+.theme--light .v-application .legend {
+    border: 1px solid black !important;
+}
+.v-application .legend {
+    max-width: 300px;
+    margin: 0 auto 0;
+    font-size: 15px !important;   
+} */
 
 .toolbar-title {
     text-transform: uppercase;
@@ -96,9 +106,15 @@ footer .v-card__text {
     padding: 6px;
 }
 
-.cosmicds-footer {
-    background-color: #003186 !important; 
+.theme--dark .cosmicds-footer {
+    background-color: var(--cosmicds-blue) !important; 
     color: #BDBDBD !important; 
+    padding-block: 0;
+}
+
+.theme--light .cosmicds-footer {
+    background-color: var(--cosmicds-blue-lighter) !important; 
+    color: #F5f5f5 !important; 
     padding-block: 0;
 }
 
@@ -129,6 +145,8 @@ footer .v-card__text {
 .v-alert .v-input--radio-group+.v-alert, .v-dialog .v-input--radio-group+.v-alert {
     background-color: #000b !important;
 }
+
+
 
 /*.solara-container-main {*/
 /*    max-width: 1264px;*/

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -75,8 +75,6 @@
     padding: 3px; 
 }
 
-
-/* TODO: For some reason, the .v-application .legend css only works when it's placed in a vue file. Don't know why; and it won't honor the light/dark theme, so I've left this redundantly in all the vue files where it is relevant. (If the user starts at a later guideline, the css won't have loaded, so it needs to be on every vue file). */
 /* NOTE: .v-application based selectors will work, but often will need to be either !important or (also) have a higher specificity selector than the default Vuetify css. */
 /* Note that theme--dark and theme--light are defined on the *same* element as v-application, so .v-application should not be a descendent of .theme--[dark/light] */
 .theme--dark.v-application .legend {

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -171,3 +171,16 @@ footer .v-card__text {
 /*    max-height: 100%;*/
 /*    overflow: auto*/
 /*}*/
+
+
+/***** 
+    ================================
+    Solara/Vuetify default overrides 
+    ================================
+*****/
+
+/* buttons should remain white, even in dark mode. 
+    as the toolbar is still #1565C0 */
+.theme--light.v-btn-toggle:not(.v-btn-toggle--group) .v-btn.v-btn .v-icon {
+    color: #fff !important;
+}

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -65,12 +65,8 @@
     background-color: var(--primary-light) !important;    
 }
 
-.theme--dark .tutorial {
-    background-color: var(--secondary-dark) !important;
-}
-
-.theme--light .tutorial {
-    background-color: var(--secondary-light) !important;
+.tutorial {
+    background-color: var(--secondary) !important;
 }
 
 .inline-guideline-button {

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -86,6 +86,11 @@
     border: 1px solid black !important;
 }
 
+.v-application .legend {
+    max-width: 300px;
+    margin: 0 auto 0;
+    font-size: 15px !important;
+}
 
 .toolbar-title {
     text-transform: uppercase;

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -22,6 +22,26 @@
     --cosmicds-blue-lighter: #1a63d9;
 }
 
+:root .theme--dark {
+    --primary: var(--primary-dark);
+    --secondary: var(--secondary-dark);
+    --accent: var(--accent-dark);
+    --error: var(--error-dark);
+    --info: var(var(--info-dark));
+    --success: var(--success-dark);
+    --warning: var(--warning-dark);
+}
+
+:root .theme--light {
+    --primary: var(--primary-light);
+    --secondary: var(--secondary-light);
+    --accent: var(--accent-light);
+    --error: var(--error-light);
+    --info: var(--info-light);
+    --success: var(--success-light);
+    --warning: var(--warning-light);
+}
+
 .theme--dark .v-sheet {
     color: white;
     background-color: #121212;
@@ -61,18 +81,15 @@
 
 
 /* TODO: For some reason, the .v-application .legend css only works when it's placed in a vue file. Don't know why; and it won't honor the light/dark theme, so I've left this redundantly in all the vue files where it is relevant. (If the user starts at a later guideline, the css won't have loaded, so it needs to be on every vue file). */
-
-/* .theme--dark .v-application .legend {
+/* NOTE: .v-application based selectors will work, but often will need to be either !important or (also) have a higher specificity selector than the default Vuetify css. */
+/* Note that theme--dark and theme--light are defined on the *same* element as v-application, so .v-application should not be a descendent of .theme--[dark/light] */
+.theme--dark.v-application .legend {
     border: 1px solid white !important;
 }
-.theme--light .v-application .legend {
+.theme--light.v-application .legend {
     border: 1px solid black !important;
 }
-.v-application .legend {
-    max-width: 300px;
-    margin: 0 auto 0;
-    font-size: 15px !important;   
-} */
+
 
 .toolbar-title {
     text-transform: uppercase;

--- a/src/hubbleds/assets/theme.js
+++ b/src/hubbleds/assets/theme.js
@@ -1,5 +1,23 @@
+// import colors from 'vuetify/lib/util/colors'
 
 vuetifyThemes = {
+    dark: {
+        // primary: colors.blue.darken4,
+        // secondary: colors.cyan.darken3,
+        // accent: colors.amber.accent3,
+        // error: colors.pink.darken1,
+        // info: colors.deepOrange.darken4,
+        // success: colors.green.accent3,
+        // warning: colors.deepOrange.accent4
+        primary: "#0D47A1",
+        secondary: "#00838F",
+        accent: "#FFC400",
+        error: "#D81B60",
+        info: "#BF360C",
+        success: "#00E676",
+        warning: "#DD2C00",
+    },
+
     light: { // currently using this one
         // primary: colors.blue.darken3,
         // secondary: colors.cyan.darken4,
@@ -8,32 +26,12 @@ vuetifyThemes = {
         // info: colors.deepOrange.lighten1,
         // success: colors.green.accent3,
         // warning: colors.deepOrange.accent4
-        primary:  "#0D47A1" ,
-        secondary: "#006064" ,
-        accent: "#FFD740" ,
-        error: "#F06292" ,
-        info: "#FF7043" ,
-        success: "#00E676 " ,
+        primary:  "#1565C0",
+        secondary: "#006064",
+        accent: "#FFD740",
+        error: "#F06292",
+        info: "#FF7043",
+        success: "#388E3C",
         warning: "#DD2C00",
-        cosmicRed: "#e60001",
-        cosmicBlue: "#0E397E",
     },
-    dark: {
-        // primary: colors.blue.darken4,
-        // secondary: colors.cyan.darken3,
-        // accent: colors.amber.accent3,
-        // error: colors.pink.lighten1,
-        // info: colors.deepOrange.darken4,
-        // success: colors.green.accent3,
-        // warning: colors.deepOrange.accent4
-        primary: "#0D47A1",
-        secondary: "#00838F",
-        accent: "#FFC400",
-        error: "#EC407A",
-        info: "#BF360C",
-        success: "#00E676",
-        warning: "#DD2C00",
-        cosmicRed: "#e60001",
-        cosmicBlue: "#0E397E",
-    }
 }

--- a/src/hubbleds/components/data_table/DataTable.vue
+++ b/src/hubbleds/components/data_table/DataTable.vue
@@ -20,7 +20,7 @@
           v-slot:top
       >
         <v-toolbar
-            color="primary"
+            class="toolbar"
             dense
             dark
             rounded

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -10,7 +10,7 @@ from hubbleds.viewers.hubble_dotplot import HubbleDotPlotView
 @solara.component
 def DotplotViewer(gjapp, data=None, height=400):
     with rv.Card() as main:
-        with rv.Toolbar(dense=True, color="primary"):
+        with rv.Toolbar(dense=True, class_="toolbar"):
             with rv.ToolbarTitle():
                 title_container = rv.Html(tag="div")
 

--- a/src/hubbleds/components/hubble_exp_universe_slideshow/HubbleExpUniverseSlideshow.vue
+++ b/src/hubbleds/components/hubble_exp_universe_slideshow/HubbleExpUniverseSlideshow.vue
@@ -26,6 +26,7 @@
         dark
       >
         <v-toolbar-title
+          style="color: white;"
           class="text-h6 text-uppercase font-weight-regular"
         >
           {{ titles[step] }}
@@ -39,8 +40,7 @@
           /> -->
         <v-btn
           icon
-          @click="closeDialog()"
-          :disabled="maxStepCompleted < length - 1"
+          @click="dialog = false;"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>

--- a/src/hubbleds/components/intro_slideshow/intro_slideshow.py
+++ b/src/hubbleds/components/intro_slideshow/intro_slideshow.py
@@ -98,7 +98,7 @@ def IntroSlideshow():
                         classes=["padded-text"],
                     )
 
-                    with solara.Card(style="background-color: #0D47A1"):
+                    with solara.Card(classes=["toolbar"]):
                         solara.HTML(
                             unsafe_innerHTML=
                             """
@@ -113,7 +113,6 @@ def IntroSlideshow():
                                 If not, how long ago did it form?
                             </p>                            
                             """,
-                            classes=["intro-card-text"],
                         )
 
                 with solara.Column(align="center"):
@@ -533,5 +532,4 @@ def IntroSlideshow():
         length=len(carousel.kwargs.get("children", [])),
         circle=True,
         class_="elevation-0",
-        navigation_color="red",
     )

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -21,13 +21,13 @@ def LineDrawViewer(plot_data=None):
     #     active.set(False)
 
     with rv.Card():
-        with rv.Toolbar(color="primary", dense=True):
-            with rv.ToolbarTitle():
+        with rv.Toolbar(class_="toolbar", dense=True):
+            with rv.ToolbarTitle(class_="toolbar"):
                 solara.Text("LINE DRAW VIEWER")
 
             rv.Spacer()
 
-            draw_button = solara.IconButton(icon_name="mdi-message-draw", on_click=on_draw_clicked)
+            draw_button = solara.IconButton(classes=["toolbar"], icon_name="mdi-message-draw", on_click=on_draw_clicked)
             rv.BtnToggle(v_model="selected", children=[draw_button], background_color="primary", borderless=True)
 
         LineDrawPlot(active=active.value, event_line_drawn=None, plot_data=plot_data)

--- a/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
+++ b/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
@@ -34,6 +34,7 @@
       >
         <v-toolbar-title
           class="text-h6 text-uppercase font-weight-regular"
+          style="color: white;"
         >
           {{ currentTitle }}
         </v-toolbar-title>

--- a/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
@@ -27,6 +27,7 @@
       >
         <v-toolbar-title
           class="text-h6 text-uppercase font-weight-regular"
+          style="color: white;"
         >
           Light and Spectra
         </v-toolbar-title>

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -26,7 +26,7 @@ def SpectrumViewer(
     vertical_line_visible = solara.use_reactive(False)
 
     with rv.Card():
-        with rv.Toolbar(color="primary", dense=True):
+        with rv.Toolbar(class_="toolbar", dense=True):
             with rv.ToolbarTitle():
                 solara.Text("SPECTRUM VIEWER")
 

--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -18,6 +18,7 @@
     >
       <v-toolbar-title
         class="text-h6 text-uppercase font-weight-regular"
+        style="color: white;"
       >
         {{ titles[step] }}
       </v-toolbar-title>

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc2.vue
@@ -107,13 +107,6 @@
   margin: 0 auto 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 </style>
 
 <script>

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
@@ -142,13 +142,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #lam_obs, #lam_rest {
   color: black;
   font-size: 18px;

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineIntroDotplot.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineIntroDotplot.vue
@@ -6,7 +6,7 @@
     :can-advance="can_advance"
   >
     <template #before-next>
-      Click <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">DOT PLOT TUTORIAL</span> button.
+      Click <span class="inline-guideline-button tutorial">DOT PLOT TUTORIAL</span> button.
     </template>
 
     <div>
@@ -17,7 +17,7 @@
         Your measurement is shown as an orange-red dot.
       </p>
       <p>
-        Click the <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">DOT PLOT TUTORIAL</span> button to learn about interpreting dot plots.
+        Click the <span class="inline-guideline-button tutorial">DOT PLOT TUTORIAL</span> button to learn about interpreting dot plots.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineReflectOnData.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineReflectOnData.vue
@@ -11,7 +11,7 @@
   >
 
     <template #before-next>
-      Click <span style="background-color: #DD2C00; border-radius: 5px; padding: 3px; color:white!important;">REFLECT</span> button.
+      Click <span class="inline-guideline-button" style="background-color: var(--warning-dark);">REFLECT</span> button.
     </template>
 
     <div
@@ -21,7 +21,7 @@
         As scientists do, let’s examine what conclusions you might draw from your data.
       </p>
       <p>
-        Click the <span style="background-color: #DD2C00; border-radius: 5px; padding: 3px; color:white!important;">REFLECT</span> button to complete the reflection sequence before moving on.
+        Click the <span class="inline-guideline-button" style="background-color: var(--warning-dark);">REFLECT</span> button to complete the reflection sequence before moving on.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
@@ -31,11 +31,11 @@
 <!--            style="font-size: 16px;"-->
 <!--        >-->
 <!--          <b>Click</b>-->
-<!--          <v-btn icon dark x-small disabled class="mx-1 black&#45;&#45;text" elevation="2" style="background-color: #00E676;">-->
+<!--          <v-btn icon dark x-small disabled class="mx-1 black&#45;&#45;text" elevation="2" style="background-color: var(--success-dark);">-->
 <!--            <v-icon style="color:black!important;">mdi-plus</v-icon>-->
 <!--          </v-btn>-->
 <!--          to add galaxy or-->
-<!--          <v-btn icon dark x-small disabled class="mx-1 black&#45;&#45;text" elevation="2" style="background-color: #00E676;">-->
+<!--          <v-btn icon dark x-small disabled class="mx-1 black&#45;&#45;text" elevation="2" style="background-color: var(--success-dark);">-->
 <!--            <v-icon style="color:black!important;">mdi-cached</v-icon>-->
 <!--          </v-btn>-->
 <!--          to choose another-->
@@ -59,14 +59,14 @@
     >
       <p>
         If this galaxy looks good to you, click
-        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;">
+        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);">
           <v-icon style="color:black!important;">mdi-plus</v-icon>
         </v-btn>
         to add it to your data set.
       </p>
       <p>
         If you’d rather look for another galaxy, click
-        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;">
+        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);">
           <v-icon style="color:black!important;">mdi-cached</v-icon>
         </v-btn>
         to reset the view and choose a different green dot.

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies3.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies3.vue
@@ -29,10 +29,10 @@
       v-if="state_view.total_galaxies < 5 && state_view.selected_galaxy"
     >
       <p>
-        If this galaxy looks good to you, click <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;"><v-icon style="color:black!important;">mdi-plus</v-icon></v-btn> to add it to your data set.
+        If this galaxy looks good to you, click <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);"><v-icon style="color:black!important;">mdi-plus</v-icon></v-btn> to add it to your data set.
       </p>
       <p>
-        If you’d rather look for another galaxy, click <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;"><v-icon style="color:black!important;">mdi-cached</v-icon></v-btn> to reset the view and choose a different green dot.
+        If you’d rather look for another galaxy, click <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);"><v-icon style="color:black!important;">mdi-cached</v-icon></v-btn> to reset the view and choose a different green dot.
       </p>
     </div>
     <div
@@ -40,7 +40,7 @@
       class="mb-4"
     >
       <p>
-        Choose another galaxy to enter into your table. You can pan around the sky from where you are or click the <v-btn icon dark small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;"><v-icon style="color:black!important;">mdi-cached</v-icon></v-btn> button to reset the view.
+        Choose another galaxy to enter into your table. You can pan around the sky from where you are or click the <v-btn icon dark small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);"><v-icon style="color:black!important;">mdi-cached</v-icon></v-btn> button to reset the view.
       </p>
     </div>
     <div

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSpectrum.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSpectrum.vue
@@ -11,7 +11,7 @@
   >
 
     <template #before-next>
-      Click <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">SPECTRUM TUTORIAL</span> button.
+      Click <span class="inline-guideline-button tutorial">SPECTRUM TUTORIAL</span> button.
     </template>
 
     <div
@@ -28,7 +28,7 @@
       v-if="!(state_view.spectrum_tutorial_opened)"
     >    
       <p>
-        Click the <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">SPECTRUM TUTORIAL</span> button to learn what spectra can tell us about galaxies.
+        Click the <span  class="inline-guideline-button tutorial">SPECTRUM TUTORIAL</span> button to learn what spectra can tell us about galaxies.
       </p>
     </div>
     <div
@@ -36,7 +36,7 @@
       v-if="state_view.spectrum_tutorial_opened"
     >
       <p>
-        You can reopen the <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">SPECTRUM TUTORIAL</span> any time you need a refresher about spectra.
+        You can reopen the <span  class="inline-guideline-button tutorial">SPECTRUM TUTORIAL</span> any time you need a refresher about spectra.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas3.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas3.vue
@@ -10,7 +10,7 @@
     :can-advance="can_advance"
   >
     <template #before-next>
-      Click the <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;"><v-icon style="color:black!important;">mdi-ruler</v-icon></v-btn>  icon.
+      Click the <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);"><v-icon style="color:black!important;">mdi-ruler</v-icon></v-btn>  icon.
     </template>
 
     <div
@@ -23,7 +23,7 @@
         Adjust the brightness using the <v-icon>mdi-brightness-6</v-icon></v-btn> slider if needed.
       </p>      
       <p>
-        Click the <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #00E676;"><v-icon style="color:black!important;">mdi-ruler</v-icon></v-btn>  icon to activate the angular size measuring tool.
+        Click the <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: var(--success-dark);"><v-icon style="color:black!important;">mdi-ruler</v-icon></v-btn>  icon to activate the angular size measuring tool.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas5a.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas5a.vue
@@ -6,14 +6,14 @@
     :can-advance="can_advance"
   >
     <template #before-next>
-      Click <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">MEASUREMENT DOS AND DONTS</span> button.
+      Click <span class="inline-guideline-button tutorial">MEASUREMENT DOS AND DONTS</span> button.
     </template>
 
     <div
       class="mb-4"
     >
       <p>
-        Given that there was not consensus on the angular size measurements for the galaxy, click <span style="background-color: #02838f; border-radius: 5px; padding: 3px; color:white!important;">MEASUREMENT DOS AND DONTS</span> for tips on how to ensure the most accurate results.
+        Given that there was not consensus on the angular size measurements for the galaxy, click <span class="inline-guideline-button tutorial">MEASUREMENT DOS AND DONTS</span> for tips on how to ensure the most accurate results.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance2.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance2.vue
@@ -91,11 +91,4 @@ module.exports = {
   margin: 0 auto 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 </style>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance3.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance3.vue
@@ -157,13 +157,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance4.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineEstimateDistance4.vue
@@ -114,13 +114,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeRaceEquation.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeRaceEquation.vue
@@ -103,11 +103,4 @@ module.exports = {
   margin: 0 auto 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 </style>

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEquation2.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEquation2.vue
@@ -125,11 +125,4 @@ module.exports = {
   margin: 20px auto !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 </style>

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate3.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate3.vue
@@ -182,13 +182,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate3.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate3.vue
@@ -163,13 +163,6 @@ module.exports = {
   margin: 16px auto !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 mjx-mfrac {
   margin: 0 4px !important;
 }

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate4.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineAgeUniverseEstimate4.vue
@@ -129,13 +129,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineHubblesExpandingUniverse1.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineHubblesExpandingUniverse1.vue
@@ -7,7 +7,7 @@
     :state="state"
   >
     <template #before-next>
-      Click <span style="background-color: #02838f; border-radius : 5px; padding: 3px; color:white!important;">HUBBLE'S DISCOVERY</span> button.
+      Click <span class="inline-guideline-button tutorial">HUBBLE'S DISCOVERY</span> button.
     </template>
     
     <div
@@ -17,7 +17,7 @@
         The relationship between your galaxies’ velocity and distance is the same as what Hubble found: galaxies at a greater distance away are moving away from us at a higher velocity.
       </p>
       <p>
-       Click the <span style="background-color: #02838f; border-radius : 5px; padding: 3px;color:white!important;">HUBBLE'S DISCOVERY</span> button to learn what was significant about this result.
+       Click the <span class="inline-guideline-button tutorial">HUBBLE'S DISCOVERY</span> button to learn what was significant about this result.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/04-explore-data/guidelines/GuidelineTrendsData2.vue
+++ b/src/hubbleds/pages/04-explore-data/guidelines/GuidelineTrendsData2.vue
@@ -19,7 +19,7 @@
         Since everyone in your class also measured 5 galaxies, let's look at a dataset that combines everyone's measurements.
       </p>
       <p>
-        Click the box next to  <span style="background-color: white; border-radius : 5px; padding: 3px; color:black!important; font-size: 80%"><b>Class Data</b></span>  in the legend panel to display measurements from your entire class.
+        Click the box next to  <span class="inline-guideline-button" style="background-color: white; color:black!important; font-size: 80%"><b>Class Data</b></span>  in the legend panel to display measurements from your entire class.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRange.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRange.vue
@@ -69,13 +69,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRangec.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRangec.vue
@@ -69,13 +69,6 @@ mjx-mstyle {
   font-size: 16px !important;
 }
 
-.v-application .legend {
-  border: 1px solid white !important;
-  max-width: 300px;
-  margin: 0 auto 0;
-  font-size: 15px !important;
-}
-
 #gal_ang_size {
   color:  black;
   font-size: 18px;

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineLearnUncertainty1.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineLearnUncertainty1.vue
@@ -8,7 +8,7 @@
   >
    
     <template #before-next>
-      Click <span style="background-color: #02838f; border-radius : 5px; padding: 3px; color:white!important;">UNCERTAINTY TUTORIAL</span> button.
+      Click <span class="inline-guideline-button tutorial">UNCERTAINTY TUTORIAL</span> button.
     </template>
 
     <div
@@ -18,7 +18,7 @@
         Before we go further, let's explore in more detail <b>why</b> different students may have obtained different age values for the universe.
       </p>
       <p>
-        Scientists explain this using a concept called <b>uncertainty</b>. Click the <span style="background-color: #02838f; border-radius : 5px; padding: 3px; color:white!important;">UNCERTAINTY TUTORIAL</span> button to learn about this important concept for interpreting data.
+        Scientists explain this using a concept called <b>uncertainty</b>. Click the <span class="inline-guideline-button tutorial">UNCERTAINTY TUTORIAL</span> button to learn about this important concept for interpreting data.
       </p>
     </div>
   </scaffold-alert>

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -3,10 +3,9 @@
     id="distance-root"
   >
     <v-toolbar
-      color="primary"
       dense
       dark
-      class="text-uppercase"
+      class="text-uppercase toolbar"
     >
       <v-toolbar-title>Cosmic Sky Viewer</v-toolbar-title>
       <v-spacer></v-spacer>
@@ -70,7 +69,7 @@
             bottom
             right
             absolute
-            :color="measuring ? 'red' : '#00E676'"
+            :color="measuring ? 'red' : 'var(--success-dark)'"
             class="measuring-fab black--text"
             :ripple="false"
             v-bind="attrs"
@@ -229,7 +228,7 @@ export default {
     setupMeasuringCanvasContext: function() {
       this.context = this.canvas.getContext('2d');
       this.context.lineWidth = 3;
-      this.context.strokeStyle = '#00e676';
+      this.context.strokeStyle = '#00E676';
     },
 
     addInitialPoint: function(event) {

--- a/src/hubbleds/widgets/exploration_tool/exploration_tool.vue
+++ b/src/hubbleds/widgets/exploration_tool/exploration_tool.vue
@@ -11,11 +11,10 @@
     }"
   >
     <v-toolbar
-      color="primary"
       height="40px"
       dense
       dark
-      class="text-uppercase"
+      class="text-uppercase toolbar"
     >
       <v-toolbar-title>Cosmic Sky Viewer</v-toolbar-title>
       <v-spacer></v-spacer>          

--- a/src/hubbleds/widgets/selection_tool/selection_tool.vue
+++ b/src/hubbleds/widgets/selection_tool/selection_tool.vue
@@ -5,9 +5,9 @@
     :class="highlighted ? 'pa-1' : ''"
   >
     <v-toolbar
-      color="primary"
       dense
       dark
+      class="toolbar"
     >
       <v-toolbar-title
         class="text-h6 text-uppercase font-weight-regular"
@@ -150,7 +150,7 @@
             bottom
             left
             absolute
-            color="#00E676"
+            color="var(--success-dark)"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
@@ -170,7 +170,7 @@
             bottom
             right
             absolute
-            color="#00E676"
+            color="var(--success-dark)"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"


### PR DESCRIPTION
This works toward improving the light/dark theme functionality as noted in #423. 

Many things are working better now, but there are still some flaky cases where I couldn't figure out how to target what we needed. Where this happens, I try to favor the dark theme functionality.

- Colors in custom.css & theme.js are now consistent and should match what's at https://github.com/cosmicds/educator_dashboard (where I had made earlier changes from the voila-hubbleds to improve contrasts).
- Where we specify theme colors by hex codes, I've changed those back to the theme colors.
- Straight vue files seem to handle the light/dark themes automatically, but things that were specified in python/solara often ignored the theme changes, so I copied the css used for the [solara webpage](https://github.com/widgetti/solara/blob/d258da07ff2ce698553e111312b2e2bc8763ea00/solara/website/assets/custom.css#L266) to make sure it updated correctly.
- One pesky issue was the border around the MathJax equation `.legend`s, as [here](https://github.com/patudom/hubbleds/blob/02ddb24447fee2e23c54f6553da21eb600edff63/src/hubbleds/pages/01-spectra-%26-velocity/guidelines/GuidelineDopplerCalc2.vue#L111). When I tried moving this to `custom.css`, it was completely ignored, and I couldn't split this into dark/light mode cases. (I think this is a problem that we never solved in the voila version either).
- Some of the toolbar buttons are gray in light mode instead of staying white.