### PR TITLE
Add in stage 3 dotplot viewers

### DIFF
--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -10,7 +10,8 @@ from hubbleds.viewers.hubble_dotplot import HubbleDotPlotView, HubbleDotPlotView
 @solara.component
 def DotplotViewer(gjapp, viewer: HubbleDotPlotViewer | None = None, data=None, component_id=None, title = None, height=400, on_click_callback = None):
     
-def DotplotViewer(gjapp, data=None, height=400):
+    vertical_line_visible = solara.use_reactive(True)
+    
     with rv.Card() as main:
         with rv.Toolbar(dense=True, color="primary"):
             with rv.ToolbarTitle():
@@ -35,12 +36,30 @@ def DotplotViewer(gjapp, data=None, height=400):
             else:
                 dotplot_view = viewer
             
-            dotplot_test_data = Data(x=[randint(1, 10) for _ in range(30)])
-            gjapp.data_collection.append(dotplot_test_data)
-            dotplot_view = gjapp.new_data_viewer(
-                HubbleDotPlotView, data=dotplot_test_data, show=False
-            )
-
+            # def on_click(**kwargs):
+            #     fig = dotplot_view.figure
+            #     fig.add_vline(
+            #         x=kwargs['points']['xs'][0],
+            #         line_width=1,
+            #         line_color="red",
+            #         annotation=f"{round(kwargs['points']['xs'][0])}",
+            #         visible=vertical_line_visible.value
+            #     )
+                
+            #     if on_click_callback is not None:
+            #         on_click_callback(**kwargs)
+                    
+            
+            # if on_click_callback is not None:
+            #     dotplot_view.set_selection_active(True)
+            #     dotplot_view.set_selection_callback(on_click)
+            # else:
+            #     dotplot_view.set_selection_callback(None)
+            #     dotplot_view.set_selection_active(False)
+            #     dotplot_view.figure.on_edits_completed(dotplot_view.figure.plotly_relayout({'selections': [], 'dragmode': False}))
+            
+            
+            print("component_id", component_id)
             if component_id is not None:
                 dotplot_view.state.x_att = viewer_data.id[component_id]
             

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -4,10 +4,12 @@ import solara
 from glue.core import Data
 from reacton import ipyvuetify as rv
 
-from hubbleds.viewers.hubble_dotplot import HubbleDotPlotView
+from hubbleds.viewers.hubble_dotplot import HubbleDotPlotView, HubbleDotPlotViewer
 
 
 @solara.component
+def DotplotViewer(gjapp, viewer: HubbleDotPlotViewer | None = None, data=None, component_id=None, title = None, height=400, on_click_callback = None):
+    
 def DotplotViewer(gjapp, data=None, height=400):
     with rv.Card() as main:
         with rv.Toolbar(dense=True, color="primary"):
@@ -20,12 +22,31 @@ def DotplotViewer(gjapp, data=None, height=400):
         viewer_container = rv.Html(tag="div", style_=f"width: 100%; height: {height}px")
 
         def _add_viewer():
+            if data is None:
+                viewer_data = Data(label = "Test Data", x=[randint(1, 10) for _ in range(30)])
+                gjapp.data_collection.append(viewer_data)
+            else: 
+                viewer_data = data
+            
+            if viewer is None:
+                dotplot_view: HubbleDotPlotViewer = gjapp.new_data_viewer(
+                    HubbleDotPlotView, data=viewer_data, show=False
+                )
+            else:
+                dotplot_view = viewer
+            
             dotplot_test_data = Data(x=[randint(1, 10) for _ in range(30)])
             gjapp.data_collection.append(dotplot_test_data)
             dotplot_view = gjapp.new_data_viewer(
                 HubbleDotPlotView, data=dotplot_test_data, show=False
             )
 
+            if component_id is not None:
+                dotplot_view.state.x_att = viewer_data.id[component_id]
+            
+            if title is not None:
+                dotplot_view.state.title = title
+    
             title_widget = solara.get_widget(title_container)
             title_widget.children = (dotplot_view.state.title or "DOTPLOT VIEWER",)
 

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -8,7 +8,7 @@ from hubbleds.viewers.hubble_dotplot import HubbleDotPlotView, HubbleDotPlotView
 
 
 @solara.component
-def DotplotViewer(gjapp, viewer: HubbleDotPlotViewer | None = None, data=None, component_id=None, title = None, height=400, on_click_callback = None):
+def DotplotViewer(gjapp, data=None, component_id=None, title = None, height=400, on_click_callback = None):
     
     vertical_line_visible = solara.use_reactive(True)
     
@@ -29,12 +29,11 @@ def DotplotViewer(gjapp, viewer: HubbleDotPlotViewer | None = None, data=None, c
             else: 
                 viewer_data = data
             
-            if viewer is None:
-                dotplot_view: HubbleDotPlotViewer = gjapp.new_data_viewer(
-                    HubbleDotPlotView, data=viewer_data, show=False
-                )
-            else:
-                dotplot_view = viewer
+
+            dotplot_view: HubbleDotPlotViewer = gjapp.new_data_viewer(
+                HubbleDotPlotView, data=viewer_data, show=False
+            )
+
             
             # def on_click(**kwargs):
             #     fig = dotplot_view.figure

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -26,7 +26,8 @@ from ...widgets.selection_tool import SelectionTool
 from ...data_models.student import student_data, StudentMeasurement, example_data
 from .component_state import ComponentState, Marker, ELEMENT_REST
 from ...remote import DatabaseAPI
-
+from ...data_management import EXAMPLE_GALAXY_SEED_DATA, DB_VELOCITY_FIELD
+from glue.core import Data
 
 GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 
@@ -230,7 +231,13 @@ def Page():
     #  a conditional will result in an error.
     def glue_setup():
         gjapp = JupyterApplication(GLOBAL_STATE.data_collection, GLOBAL_STATE.session)
-
+        # Get the example seed data
+        if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
+            example_seed_data = DatabaseAPI.get_example_seed_measurement()
+            data = Data(label=EXAMPLE_GALAXY_SEED_DATA, **{k: np.asarray([r[k] for r in example_seed_data]) for k in example_seed_data[0].keys()})
+            gjapp.data_collection.append(data)
+        else:
+            data = gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
         return gjapp
 
     gjapp = solara.use_memo(glue_setup)
@@ -685,7 +692,7 @@ def Page():
                     ),
                 )
 
-                DotplotViewer(gjapp)
+                DotplotViewer(gjapp, data=gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA], component_id=DB_VELOCITY_FIELD)
 
             if component_state.is_current_step(Marker.ref_dat1):
                 ReflectVelocitySlideshow(

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -4,7 +4,6 @@ from cosmicds.components import ScaffoldAlert, StateEditor, MathJaxSupport, Plot
 import astropy.units as u
 from cosmicds import load_custom_vue_components
 from glue_jupyter.app import JupyterApplication
-from glue_jupyter.table import TableViewer
 from reacton import component, ipyvuetify as rv
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from glue.core import Data
 from typing import List, Optional, cast
 
 component_state = ComponentState()
+
 
 def _update_angular_size(data, galaxy, angular_size, count):
     if bool(galaxy) and angular_size is not None:
@@ -144,18 +144,18 @@ def Page():
     StateEditor(Marker, component_state) 
     # This will print the tables 
     # need to > from pandas import DataFrame
-    def meas_to_df(meas):
-        try:
-            meas = meas.model_dump()
-        except AttributeError:
-            pass
-        try:
-            gal = meas.pop('galaxy')
-        except:
-            gal = {}
-        # gal = gal.model_dump(exclude={'spectrum'})
-        gal = {k:v for k,v in gal.items() if k != 'spectrum'}
-        return {**gal, **meas}
+    # def meas_to_df(meas):
+    #     try:
+    #         meas = meas.model_dump()
+    #     except AttributeError:
+    #         pass
+    #     try:
+    #         gal = meas.pop('galaxy')
+    #     except:
+    #         gal = {}
+    #     # gal = gal.model_dump(exclude={'spectrum'})
+    #     gal = {k:v for k,v in gal.items() if k != 'spectrum'}
+    #     return {**gal, **meas}
     
     # solara.HTML(unsafe_innerHTML=DataFrame([meas_to_df(s) for s in student_data.measurements or []]).to_html())
     # solara.HTML(unsafe_innerHTML=DataFrame([meas_to_df(s) for s in example_data.measurements or []]).to_html())
@@ -172,6 +172,7 @@ def Page():
         #     component_state.transition_to(Marker.sel_gal3, force=True)
 
         # solara.Button("Select 5 Galaxies", on_click=_on_select_galaxies_clicked)
+
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():
@@ -315,9 +316,6 @@ def Page():
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():
-            
-            
-            
             ScaffoldAlert(
                 # TODO This will need to be wired up once table is implemented
                 GUIDELINE_ROOT / "GuidelineChooseRow1.vue",
@@ -571,8 +569,27 @@ def Page():
                 
                 # if component_state.current_step_at_or_after(Marker.dot_seq5):
                 solara.Button("Add Example Data", on_click=add_student_measurement)
-            solara.Markdown("blah blah")
-
+                
+                def on_click(trace, points, selector):
+                    # print(*args, **kwargs)
+                    fig = dotplot_angsize.figure
+                    print(selector)
+                    fig.add_vline(
+                        x=selector.xrange[0],
+                        line_width=1,
+                        line_color="red",
+                        visible=True
+                    )
+                    
+                    # print(**kwargs)
+                        
+                
+                dotplot_angsize.figure.update_layout(clickmode='event', dragmode='select')
+                dotplot_angsize.set_selection_active(True)
+                # dotplot_angsize.set_selection_callback(on_click)
+                ## I am unsure why on_seleciton works and on_click does not
+                dotplot_angsize.selection_layer.on_selection(on_click)
+                # dotplot_angsize.selection_layer.on_click(on_click)
                 
                 ViewerLayout(dotplot_angsize)
                 ViewerLayout(dotplot_distance)

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -1,6 +1,7 @@
 import dataclasses
 from cosmicds.state import GLOBAL_STATE, BaseState
 from solara import Reactive
+from glue.core import Data
 from glue.core.data_factories import load_data
 from pathlib import Path
 from hubbleds.decorators import computed_property
@@ -79,8 +80,15 @@ LOCAL_STATE = LocalState()
 
 
 def add_link(from_dc_name, from_att, to_dc_name, to_att):
-    from_dc = GLOBAL_STATE.data_collection[from_dc_name]
-    to_dc = GLOBAL_STATE.data_collection[to_dc_name]
+    if isinstance(from_dc_name, Data):
+        from_dc = from_dc_name
+    else:
+        from_dc = GLOBAL_STATE.data_collection[from_dc_name]
+    
+    if isinstance(to_dc_name, Data):
+        to_dc = to_dc_name
+    else:
+        to_dc = GLOBAL_STATE.data_collection[to_dc_name]
     GLOBAL_STATE._glue_app.add_link(from_dc, from_att, to_dc, to_att)
 
 

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -4,6 +4,10 @@ from numpy import argsort, pi
 
 from cosmicds.utils import mode, percent_around_center_indices
 
+from .data_models.student import StudentMeasurement
+from glue.core import Data
+from numpy import asarray
+
 try:
     from astropy.cosmology import Planck18 as planck
 except ImportError:
@@ -126,3 +130,13 @@ def data_summary_for_component(data, component_id):
         summary[f"{percent}%"] = (bottom, top)
 
     return summary
+
+def measurement_list_to_glue_data(measurements: list[StudentMeasurement] | list[dict], label = ""):
+    x = []
+    for measurement in measurements:
+        if isinstance(measurement, StudentMeasurement):
+            x.append(measurement.model_dump())
+        else:
+            x.append(measurement)
+    return Data(label = label, **{k: asarray([r[k] for r in x]) for k in x[0].keys()})
+


### PR DESCRIPTION
This hooks up the dotplot viewers to real data in the stages 1 and 3. 

In stage 3, it is setup to show the students data on the graph. Sequencing has not been implemented, but should be pretty simple. 

Currently I am not using the `DotplotViewer` @nmearl made, as while I was making this it did not allow data to be added (I have fixed this, but it currently only takes in a single data set (I suppose I can fix this too). 

A major outstanding issue is adding the red line. I can't seem to hook into the `viewer.figure.selection_layer.on_click `callback. However, it seems like we ought to be able to use the click event the same way[ glue uses the selection event](https://github.com/glue-viz/glue-plotly/blob/34e231661e53dc49571d85c0be98437410692f78/glue_plotly/viewers/common/tools.py#L36). However in my attempt, I couldn't get the click callback?? 

In the spectrum viewer, @nmearl get's around this using the plotly figure object directly. 

I am not quite sure how to go about this, perhaps @Carifio24 or @nmearl have ideas. I didn't see any built-in glue-plotly tools which used the single click (I think the nearest uses hover, which snaps to a nearby point) 