### PR TITLE
Add css to style piggybank chip

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -57,6 +57,12 @@
     display: none !important;
 }
 
+.piggy-chip {
+    background-color: black !important; 
+    border: 1px solid var(--success-dark) !important;
+    color: white;
+}
+
 .theme--dark .toolbar {
     background-color: var(--primary-dark) !important;    
 }


### PR DESCRIPTION
This replaces #434, which had an unnecessarily complicated history for adding only 1 commit.