### PR TITLE
Wire up stage 6 mc fr questions

### DIFF
--- a/src/hubbleds/pages/00-test-page/component_state.py
+++ b/src/hubbleds/pages/00-test-page/component_state.py
@@ -38,6 +38,9 @@ class ComponentState(BaseState, BaseComponentState):
     def mark3_gate(self) -> bool:
         return LOCAL_STATE.value.question_completed("mc-2")
     
+    @property
+    def mark4_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("fr-1")
 
 
     

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -1,43 +1,44 @@
-# Stage 6 (prodata)
 import solara
-from hubbleds.state import LOCAL_STATE, GLOBAL_STATE
-from .component_state import COMPONENT_STATE, Marker
-from hubbleds.remote import LOCAL_API
-from glue_jupyter import JupyterApplication
-import asyncio
-from pathlib import Path
+from solara.toestand import Ref
+import reacton.ipyvuetify as rv
+
+# cosmicds
 from cosmicds.components import (
     ScaffoldAlert,
     LayerToggle,
     StateEditor,
     ViewerLayout
 )
-from reacton import ipyvuetify as rv
+from cosmicds.logger import setup_logger
+
+# hubbleds
+from hubbleds.remote import LOCAL_API
 from hubbleds.base_component_state import (
-    transition_to,
     transition_previous,
     transition_next,
 )
-from hubbleds.components import (
-    SelectionTool,
-    DataTable,
-    DopplerSlideshow,
-    SpectrumViewer,
-    SpectrumSlideshow,
-    DotplotViewer,
-    ReflectVelocitySlideshow,
-    DotplotTutorialSlideshow,
-)
+from hubbleds.state import (
+    LOCAL_STATE, 
+    GLOBAL_STATE, 
+    mc_callback, 
+    fr_callback, 
+    get_free_response, 
+    get_multiple_choice
+    )
+
+from ...utils import HST_KEY_AGE
+
+from .component_state import COMPONENT_STATE, Marker
+
+# glue-jupyter
+from glue_jupyter import JupyterApplication
+
+# misc.
+from pathlib import Path
 
 from ...viewers import HubbleFitView
 
-from solara.lab import Ref
-from cosmicds.logger import setup_logger
-
-from ...data_management import *
-# from ...state import mc_callback, mc_serialize_score, get_free_response, fr_callback
-# import for type definitions
-from typing import cast, Tuple
+# from ...data_management import *
 
 logger = setup_logger("STAGE")
 
@@ -56,27 +57,35 @@ def basic_viewer_setup(viewer_class, glue_session, data_collection, name, x_att,
 # create the Page for the current stage
 @solara.component
 def Page():
+    # === Setup State Loading and Writing ===
     loaded_component_state = solara.use_reactive(False)
-
+    
     async def _load_component_state():
-        # Load stored component state from database, measurement data is
-        #   considered higher-level and is loaded when the story starts.
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
-
-    logger.info("Finished loading component state.")
-    loaded_component_state.set(True)
-
+        logger.info("Finished loading component state")
+        loaded_component_state.set(True)
+    
     solara.lab.use_task(_load_component_state)
+    
+    async def _write_component_state():
+        if not loaded_component_state.value:
+            return
 
+        # Listen for changes in the states and write them to the database
+        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+
+        logger.info("Wrote component state to database.")
+
+    solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
+    
+    # === Setup Glue ===
+    
     def _glue_setup() -> JupyterApplication:
         # NOTE: use_memo has to be part of the main page render. Including it
         #  in a conditional will result in an error.
-
-        # create glue app with the global data collection and session
         gjapp = JupyterApplication(
             GLOBAL_STATE.value.glue_data_collection, GLOBAL_STATE.value.glue_session
         )
-
         # TODO: Should viewer creation happen somewhere else?
 
         # viewer = gjapp.new_data_viewer(HubbleFitView, show=False)
@@ -85,12 +94,19 @@ def Page():
         # viewer.figure.update_yaxes(showline=True, mirror=False)
         
         # return gjapp, cast(HubbleFitView, viewer)
+
         return gjapp
-    
+
     gjapp = solara.use_memo(_glue_setup)
 
+    def _state_callback_setup():
+        # We want to minimize duplicate state handling, but also keep the states
+        #  independent. We'll set up observers for changes here so that they
+        #  automatically keep the states in sync.
+        # See Stage 1 for an example of how to do this manually.
+        pass
 
-    
+    solara.use_memo(_state_callback_setup)    
     
     # # viewer.toolbar.set_tool_enabled("hubble:linefit", False)
     # component_state.add_data_by_marker(viewer)
@@ -100,23 +116,14 @@ def Page():
     # mc_scoring, set_mc_scoring  = solara.use_state(LOCAL_STATE.mc_scoring.value)
     # print('\n =============  done setting up mc scoring ============= \n')
 
-        
-    # StateEditor(Marker, component_state)
-    
-    # solara.Markdown(
-    #     f"""
+    StateEditor(Marker, COMPONENT_STATE)
 
-    #     mc-scoring: {mc_scoring}  
+    with solara.Card():
+        with solara.Div():
+            solara.Text(f"mc_scoring: {LOCAL_STATE.value.mc_scoring}")
+        with solara.Div():
+            solara.Text(f"free_responses: {LOCAL_STATE.value.free_responses}")
 
-    #     free-responses: {LOCAL_STATE.free_responses}
-
-    #     """
-    # )
-    
-    solara.Text(f"{GLOBAL_STATE.value.dict()}")
-    solara.Text(f"{LOCAL_STATE.value.dict()}")
-    solara.Text(f"{COMPONENT_STATE.value.dict()}")
-    
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():
             ScaffoldAlert(
@@ -131,8 +138,8 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat1),
-            #     event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-            #     state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat1')), 'score_tag': 'pro-dat1'}
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                state_view={'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat1'), 'score_tag': 'pro-dat1'}
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData2.vue",
@@ -140,9 +147,8 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat2),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat2')), 'score_tag': 'pro-dat2'}
-                
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                state_view={'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat2'), 'score_tag': 'pro-dat2'}
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData3.vue",
@@ -150,8 +156,8 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat3),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat3')), 'score_tag': 'pro-dat3'}
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                state_view={'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat3'), 'score_tag': 'pro-dat3'}
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData4.vue",
@@ -159,11 +165,14 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat4),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
-                # state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat4')), 'score_tag': 'pro-dat4',
-                #             'free_response': get_free_response(LOCAL_STATE.free_responses,'prodata-free-4')
-                #             }
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                event_fr_callback = lambda event: fr_callback(event, LOCAL_STATE),
+                state_view={
+                    'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat4'), 
+                    'score_tag': 'pro-dat4',
+                    'free_response': get_free_response(LOCAL_STATE, 'prodata-free-4'),
+                    'mc_completed': LOCAL_STATE.value.question_completed("pro-dat4"),
+                }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData5.vue",
@@ -178,13 +187,13 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat6),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # state_view={
-                #     'hst_age': component_state.hst_age, 
-                #     'class_age': component_state.class_age.value,
-                #     'mc_score': mc_serialize_score(mc_scoring.get('pro-dat6')), 
-                #     'score_tag': 'pro-dat6'
-                #     }
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                state_view={
+                    'hst_age': HST_KEY_AGE, 
+                    'class_age': COMPONENT_STATE.value.class_age,
+                    'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat6'), 
+                    'score_tag': 'pro-dat6'
+                }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData7.vue",
@@ -192,11 +201,14 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat7),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
-                # state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat7')), 'score_tag': 'pro-dat7', 
-                #             'free_response': get_free_response(LOCAL_STATE.free_responses,'prodata-free-7')}
-                
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                event_fr_callback = lambda event: fr_callback(event, LOCAL_STATE),
+                state_view={
+                    'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat7'), 
+                    'score_tag': 'pro-dat7',
+                    'free_response': get_free_response(LOCAL_STATE, 'prodata-free-7'),
+                    'mc_completed': LOCAL_STATE.value.question_completed("pro-dat7"),
+                }                
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData8.vue",
@@ -204,12 +216,12 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat8),
-                # event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
-                # state_view={
-                #     'free_response_a': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8a'),
-                #     'free_response_b': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8b'),
-                #     'free_response_c': get_free_response(LOCAL_STATE.free_responses,'prodata-reflect-8c'),
-                # }
+                event_fr_callback = lambda event: fr_callback(event, LOCAL_STATE),
+                state_view={
+                    'free_response_a': get_free_response(LOCAL_STATE,'prodata-reflect-8a'),
+                    'free_response_b': get_free_response(LOCAL_STATE,'prodata-reflect-8b'),
+                    'free_response_c': get_free_response(LOCAL_STATE,'prodata-reflect-8c'),
+                }
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData9.vue",
@@ -217,8 +229,8 @@ def Page():
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat9),
-                # event_mc_callback=lambda event: mc_callback(event=event, local_state=LOCAL_STATE, callback=set_mc_scoring),
-                # state_view={'mc_score': mc_serialize_score(mc_scoring.get('pro-dat9')), 'score_tag': 'pro-dat9'}
+                event_mc_callback = lambda event: mc_callback(event, LOCAL_STATE),
+                state_view={'mc_score': get_multiple_choice(LOCAL_STATE, 'pro-dat9'), 'score_tag': 'pro-dat9'}
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineStoryFinish.vue",

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -116,7 +116,7 @@ def Page():
     # mc_scoring, set_mc_scoring  = solara.use_state(LOCAL_STATE.mc_scoring.value)
     # print('\n =============  done setting up mc scoring ============= \n')
 
-    StateEditor(Marker, COMPONENT_STATE)
+    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
     with solara.Card():
         with solara.Div():

--- a/src/hubbleds/pages/06-prodata/component_state.py
+++ b/src/hubbleds/pages/06-prodata/component_state.py
@@ -1,13 +1,17 @@
-from pydantic import BaseModel, field_validator
+import solara
+
+from pydantic import field_validator
+
 from cosmicds.state import BaseState
 from hubbleds.base_marker import BaseMarker
-import enum
-from functools import cached_property
 from hubbleds.base_component_state import BaseComponentState
-import solara
+from hubbleds.state import LOCAL_STATE
+
+import enum
 from typing import Any
 
-from ...utils import HST_KEY_AGE
+from functools import cached_property
+
 from ...data_management import HUBBLE_1929_DATA_LABEL, HUBBLE_KEY_DATA_LABEL
 
 
@@ -29,8 +33,6 @@ class Marker(enum.Enum, BaseMarker):
 class ComponentState(BaseComponentState, BaseState):
     current_step: Marker = Marker.pro_dat0
     stage_id: str = "professional_data"
-    
-    hst_age: float = HST_KEY_AGE # a constant value
     
     # TODO: I don't think our_age is used anywhere
     our_age: float = 0
@@ -77,56 +79,44 @@ class ComponentState(BaseComponentState, BaseState):
     #             "x": 0.01
     #         })
     #     return
+
+    @field_validator("current_step", mode="before")
+    def convert_int_to_enum(cls, v: Any) -> Marker:
+        if isinstance(v, int):
+            return Marker(v)
+        return v
     
-    # def pro_dat0_gate(self):
-    #     return True
+    @property
+    def pro_dat2_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat1")
     
-    # @computed_property
-    # def pro_dat1_gate(self):
-    #     return True
+    @property
+    def pro_dat3_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat2")
     
-    # @computed_property
-    # def pro_dat2_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat1")
+    @property
+    def pro_dat4_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat3") 
     
-    # @computed_property
-    # def pro_dat3_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat2")
+    @property
+    def pro_dat5_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat4") and LOCAL_STATE.value.question_completed("prodata-free-4")
     
-    # @computed_property
-    # def pro_dat4_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat3")
+    @property
+    def pro_dat7_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat6")
     
-    # @computed_property
-    # def pro_dat5_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat4")
+    @property
+    def pro_dat8_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat7") and LOCAL_STATE.value.question_completed("prodata-free-7")
     
-    # @computed_property
-    # def pro_dat6_gate(self):
-    #     return True
+    @property
+    def pro_dat9_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("prodata-reflect-8a") and LOCAL_STATE.value.question_completed("prodata-reflect-8b") and LOCAL_STATE.value.question_completed("prodata-reflect-8c")
     
-    # @computed_property
-    # def pro_dat7_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat6")
+    @property
+    def sto_fin1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("pro-dat9")
     
-    # @computed_property
-    # def pro_dat8_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat7")
-    
-    # @computed_property
-    # def pro_dat9_gate(self):
-    #     return True
-    
-    # @computed_property
-    # def sto_fin1_gate(self):
-    #     return LOCAL_STATE.question_completed("pro-dat9")
-    
-    # @computed_property
-    # def sto_fin2_gate(self):
-    #     return True
-    
-    # @computed_property
-    # def sto_fin3_gate(self):
-    #     return True
     
 COMPONENT_STATE = solara.reactive(ComponentState())

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData4.vue
@@ -6,8 +6,14 @@
     :can-advance="can_advance"
   >
     <template #before-next>
-      Choose a response.
+      <div v-if="!state_view.mc_completed">
+        Choose a response.
+      </div>
+      <div v-else>
+        Enter a response.
+      </div>
     </template>
+
     <div
       class="mb-4"
     >
@@ -24,7 +30,6 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[]"
           :neutral-answers='[0,1]'
-          @select="(status) => { if (status.neutral) { question_completed = true; } }"
           :score-tag="state_view.score_tag"
           @mc-emit="mc_callback($event)"
           :initialization="state_view.mc_score"
@@ -36,12 +41,11 @@
         auto-grow
         rows="2"
         label="Why?"
-        tag="prodata-free-4"
         :tag="state_view.free_response.tag"
         :initial-response="state_view.free_response.response"
         :initialized="state_view.free_response.initialized"
         @fr-emit="fr_callback($event)"
-        v-if="question_completed"
+        v-if="state_view.mc_completed"
       ></free-response>
     </div>
   </scaffold-alert>
@@ -51,7 +55,6 @@
 module.exports = {
   data() {
     return {
-      question_completed: false,
     };
   },
 };

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData7.vue
@@ -6,7 +6,12 @@
     :can-advance="can_advance"
   >
     <template #before-next>
-      Choose a response.
+      <div v-if="!state_view.mc_completed">
+        Choose a response.
+      </div>
+      <div v-else>
+        Enter a response.
+      </div>
     </template>
     <div
       class="mb-4"
@@ -21,7 +26,6 @@
           :feedbacks="['Interesting! Why do you choose that?','Interesting! Why do you choose that?']"
           :correct-answers="[]"
           :neutral-answers='[0,1]'
-          @select="(status) => { if (status.neutral) { question_completed = true; } }"
           :score-tag="state_view.score_tag"
           @mc-emit="mc_callback($event)"
           :initialization="state_view.mc_score"
@@ -37,7 +41,7 @@
         :initial-response="state_view.free_response.response"
         :initialized="state_view.free_response.initialized"
         @fr-emit="fr_callback($event)"
-        v-if="question_completed"
+        v-if="state_view.mc_completed"
       ></free-response>
     </div>
   </scaffold-alert>
@@ -47,7 +51,6 @@
 module.exports = {
   data() {
     return {
-      question_completed: false,
     };
   },
 };

--- a/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
+++ b/src/hubbleds/pages/06-prodata/guidelines/GuidelineProfessionalData8.vue
@@ -9,6 +9,9 @@
     @next="next_callback()"
     :can-advance="can_advance"
   >
+    <template #before-next>
+        Enter your responses.
+    </template>
     <div
       class="mb-4"
     >
@@ -24,7 +27,6 @@
           auto-grow
           rows="2"
           label="Reflection #1"
-          tag="prodata-reflect-8a"
           :tag="state_view.free_response_a.tag"
           :initial-response="state_view.free_response_a.response"
           :initialized="state_view.free_response_a.initialized"
@@ -37,7 +39,6 @@
           auto-grow
           rows="2"
           label="Age from Edwin Hubble"
-          tag="prodata-reflect-8b"
           type="float"
           :tag="state_view.free_response_b.tag"
           :initial-response="state_view.free_response_b.response"
@@ -51,7 +52,6 @@
           auto-grow
           rows="2"
           label="Age from HST Key Project"
-          tag="prodata-reflect-8c"
           type="float"
           :tag="state_view.free_response_c.tag"
           :initial-response="state_view.free_response_c.response"


### PR DESCRIPTION
This hooks up the MC & FR questions to the Stage 6 guidelines in the new state setup.

(Note that the hubble viewer & layer toggle are not set up yet).

One thing I'm noticing with the current FR handling is that typing in the FR box with valid content does not automatically change the "before-next" content to become the "next" button like it used to. You have to explicitly do something to leave the box before the next button will appear, and that is not intuitive behavior. I could picture a student pressing "enter" after entering their response, but that just adds more lines inside the FR box. I wouldn't expect a student to think to press "tab" or click somewhere outside the box to get the content to register, which is what you have to do now. Is this something we can change?