### PR TITLE
Fix story states not updating

### DIFF
--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -372,7 +372,8 @@ class LocalAPI(BaseAPI):
         state_json = json.dumps(state, cls=CDSJSONEncoder)
         r = self.request_session.put(
             f"{self.API_URL}/story-state/{global_state.value.student.id}/{local_state.value.story_id}",
-            json=state_json,
+            headers={"Content-Type": "application/json"},
+            data=state_json,
         )
 
         if r.status_code != 200:


### PR DESCRIPTION
This PR fixes the issue that we're seeing with the story states not updating. The reason for this is that we're now doing the JSON encoding ourselves, so we want to pass this in as `data` to the request session (and set the `Content-Type` header), which is what this PR does.