### PR TITLE
Fix issues with potential missing values in stage 5

### DIFF
--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -276,6 +276,7 @@ class LocalAPI(BaseAPI):
         url = (
             f"{self.API_URL}/{local_state.value.story_id}/class-measurements/"
             f"{global_state.value.student.id}/{global_state.value.classroom.class_info['id']}"
+            f"?complete_only=true"
         )
         r = self.request_session.get(url)
         measurement_json = r.json()

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -174,8 +174,11 @@ def make_summary_data(measurement_data: Data,
     for i in range(measurement_data.size):
         id_num = measurement_data[input_id_field][i]
         ids.add(id_num)
-        dists[id_num].append(d[i])
-        vels[id_num].append(v[i])
+        dist = d[i]
+        vel = v[i]
+        if dist is not None and vel is not None:
+            dists[id_num].append(dist)
+            vels[id_num].append(vel)
 
     hubbles: List[float] = []
     ages: List[float] = []


### PR DESCRIPTION
This PR fixes the issue that we noticed during the testing today, where we were getting an error with the line fits failing due to the presence of `None` values in some of the class measurements. Additionally, this (together with https://github.com/cosmicds/cds-api/pull/120) fixes a related issue that was causing an endless render loop in the student slider.