### PR TITLE
Stage 5 - layout update, wire up mc and fr guidelines

### DIFF
--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -331,8 +331,8 @@ def Page():
                     }                    
                 )
 
-                with rv.Col():
-                    ViewerLayout(viewer=viewers["layer"])
+            with rv.Col():
+                ViewerLayout(viewer=viewers["layer"])
 
     # --------------------- Row 2: SLIDER VERSION: OUR DATA HUBBLE VIEWER -----------------------
     if COMPONENT_STATE.value.current_step_between(Marker.cla_res1, Marker.con_int3):
@@ -429,7 +429,7 @@ def Page():
                 color = highlight_color if highlighted else default_color
                 student_slider_subset.style.color = color
 
-            with rv.Col():
+            with rv.Col(class_="no-padding"):
                 ViewerLayout(viewer=viewers["student_slider"])
                 if class_data_added.value:
                     class_summary_data = gjapp.data_collection["Class Summaries"]
@@ -478,6 +478,10 @@ def Page():
                     event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                     can_advance=COMPONENT_STATE.value.can_transition(next=True),
                     show=COMPONENT_STATE.value.is_current_step(Marker.cla_age1c),
+                    state_view={
+                        "class_low_age": COMPONENT_STATE.value.class_low_age,
+                        "class_high_age": COMPONENT_STATE.value.class_high_age,
+                    }
                 )
 
             def update_class_slider_subset(id, highlighted):
@@ -488,54 +492,57 @@ def Page():
                 class_slider_subset.style.color = color
 
             with rv.Col():
-                with solara.Card():
-                    ViewerLayout(viewer=viewers["class_slider"])
-                    if all_data_added.value:
-                        all_summary_data = gjapp.data_collection["All Class Summaries"]
-                        IdSlider(
-                            gjapp=gjapp,
-                            data=all_summary_data,
-                            on_id=update_class_slider_subset,
-                            highlight_ids=[GLOBAL_STATE.value.classroom.class_info.get("id", 0)],
-                            id_component=all_summary_data.id['class_id'],
-                            value_component=all_summary_data.id['age_value'],
-                            default_color=default_color,
-                            highlight_color=highlight_color
+                ViewerLayout(viewer=viewers["class_slider"])
+                if all_data_added.value:
+                    all_summary_data = gjapp.data_collection["All Class Summaries"]
+
+                    IdSlider(
+                        gjapp=gjapp,
+                        data=all_summary_data,
+                        on_id=update_class_slider_subset,
+                        highlight_ids=[GLOBAL_STATE.value.classroom.class_info.get("id", 0)],
+                        id_component=all_summary_data.id['class_id'],
+                        value_component=all_summary_data.id['age_value'],
+                        default_color=default_color,
+                        highlight_color=highlight_color
                         )
 
-            with rv.Col(cols=10, offset=1):
-                UncertaintySlideshow(
-                    event_on_slideshow_finished=lambda _: Ref(COMPONENT_STATE.fields.uncertainty_slideshow_finished).set(True),
-                    step=COMPONENT_STATE.value.uncertainty_state.step,
-                    age_calc_short1=get_free_response(LOCAL_STATE, "shortcoming-1").get("response"),
-                    age_calc_short2=get_free_response(LOCAL_STATE, "shortcoming-2").get("response"),
-                    age_calc_short_other=get_free_response(LOCAL_STATE, "other-shortcomings").get("response"),  
-                    event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
-                    free_responses=[get_free_response(LOCAL_STATE, 'shortcoming-4'), get_free_response(LOCAL_STATE, 'systematic-uncertainty')]
+                with rv.Col(cols=10, offset=1):
+                    UncertaintySlideshow(
+                        event_on_slideshow_finished=lambda _: Ref(COMPONENT_STATE.fields.uncertainty_slideshow_finished).set(True),
+                        step=COMPONENT_STATE.value.uncertainty_state.step,
+                        age_calc_short1=get_free_response(LOCAL_STATE, "shortcoming-1").get("response"),
+                        age_calc_short2=get_free_response(LOCAL_STATE, "shortcoming-2").get("response"),
+                        age_calc_short_other=get_free_response(LOCAL_STATE, "other-shortcomings").get("response"),  
+                        event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
+                        free_responses=[get_free_response(LOCAL_STATE, 'shortcoming-4'), get_free_response(LOCAL_STATE, 'systematic-uncertainty')]
                 )
 
     #--------------------- Row 4: OUR CLASS HISTOGRAM VIEWER -----------------------
     if COMPONENT_STATE.value.current_step_between(Marker.age_dis1, Marker.con_int3):
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
-                class_summary_data = gjapp.data_collection["Class Summaries"]
-                if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
-                    statistics_selected = Ref(COMPONENT_STATE.fields.statistics_selection)
-                    StatisticsSelector(
-                        viewers=[viewers["student_hist"]],
-                        glue_data=[class_summary_data],
-                        units=["counts"],
-                        transform=round,
-                        selected=statistics_selected,
-                    )
+                with rv.Row():
+                    with rv.Col():
+                        class_summary_data = gjapp.data_collection["Class Summaries"]
+                        if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
+                            statistics_selected = Ref(COMPONENT_STATE.fields.statistics_selection)
+                            StatisticsSelector(
+                                viewers=[viewers["student_hist"]],
+                                glue_data=[class_summary_data],
+                                units=["counts"],
+                                transform=round,
+                                selected=statistics_selected,
+                            )
 
-                if COMPONENT_STATE.value.current_step_between(Marker.con_int2, Marker.con_int3):
-                    percentage_selected = Ref(COMPONENT_STATE.fields.percentage_selection)
-                    PercentageSelector(
-                        viewers=[viewers["student_hist"]],
-                        glue_data=[class_summary_data],
-                        selected=percentage_selected
-                    )
+                    with rv.Col():
+                        if COMPONENT_STATE.value.current_step_between(Marker.con_int2, Marker.con_int3):
+                            percentage_selected = Ref(COMPONENT_STATE.fields.percentage_selection)
+                            PercentageSelector(
+                                viewers=[viewers["student_hist"]],
+                                glue_data=[class_summary_data],
+                                selected=percentage_selected
+                            )
 
                 ScaffoldAlert(
                     GUIDELINE_ROOT / "GuidelineClassAgeDistribution.vue",
@@ -611,22 +618,25 @@ def Page():
     if COMPONENT_STATE.value.current_step_between(Marker.age_dis1c):
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
-                all_class_summary_data = gjapp.data_collection["All Class Summaries"]
-                statistics_class_selected = Ref(COMPONENT_STATE.fields.statistics_selection_class)
-                StatisticsSelector(
-                    viewers=[viewers["class_hist"]],
-                    glue_data=[all_class_summary_data],
-                    units=["counts"],
-                    transform=round,
-                    selected=statistics_class_selected
-                )
+                with rv.Row():
+                    with rv.Col():
+                        all_class_summary_data = gjapp.data_collection["All Class Summaries"]
+                        statistics_class_selected = Ref(COMPONENT_STATE.fields.statistics_selection_class)
+                        StatisticsSelector(
+                            viewers=[viewers["class_hist"]],
+                            glue_data=[all_class_summary_data],
+                            units=["counts"],
+                            transform=round,
+                            selected=statistics_class_selected
+                        )
 
-                percentage_class_selected = Ref(COMPONENT_STATE.fields.percentage_selection_class)
-                PercentageSelector(
-                    viewers=[viewers["class_hist"]],
-                    glue_data=[all_class_summary_data],
-                    selected=percentage_class_selected
-                )
+                    with rv.Col():
+                        percentage_class_selected = Ref(COMPONENT_STATE.fields.percentage_selection_class)
+                        PercentageSelector(
+                            viewers=[viewers["class_hist"]],
+                            glue_data=[all_class_summary_data],
+                            selected=percentage_class_selected
+                        )
 
                 ScaffoldAlert(
                     GUIDELINE_ROOT / "GuidelineClassAgeDistributionc.vue",

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -523,26 +523,27 @@ def Page():
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
                 with rv.Row():
-                    with rv.Col():
+                    if class_data_added.value:
                         class_summary_data = gjapp.data_collection["Class Summaries"]
-                        if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
-                            statistics_selected = Ref(COMPONENT_STATE.fields.statistics_selection)
-                            StatisticsSelector(
-                                viewers=[viewers["student_hist"]],
-                                glue_data=[class_summary_data],
-                                units=["counts"],
-                                transform=round,
-                                selected=statistics_selected,
-                            )
+                        with rv.Col():
+                            if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
+                                statistics_selected = Ref(COMPONENT_STATE.fields.statistics_selection)
+                                StatisticsSelector(
+                                    viewers=[viewers["student_hist"]],
+                                    glue_data=[class_summary_data],
+                                    units=["counts"],
+                                    transform=round,
+                                    selected=statistics_selected,
+                                )
 
-                    with rv.Col():
-                        if COMPONENT_STATE.value.current_step_between(Marker.con_int2, Marker.con_int3):
-                            percentage_selected = Ref(COMPONENT_STATE.fields.percentage_selection)
-                            PercentageSelector(
-                                viewers=[viewers["student_hist"]],
-                                glue_data=[class_summary_data],
-                                selected=percentage_selected
-                            )
+                        with rv.Col():
+                            if COMPONENT_STATE.value.current_step_between(Marker.con_int2, Marker.con_int3):
+                                percentage_selected = Ref(COMPONENT_STATE.fields.percentage_selection)
+                                PercentageSelector(
+                                    viewers=[viewers["student_hist"]],
+                                    glue_data=[class_summary_data],
+                                    selected=percentage_selected
+                                )
 
                 ScaffoldAlert(
                     GUIDELINE_ROOT / "GuidelineClassAgeDistribution.vue",
@@ -619,24 +620,25 @@ def Page():
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
                 with rv.Row():
-                    with rv.Col():
+                    if all_data_added.value:
                         all_class_summary_data = gjapp.data_collection["All Class Summaries"]
-                        statistics_class_selected = Ref(COMPONENT_STATE.fields.statistics_selection_class)
-                        StatisticsSelector(
-                            viewers=[viewers["class_hist"]],
-                            glue_data=[all_class_summary_data],
-                            units=["counts"],
-                            transform=round,
-                            selected=statistics_class_selected
-                        )
+                        with rv.Col():
+                            statistics_class_selected = Ref(COMPONENT_STATE.fields.statistics_selection_class)
+                            StatisticsSelector(
+                                viewers=[viewers["class_hist"]],
+                                glue_data=[all_class_summary_data],
+                                units=["counts"],
+                                transform=round,
+                                selected=statistics_class_selected
+                            )
 
-                    with rv.Col():
-                        percentage_class_selected = Ref(COMPONENT_STATE.fields.percentage_selection_class)
-                        PercentageSelector(
-                            viewers=[viewers["class_hist"]],
-                            glue_data=[all_class_summary_data],
-                            selected=percentage_class_selected
-                        )
+                        with rv.Col():
+                            percentage_class_selected = Ref(COMPONENT_STATE.fields.percentage_selection_class)
+                            PercentageSelector(
+                                viewers=[viewers["class_hist"]],
+                                glue_data=[all_class_summary_data],
+                                selected=percentage_class_selected
+                            )
 
                 ScaffoldAlert(
                     GUIDELINE_ROOT / "GuidelineClassAgeDistributionc.vue",

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -593,8 +593,9 @@ def Page():
         show=COMPONENT_STATE.value.is_current_step(Marker.mos_lik4),
         event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
         state_view={
-            'free_response_a': get_free_response(LOCAL_STATE,'best-guess-age').get("response"),
-            'free_response_b': get_free_response(LOCAL_STATE,'my-reasoning').get("response")
+            'free_response_a': get_free_response(LOCAL_STATE,'best-guess-age'),
+            'best_guess_answered': LOCAL_STATE.value.question_completed("best-guess-age"),
+            'free_response_b': get_free_response(LOCAL_STATE,'my-reasoning')
         }
     )
 
@@ -608,6 +609,7 @@ def Page():
         state_view={
             'free_response_a': get_free_response(LOCAL_STATE,'likely-low-age'),
             'free_response_b': get_free_response(LOCAL_STATE,'likely-high-age'),
+            'high_low_answered': LOCAL_STATE.value.question_completed("likely-low-age") and LOCAL_STATE.value.question_completed("likely-high-age"),
             'free_response_c': get_free_response(LOCAL_STATE,'my-reasoning-2'),
         }
     )
@@ -721,9 +723,9 @@ def Page():
             show=COMPONENT_STATE.value.is_current_step(Marker.con_int2c),
             event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
             state_view={
-                "low_guess": get_free_response(LOCAL_STATE, "likely-low-age").get("response"),
-                "high_guess": get_free_response(LOCAL_STATE, "likely-high-age").get("response"),
-                "best_guess": get_free_response(LOCAL_STATE, "best-guess-age").get("response"),
+                "low_guess": get_free_response(LOCAL_STATE, "likely-low-age"),
+                "high_guess": get_free_response(LOCAL_STATE, "likely-high-age"),
+                "best_guess": get_free_response(LOCAL_STATE, "best-guess-age"),
                 'free_response_a': get_free_response(LOCAL_STATE, 'new-most-likely-age'),
                 'free_response_b': get_free_response(LOCAL_STATE, 'new-likely-low-age'),
                 'free_response_c': get_free_response(LOCAL_STATE, 'new-likely-high-age'),

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -723,9 +723,9 @@ def Page():
             show=COMPONENT_STATE.value.is_current_step(Marker.con_int2c),
             event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
             state_view={
-                "low_guess": get_free_response(LOCAL_STATE, "likely-low-age"),
-                "high_guess": get_free_response(LOCAL_STATE, "likely-high-age"),
-                "best_guess": get_free_response(LOCAL_STATE, "best-guess-age"),
+                "low_guess": get_free_response(LOCAL_STATE, "likely-low-age").get("response"),
+                "high_guess": get_free_response(LOCAL_STATE, "likely-high-age").get("response"),
+                "best_guess": get_free_response(LOCAL_STATE, "best-guess-age").get("response"),
                 'free_response_a': get_free_response(LOCAL_STATE, 'new-most-likely-age'),
                 'free_response_b': get_free_response(LOCAL_STATE, 'new-likely-low-age'),
                 'free_response_c': get_free_response(LOCAL_STATE, 'new-likely-high-age'),

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -46,16 +46,16 @@ def Page():
 
     solara.lab.use_task(_load_component_state)
 
-    async def _write_component_state():
-        if not loaded_component_state.value:
-            return
+    # async def _write_component_state():
+    #     if not loaded_component_state.value:
+    #         return
 
-        # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+    #     # Listen for changes in the states and write them to the database
+    #     LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
 
-        logger.info("Wrote stage 5 component state to database.")
+    #     logger.info("Wrote stage 5 component state to database.")
 
-    solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
+    # solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     
     class_data_loaded = solara.use_reactive(False)
     async def _load_class_data():

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -593,7 +593,6 @@ def Page():
         show=COMPONENT_STATE.value.is_current_step(Marker.mos_lik4),
         event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
         state_view={
-            "hint1_dialog": COMPONENT_STATE.value.age_calc_state.hint1_dialog,
             'free_response_a': get_free_response(LOCAL_STATE,'best-guess-age').get("response"),
             'free_response_b': get_free_response(LOCAL_STATE,'my-reasoning').get("response")
         }
@@ -607,7 +606,6 @@ def Page():
         show=COMPONENT_STATE.value.is_current_step(Marker.con_int3),
         event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
         state_view={
-            "hint2_dialog": COMPONENT_STATE.value.age_calc_state.hint2_dialog,
             'free_response_a': get_free_response(LOCAL_STATE,'likely-low-age'),
             'free_response_b': get_free_response(LOCAL_STATE,'likely-high-age'),
             'free_response_c': get_free_response(LOCAL_STATE,'my-reasoning-2'),
@@ -723,8 +721,6 @@ def Page():
             show=COMPONENT_STATE.value.is_current_step(Marker.con_int2c),
             event_fr_callback=lambda event: fr_callback(event=event, local_state=LOCAL_STATE),
             state_view={
-                "hint1_dialog": COMPONENT_STATE.value.age_calc_state.hint1_dialog,
-                "hint2_dialog": COMPONENT_STATE.value.age_calc_state.hint2_dialog,
                 "low_guess": get_free_response(LOCAL_STATE, "likely-low-age").get("response"),
                 "high_guess": get_free_response(LOCAL_STATE, "likely-high-age").get("response"),
                 "best_guess": get_free_response(LOCAL_STATE, "best-guess-age").get("response"),

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -1,13 +1,15 @@
-import enum
-from pydantic import BaseModel, field_validator
 import solara
-from typing import List, Any
+
+from pydantic import BaseModel, field_validator
 
 from cosmicds.state import BaseState
 from hubbleds.base_marker import BaseMarker
 from hubbleds.base_component_state import BaseComponentState
 from hubbleds.state import LOCAL_STATE
 
+import enum
+
+from typing import List, Any
 
 class Marker(enum.Enum, BaseMarker):
     ran_var1 = enum.auto()
@@ -84,8 +86,24 @@ class ComponentState(BaseComponentState, BaseState):
         return v
 
     @property
-    def mos_lik_gate(self) -> bool:
-        return self.uncertainty_slideshow_finished
+    def mos_lik1_gate(self) -> bool:
+        return COMPONENT_STATE.value.uncertainty_slideshow_finished
+    
+    @property
+    def cla_age1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("age-slope-trend")
+    
+    @property
+    def two_his3_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("histogram-range")
+    
+    @property
+    def two_his4_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("histogram-percent-range")
+    
+    @property
+    def two_his5_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("histogram-distribution")
 
     # TODO: Implement other gates that require checking MC status
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -56,13 +56,6 @@ class MMMState(BaseModel):
     length: int = 3
     titles: List[str] = ["Mean", "Median", "Mode"]
 
-
-class AgeCalcState(BaseModel):
-    hint1_dialog: bool = False
-    hint2_dialog: bool = False
-    hint3_dialog: bool = False
-
-
 class ComponentState(BaseComponentState, BaseState):
     current_step: Marker = Marker.first()
     stage_id: str = "class_results_and_uncertainty"
@@ -73,7 +66,6 @@ class ComponentState(BaseComponentState, BaseState):
     uncertainty_state: UncertaintyState = UncertaintyState()
     uncertainty_slideshow_finished: bool = False
     mmm_state: MMMState = MMMState()
-    age_calc_state: AgeCalcState = AgeCalcState()
     percentage_selection: str | None = None
     statistics_selection: str | None = None
     percentage_selection_class: int | None = None

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -78,13 +78,25 @@ class ComponentState(BaseComponentState, BaseState):
         return v
 
     @property
-    def mos_lik1_gate(self) -> bool:
-        return COMPONENT_STATE.value.uncertainty_slideshow_finished
-    
-    @property
     def cla_age1_gate(self) -> bool:
         return LOCAL_STATE.value.question_completed("age-slope-trend")
+
+    @property
+    def mos_lik1_gate(self) -> bool:
+        return COMPONENT_STATE.value.uncertainty_slideshow_finished
+
+    @property
+    def con_int1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("best-guess-age") and LOCAL_STATE.value.question_completed("my-reasoning")    
     
+    @property
+    def cla_dat1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("likely-low-age") and LOCAL_STATE.value.question_completed("likely-high-age") and LOCAL_STATE.value.question_completed("my-reasoning-2")  
+    
+    @property
+    def two_his1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("new-most-likely-age") and LOCAL_STATE.value.question_completed("new-likely-low-age") and LOCAL_STATE.value.question_completed("new-likely-high-age") and LOCAL_STATE.value.question_completed("my-updated-reasoning")  
+
     @property
     def two_his3_gate(self) -> bool:
         return LOCAL_STATE.value.question_completed("histogram-range")
@@ -97,7 +109,9 @@ class ComponentState(BaseComponentState, BaseState):
     def two_his5_gate(self) -> bool:
         return LOCAL_STATE.value.question_completed("histogram-distribution")
 
-    # TODO: Implement other gates that require checking MC status
-
+    @property
+    def mor_dat1_gate(self) -> bool:
+        return LOCAL_STATE.value.question_completed("unc-range-change-reasoning")
+    
 
 COMPONENT_STATE = solara.reactive(ComponentState())

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRangec.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineClassAgeRangec.vue
@@ -34,7 +34,6 @@
         $$ \text{Lowest age:  } \bbox[#FBE9E7]{\input[low_age][]{} } \text{ Gyr} $$
         $$ \text{Highest age:  } \bbox[#FBE9E7]{\input[high_age][]{} } \text{ Gyr} $$
       </div>
-      <v-divider role="presentation"></v-divider>
     </div>
     <v-divider
       class="my-4"

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
@@ -24,11 +24,11 @@
         <v-col>
           <v-btn
             color="secondary lighten-1"
-            @click="state_view.hint1_dialog = true"
+            @click="dialog1 = true"
           >
             hint
             <v-dialog
-              v-model="state_view.hint1_dialog"
+              v-model="dialog1"
               persistent
               max-width="600px">
               <v-card
@@ -49,7 +49,7 @@
                     @click="
                       () => {
                         $emit('close');
-                        state_view.hint1_dialog = false;
+                        dialog1 = false;
                       }
                     "
                   >
@@ -102,11 +102,11 @@
         <v-col>
           <v-btn
             color="secondary lighten-1"
-            @click="state_view.hint2_dialog = true"
+            @click="dialog2 = true"
           >
             hint
             <v-dialog
-              v-model="state_view.hint2_dialog"
+              v-model="dialog2"
               persistent
               max-width="600px">
               <v-card
@@ -127,7 +127,7 @@
                     @click="
                       () => {
                         $emit('close');
-                        state_view.hint2_dialog = false;
+                        dialog2 = false;
                       }
                     "
                   >
@@ -208,4 +208,12 @@
   </scaffold-alert>
 </template>
 <script>
+export default {
+  data() {
+    return {
+      dialog1: false,
+      dialog2: false,
+    }
+  },
+}
 </script>

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect2c.vue
@@ -6,6 +6,9 @@
     @next="next_callback()"
     :can-advance="can_advance"
   >
+    <template #before-next>
+      Enter responses.
+    </template>
     <div
       class="mb-4"
     >
@@ -80,7 +83,7 @@
             outlined
             rows="1"
             label="New Most Likely Age"
-            tag="new-most-likely-age"
+            :tag="state_view.free_response_a.tag"
             type="float"
             :initial-response="state_view.free_response_a.response"
             :initialized="state_view.free_response_a.initialized"
@@ -161,7 +164,7 @@
             outlined
             rows="1"
             label="New Likely Low Age"
-            tag="new-likely-low-age"
+            :tag="state_view.free_response_b.tag"
             type="float"
             :initial-response="state_view.free_response_b.response"
             :initialized="state_view.free_response_b.initialized"
@@ -179,7 +182,7 @@
             outlined
             rows="1"
             label="New Likely High Age"
-            tag="new-likely-high-age"
+            :tag="state_view.free_response_c.tag"
             type="float"
             :initial-response="state_view.free_response_c.response"
             :initialized="state_view.free_response_c.initialized"
@@ -199,7 +202,7 @@
         outlined
         rows="1"
         label="My Updated Reasoning"
-        tag="my-updated-reasoning"
+        :tag="state_view.free_response_d.tag"
         :initial-response="state_view.free_response_d.response"
         :initialized="state_view.free_response_d.initialized"
         @fr-emit="fr_callback($event)"

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
@@ -3,18 +3,12 @@
     title-text="Identify Your Confidence Interval"
     ref="scaffold"
     @back="back_callback()"
-    @next="() => {
-      if (revealIter < 1) {
-        revealIter = revealIter + 1;
-      }
-      else {
-        next_callback();
-        // state_view.trend_line_drawn = false;
-        // state_view.best_fit_clicked = false;
-      }
-    }"
+    @next="next_callback()"
     :can-advance="can_advance"
   >
+    <template #before-next>
+      Enter responses.
+    </template>
     <div
       class="mb-4"
     >
@@ -82,9 +76,7 @@
           </v-btn>
         </v-col>
       </v-row>
-      <v-row
-        v-if="revealIter >= 0"
-      >
+      <v-row>
         <v-col
           cols="12"
           lg="3">
@@ -92,7 +84,7 @@
             outlined
             rows="1"
             label="Likely Low Age"
-            tag="likely-low-age"
+            :tag="state_view.free_response_a.tag"
             type="float"
             :initial-response="state_view.free_response_a.response"
             :initialized="state_view.free_response_a.initialized"
@@ -110,7 +102,7 @@
             outlined
             rows="1"
             label="Likely High Age"
-            tag="likely-high-age"
+            :tag="state_view.free_response_b.tag"
             type="float"
             :initial-response="state_view.free_response_b.response"
             :initialized="state_view.free_response_b.initialized"
@@ -124,14 +116,14 @@
       </v-row>
 
       <v-row
-        v-if="revealIter >= 1"
+        v-if="state_view.high_low_answered"
       >
         <v-col>
           4. Explain why you chose your values using information from the histogram or other viewers:
         </v-col>
       </v-row>
       <v-row
-        v-if="revealIter >= 1"
+        v-if="state_view.high_low_answered"
       >
         <v-col>
           <free-response
@@ -139,7 +131,7 @@
             auto-grow
             rows="2"
             label="My Reasoning"
-            tag="my-reasoning-2"
+            :tag="state_view.free_response_c.tag"
             :initial-response="state_view.free_response_c.response"
             :initialized="state_view.free_response_c.initialized"
             @fr-emit="fr_callback($event)"
@@ -156,21 +148,9 @@
 export default {
   data() {
     return {
-      revealIter: 0,
       dialog: false,
     }
   },
-  watch: {
-    revealIter(_value) {
-      const scaffold = this.$refs.scaffold;
-      this.$nextTick(() => {
-        scaffold.$refs.next.$el.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        });
-      });
-    }
-  }
 }
 </script>
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineConfidenceIntervalReflect3.vue
@@ -32,11 +32,11 @@
         <v-col>
           <v-btn
             color="secondary lighten-1"
-            @click="state_view.hint2_dialog = true"
+            @click="dialog = true"
           >
             hint
             <v-dialog
-              v-model="state_view.hint2_dialog"
+              v-model="dialog"
               persistent
               max-width="600px">
               <v-card
@@ -57,7 +57,7 @@
                     @click="
                       () => {
                         $emit('close');
-                        state_view.hint2_dialog = false;
+                        dialog = false;
                       }
                     "
                   >
@@ -156,7 +156,8 @@
 export default {
   data() {
     return {
-      revealIter: 0
+      revealIter: 0,
+      dialog: false,
     }
   },
   watch: {

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
@@ -28,11 +28,11 @@
         <v-col>
           <v-btn
             color="secondary lighten-1"
-            @click="state_view.hint1_dialog = true"
+            @click="dialog = true"
           >
             hint
             <v-dialog
-              v-model="state_view.hint1_dialog"
+              v-model="dialog"
               persistent
               max-width="600px">
               <v-card
@@ -53,7 +53,7 @@
                     @click="
                       () => {
                         $emit('close');
-                        state_view.hint1_dialog = false;
+                        dialog = false;
                       }
                     "
                   >
@@ -128,6 +128,7 @@
 export default {
   data() {
     return {
+      dialog: false,
       revealIter: 0
     }
   },

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineMostLikelyValueReflect4.vue
@@ -1,18 +1,13 @@
 <template>
   <scaffold-alert
     title-text="Identify Your Confidence Interval"
-    ref="scaffold"
     @back="back_callback()"
-    @next="() => {
-      if (revealIter < 1) {
-        revealIter = revealIter + 1;
-      }
-      else {
-        next_callback();
-      }
-    }"
+    @next="next_callback();"
     :can-advance="can_advance"
   >
+    <template #before-next>
+      Enter a response.
+    </template>
     <div
       class="mb-4"
     >
@@ -84,7 +79,7 @@
             outlined
             rows="1"
             label="Most Likely Age"
-            tag="best-guess-age"
+            :tag="state_view.free_response_a.tag"
             type="float"
             :initial-response="state_view.free_response_a.response"
             :initialized="state_view.free_response_a.initialized"
@@ -98,14 +93,14 @@
 
 
       <v-row
-        v-if="revealIter >= 1"
+        v-if="state_view.best_guess_answered"
       >
         <v-col>
           2. Explain why you picked that value and how your choice is connected to your understanding of the mean, median, or mode.
         </v-col>
       </v-row>
       <v-row
-        v-if="revealIter >= 1"
+        v-if="state_view.best_guess_answered"
       >
         <v-col>
           <free-response
@@ -113,7 +108,7 @@
             auto-grow
             rows="2"
             label="My Reasoning"
-            tag="my-reasoning"
+            :tag="state_view.free_response_b.tag"
             :initial-response="state_view.free_response_b.response"
             :initialized="state_view.free_response_b.initialized"
             @fr-emit="fr_callback($event)"
@@ -129,20 +124,8 @@ export default {
   data() {
     return {
       dialog: false,
-      revealIter: 0
     }
   },
-  watch: {
-    revealIter(_value) {
-      const scaffold = this.$refs.scaffold;
-      this.$nextTick(() => {
-        scaffold.$refs.next.$el.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        });
-      });
-    }
-  }
 }
 </script>
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/guidelines/GuidelineTwoHistogramsReflect5.vue
@@ -5,6 +5,9 @@
     @next="next_callback()"
     :can-advance="can_advance"
   >
+    <template #before-next>
+      Enter a response.
+    </template>
     <div
       class="mb-4"
     >


### PR DESCRIPTION
This updates the layout to match the voila version more closely and wires up the MC & FR questions.

Note that we still have the FR issue where simply entering a valid response in the box does not trigger the gate to the next guideline to open. You have to click outside the entry box for it to register.

I've also commented out the writing of the Stage 5 component state to the db because it was triggering a lot of errors during testing depending on what guideline I was on. We'll need to do some more testing to track those all down.

Note that FR & MC questions will still be stored to the db because those are in the story state, not the stage state.