### PR TITLE
Exclude measurements and summaries from local state serialization

### DIFF
--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -369,10 +369,8 @@ class LocalAPI(BaseAPI):
         logger.info("Serializing state into DB.")
 
         state = {
-            "app": global_state.value.dict(),
-            "story": local_state.value.dict(
-                exclude={"measurements", "example_measurements"}
-            ),
+            "app": global_state.value.model_dump(),
+            "story": local_state.value.as_dict(),
         }
 
         state_json = json.dumps(state, cls=CDSJSONEncoder)

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -136,7 +136,15 @@ class LocalState(BaseLocalState):
         return LOCAL_API.get_galaxies(LOCAL_STATE)
 
     def as_dict(self):
-        self.model_dump(exclude={"measurements_loaded"})
+        return self.model_dump(exclude={
+            "example_measurements",
+            "measurements",
+            "measurements_loaded",
+            "class_measurements",
+            "all_measurements",
+            "student_summaries",
+            "class_summaries",
+        })
 
     def get_measurement(self, galaxy_id: int) -> StudentMeasurement | None:
         return next((x for x in self.measurements if x.galaxy_id == galaxy_id), None)


### PR DESCRIPTION
This PR resolves #470 by excluding items from the state model dump that we don't really need - in particular, all of the measurements and summaries that we're going to load from other database tables.