### PR TITLE
Get class best fit slope from line draw viewer

### DIFF
--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
   name: "LineDrawPlot",
-  props: ["active", "fit_active", "line_drawn", "plot_data", "x_axis_label", "y_axis_label"],
+  props: ["active", "fit_active", "line_drawn", "line_fit", "plot_data", "x_axis_label", "y_axis_label"],
   async mounted() {
     await window.plotlyPromise;
 
@@ -92,6 +92,7 @@ export default {
       lineTraceIndex: 0,
       fitLineTraceIndex: 1,
       endpointSize: 10,
+      lastFitSlope: null,
     };
   },
   methods: {
@@ -227,6 +228,7 @@ export default {
     },
     fitLinePoints(x, y) {
       const [a, b] = this.linearRegression(x, y);
+      this.lastFitSlope = a;
       const xs = this.element._fullLayout.xaxis.range;
       const ys = xs.map(v => a * v + b);
       return [xs, ys];
@@ -291,6 +293,9 @@ export default {
           'y.0': ys[0],
           'y.1': ys[1],
         };
+        if (this.line_fit) {
+          this.line_fit(this.lastFitSlope);
+        }
       }
       Plotly.update(this.chart.uuid, update, {}, [this.fitLineTraceIndex]);
     },

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -1,20 +1,26 @@
 import reacton.ipyvuetify as rv
 import solara
+from typing import Callable, Optional
 
 
 @solara.component_vue("LineDrawPlot.vue")
-def LineDrawPlot(active,
-                 fit_active=False,
-                 event_line_drawn=None,
-                 plot_data=None,
-                 x_axis_label=None,
-                 y_axis_label=None
+def LineDrawPlot(active: bool,
+                 fit_active: bool=False,
+                 event_line_drawn: Optional[Callable]=None,
+                 event_line_fit: Optional[Callable[[float], None]]=None,
+                 plot_data: Optional[list[dict]]=None,
+                 x_axis_label: Optional[str]=None,
+                 y_axis_label: Optional[str]=None
 ):
     pass
 
 
 @solara.component
-def LineDrawViewer(plot_data=None, x_axis_label=None, y_axis_label=None):
+def LineDrawViewer(plot_data: Optional[list[dict]]=None,
+                   x_axis_label: Optional[str]=None,
+                   y_axis_label: Optional[str]=None,
+                   on_line_drawn: Optional[Callable]=None,
+                   on_line_fit: Optional[Callable[[float], None]]=None):
 
     draw_active = solara.use_reactive(False)
     fit_active = solara.use_reactive(False)
@@ -25,7 +31,7 @@ def LineDrawViewer(plot_data=None, x_axis_label=None, y_axis_label=None):
 
     def on_fit_clicked():
         draw_active.set(False)
-        fit_active.set(not fit_active.value) 
+        fit_active.set(not fit_active.value)
 
     # If we want to disable the tool after finishing a line draw
     # pass this function to `LineDrawPlot` as `event_line_drawn`
@@ -45,7 +51,8 @@ def LineDrawViewer(plot_data=None, x_axis_label=None, y_axis_label=None):
 
         LineDrawPlot(active=draw_active.value,
                      fit_active=fit_active.value,
-                     event_line_drawn=None,
+                     event_line_drawn=on_line_drawn,
+                     event_line_fit=on_line_fit,
                      plot_data=plot_data,
                      x_axis_label=x_axis_label,
                      y_axis_label=y_axis_label

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -260,7 +260,11 @@ def Page():
                                 "marker": { "color": "red", "size": 12 },
                                 "hoverinfo": "none"
                             }]
-                            LineDrawViewer(plot_data=plot_data, x_axis_label="Distance (Mpc)", y_axis_label="Velocity (km / s)")
+                            best_fit_slope = Ref(LOCAL_STATE.fields.best_fit_slope)
+                            LineDrawViewer(plot_data=plot_data,
+                                           on_line_fit=best_fit_slope.set,
+                                           x_axis_label="Distance (Mpc)",
+                                           y_axis_label="Velocity (km / s)")
 
             with rv.Col(cols=10, offset=1):
                 if COMPONENT_STATE.value.current_step_at_or_after(

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -119,6 +119,7 @@ class LocalState(BaseLocalState):
     calculations: dict = {}
     validation_failure_counts: dict = {}
     has_best_fit_galaxy: bool = False
+    best_fit_slope: Optional[float] = None
     enough_students_ready: bool = False
     class_data_students: list = []
     class_data_info: dict = {}


### PR DESCRIPTION
One thing that #479 didn't do was provide us with a way to get a slope value out of the best-fit line from the stage 4 viewer where the students do the line draw and fit for their data. This PR updates enables that, storing the most recent best-fit slope value in a new `best_fit_slope` value in the story state.