### PR TITLE
Set WWT widget to have black background

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -168,7 +168,10 @@ footer .v-card__text {
     background-color: #000b !important;
 }
 
-
+/** By default the WWT widget has a transparent background, but we want it to be black **/
+#app .wwtelescope-component {
+    background-color: #000;
+}
 
 /*.solara-container-main {*/
 /*    max-width: 1264px;*/


### PR DESCRIPTION
This PR fixes #451 by setting the background color of the `div` containing a WWT widget in our custom CSS.