### PR TITLE
Dont store percent and stats selections

### DIFF
--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -549,22 +549,18 @@ def Page():
                         class_summary_data = gjapp.data_collection["Class Summaries"]
                         with rv.Col():
                             if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
-                                statistics_selected = Ref(COMPONENT_STATE.fields.statistics_selection)
                                 StatisticsSelector(
                                     viewers=[viewers["student_hist"]],
                                     glue_data=[class_summary_data],
                                     units=["counts"],
                                     transform=round,
-                                    selected=statistics_selected,
                                 )
 
                         with rv.Col():
                             if COMPONENT_STATE.value.current_step_between(Marker.con_int2, Marker.con_int3):
-                                percentage_selected = Ref(COMPONENT_STATE.fields.percentage_selection)
                                 PercentageSelector(
                                     viewers=[viewers["student_hist"]],
                                     glue_data=[class_summary_data],
-                                    selected=percentage_selected
                                 )
 
                 ScaffoldAlert(
@@ -644,21 +640,17 @@ def Page():
                 with rv.Row():
                     all_class_summary_data = gjapp.data_collection["All Class Summaries"]
                     with rv.Col():
-                        statistics_class_selected = Ref(COMPONENT_STATE.fields.statistics_selection_class)
                         StatisticsSelector(
                             viewers=[viewers["class_hist"]],
                             glue_data=[all_class_summary_data],
                             units=["counts"],
                             transform=round,
-                            selected=statistics_class_selected
                         )
 
                     with rv.Col():
-                        percentage_class_selected = Ref(COMPONENT_STATE.fields.percentage_selection_class)
                         PercentageSelector(
                             viewers=[viewers["class_hist"]],
                             glue_data=[all_class_summary_data],
-                            selected=percentage_class_selected
                         )
 
                 ScaffoldAlert(

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -193,13 +193,14 @@ def Page():
                                                output_id_field="id",
                                                label="Class Summaries")
         class_summary_data = GLOBAL_STATE.value.add_or_update_data(class_summary_data)
-        class_data_added.set(True)
 
         hist_viewer = viewers["student_hist"]
         hist_viewer.add_data(class_summary_data)
         hist_viewer.state.x_att = class_summary_data.id['age_value']
         hist_viewer.state.title = "My class ages (5 galaxies each)"
         hist_viewer.layers[0].state.color = "red"
+
+        class_data_added.set(True)
 
     class_data_loaded.subscribe(_on_class_data_loaded)
 
@@ -251,8 +252,6 @@ def Page():
         else:
             class_slider_subset = all_data.subsets[0]
 
-        all_data_added.set(True)
-
         slider_viewer = viewers["class_slider"]
         slider_viewer.add_data(all_data)
         slider_viewer.state.x_att = all_data.id['est_dist_value']
@@ -267,7 +266,11 @@ def Page():
         hist_viewer.state.title = "All class ages (5 galaxies each)"
         hist_viewer.layers[0].state.color = "blue"
 
+        all_data_added.set(True)
+
     all_data_loaded.subscribe(_on_all_data_loaded)
+
+
     student_data_added.subscribe(_setup_links)
     class_data_added.subscribe(_setup_links)
 
@@ -283,6 +286,8 @@ def Page():
             size=100,
         )
         return
+
+    logger.info("DATA IS READY")
 
     StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/component_state.py
@@ -50,12 +50,6 @@ class Marker(enum.Enum, BaseMarker):
 class UncertaintyState(BaseModel):
     step: int = 0
 
-
-class MMMState(BaseModel):
-    step: int = 0
-    length: int = 3
-    titles: List[str] = ["Mean", "Median", "Mode"]
-
 class ComponentState(BaseComponentState, BaseState):
     current_step: Marker = Marker.first()
     stage_id: str = "class_results_and_uncertainty"
@@ -65,11 +59,6 @@ class ComponentState(BaseComponentState, BaseState):
     class_high_age: int = 0
     uncertainty_state: UncertaintyState = UncertaintyState()
     uncertainty_slideshow_finished: bool = False
-    mmm_state: MMMState = MMMState()
-    percentage_selection: int | None = None
-    statistics_selection: str | None = None
-    percentage_selection_class: int | None = None
-    statistics_selection_class: str | None = None
 
     @field_validator("current_step", mode="before")
     def convert_int_to_enum(cls, v: Any) -> Marker:


### PR DESCRIPTION
This goes with https://github.com/cosmicds/cosmicds/pull/313.

We don't need to store students' selections on the percentage or statistics selectors on reload, and it was causing problems reloading the Stage 5 state, as noted [here](https://github.com/cosmicds/hubbleds/pull/487).

Instead of passing the values to the component from the Stage 5 page, we just use local reactive variables.

Note that on the `two_his1` guideline, the stats/percentage selector should target both viewers, but it currently only displays the stats line/percentage subsets in the bottom viewer. (This was the case before I made this update).