### PR TITLE
Add score to piggybank_total as part of mc_callback

### DIFF
--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -216,6 +216,7 @@ def mc_callback(
     """
 
     mc_scoring = Ref(local_state.fields.mc_scoring)
+    piggybank_total = Ref(GLOBAL_STATE.fields.piggybank_total)
     new = mc_scoring.value.model_copy(deep=True)
     logger.info(f"MC Callback Event: {event[0]}")
     logger.info(f"Current mc_scoring: {new}")
@@ -231,7 +232,16 @@ def mc_callback(
     # mc-score event returns a data which is an mc-score dictionary (includes tag)
     elif event[0] == "mc-score":
         new.update_mc_score(**event[1])
+
+        # update piggybank_total
+        try:
+            score = int(event[1]["score"])
+        except (TypeError, ValueError):
+            score = 0
+        total_score = piggybank_total.value + score
+        piggybank_total.set(total_score)
         mc_scoring.set(new)
+        
         if callback is not None:
             callback(new)
 

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -216,7 +216,7 @@ def mc_callback(
     """
 
     mc_scoring = Ref(local_state.fields.mc_scoring)
-    piggybank_total = Ref(GLOBAL_STATE.fields.piggybank_total)
+    piggybank_total = Ref(local_state.fields.piggybank_total)
     new = mc_scoring.value.model_copy(deep=True)
     logger.info(f"MC Callback Event: {event[0]}")
     logger.info(f"Current mc_scoring: {new}")


### PR DESCRIPTION
This goes with https://github.com/cosmicds/cosmicds/pull/315.

Not sure if this is quite the right way to do this, but it seems to work.

I'm using the `GLOBAL_STATE` here because the `piggybank_total` is displayed in the `cosmicds layout.py.` Note, though, that the points total seems like it should be a story state thing (`LOCAL_STATE`) rather than app state. @nmearl, is there a way for the `cosmicds layout.py` to access the story state? 