### PR TITLE
Update stage 5 histograms and selectors

### DIFF
--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -128,12 +128,14 @@ def Page():
         student_slider_viewer = gjapp.new_data_viewer(HubbleScatterView, show=False)
         class_slider_viewer = gjapp.new_data_viewer(HubbleScatterView, show=False)
         student_hist_viewer = gjapp.new_data_viewer(CDSHistogramView, show=False)
+        all_student_hist_viewer = gjapp.new_data_viewer(CDSHistogramView, show=False)
         class_hist_viewer = gjapp.new_data_viewer(CDSHistogramView, show=False)
         viewers = {
             "layer": layer_viewer,
             "student_slider": student_slider_viewer,
             "class_slider": class_slider_viewer,
             "student_hist": student_hist_viewer,
+            "all_student_hist": all_student_hist_viewer,
             "class_hist": class_hist_viewer
         }
 
@@ -260,11 +262,17 @@ def Page():
         slider_viewer.layers[0].state.visible = False
         slider_viewer.add_subset(class_slider_subset)
 
-        hist_viewer = viewers["class_hist"]
-        hist_viewer.add_data(all_class_summ_data)
-        hist_viewer.state.x_att = all_class_summ_data.id['age_value']
-        hist_viewer.state.title = "All class ages (5 galaxies each)"
-        hist_viewer.layers[0].state.color = "blue"
+        student_hist_viewer = viewers["all_student_hist"]
+        student_hist_viewer.add_data(student_summ_data)
+        student_hist_viewer.state.x_att = student_summ_data.id['age_value']
+        student_hist_viewer.state.title = "All student ages (5 galaxies each)"
+        student_hist_viewer.layers[0].state.color = "red"
+
+        class_hist_viewer = viewers["class_hist"]
+        class_hist_viewer.add_data(all_class_summ_data)
+        class_hist_viewer.state.x_att = all_class_summ_data.id['age_value']
+        class_hist_viewer.state.title = "All class ages (5 galaxies each)"
+        class_hist_viewer.layers[0].state.color = "blue"
 
         all_data_added.set(True)
 
@@ -641,10 +649,10 @@ def Page():
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
                 with rv.Row():
-                    class_summary_data = gjapp.data_collection["Class Summaries"]
+                    all_student_summary_data = gjapp.data_collection["All Student Summaries"]
                     all_class_summary_data = gjapp.data_collection["All Class Summaries"]
-                    hist_viewers = [viewers["student_hist"], viewers["class_hist"]]
-                    hist_data = [class_summary_data, all_class_summary_data]
+                    hist_viewers = [viewers["all_student_hist"], viewers["class_hist"]]
+                    hist_data = [all_student_summary_data, all_class_summary_data]
                     units = ["counts" for _ in range(len(hist_viewers))]
                     with rv.Col():
                         StatisticsSelector(
@@ -731,7 +739,7 @@ def Page():
 
             with rv.Col():
                 if COMPONENT_STATE.value.current_step_between(Marker.two_his1):
-                    ViewerLayout(viewers["student_hist"])
+                    ViewerLayout(viewers["all_student_hist"])
 
                 ViewerLayout(viewers["class_hist"]) 
 

--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -641,19 +641,23 @@ def Page():
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
                 with rv.Row():
+                    class_summary_data = gjapp.data_collection["Class Summaries"]
                     all_class_summary_data = gjapp.data_collection["All Class Summaries"]
+                    hist_viewers = [viewers["student_hist"], viewers["class_hist"]]
+                    hist_data = [class_summary_data, all_class_summary_data]
+                    units = ["counts" for _ in range(len(hist_viewers))]
                     with rv.Col():
                         StatisticsSelector(
-                            viewers=[viewers["class_hist"]],
-                            glue_data=[all_class_summary_data],
-                            units=["counts"],
+                            viewers=hist_viewers,
+                            glue_data=hist_data,
+                            units=units,
                             transform=round,
                         )
 
                     with rv.Col():
                         PercentageSelector(
-                            viewers=[viewers["class_hist"]],
-                            glue_data=[all_class_summary_data],
+                            viewers=hist_viewers,
+                            glue_data=hist_data,
                         )
 
                 ScaffoldAlert(


### PR DESCRIPTION
This PR makes two main changes in the "two histograms" portion of stage 5:
* Connect the top viewer to the percentage and statistics selectors (the bottom on is already connected)
* Replace the data in the top viewer, changing from class summaries -> all student summaries