### PR TITLE
Remove extra app & story state writers in stage 1

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -78,21 +78,6 @@ def Page():
     solara.lab.use_task(_load_component_state)
     # solara.use_memo(_load_component_state)
 
-    async def _write_local_global_states():
-        # Listen for changes in the states and write them to the database
-        LOCAL_API.put_story_state(GLOBAL_STATE, LOCAL_STATE)
-
-        # Be sure to write the measurement data separately since it's stored
-        #  in another location in the database
-        LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
-        LOCAL_API.put_sample_measurements(GLOBAL_STATE, LOCAL_STATE)
-
-        logger.info("Wrote state to database.")
-
-    solara.lab.use_task(
-        _write_local_global_states, dependencies=[GLOBAL_STATE.value, LOCAL_STATE.value]
-    )
-
     async def _write_component_state():
         if not loaded_component_state.value:
             return


### PR DESCRIPTION
I never removed the app and story state writers in stage 1 once we moved them to the base layout class. This may be at least part of the issue @patudom is seeing in cosmicds/hubbleds#503.