### PR TITLE
Always mount Plotly & MathJax support components

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -11,13 +11,10 @@ logger = setup_logger("LAYOUT")
 
 @solara.component
 def Layout(children=[]):
-    def _mount_external():
-        logger.info("Mounted external libraries.")
-        MathJaxSupport()
 
-    solara.use_memo(_mount_external)
-
+    MathJaxSupport()
     PlotlySupport()
+    logger.info("Mounted external libraries.")
 
     student_id = Ref(GLOBAL_STATE.fields.student.id)
     loaded_states = solara.use_reactive(False)

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -14,9 +14,10 @@ def Layout(children=[]):
     def _mount_external():
         logger.info("Mounted external libraries.")
         MathJaxSupport()
-        PlotlySupport()
 
     solara.use_memo(_mount_external)
+
+    PlotlySupport()
 
     student_id = Ref(GLOBAL_STATE.fields.student.id)
     loaded_states = solara.use_reactive(False)


### PR DESCRIPTION
This PR gives a partial resolution to #492 by moving the `PlotlySupport` component outside of the `use_memo` in the layout. As the discussion there mentions, there is another part to that issue which involves tasks and loading in the data. That issue is being a bit difficult to resolve (mainly because it only happens every 1 in ~10 refreshes for me) so I figured we could merge this and at least make things better for now.