### PR TITLE
Link histogram ranges and give extra padding

### DIFF
--- a/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-&-uncertainty/__init__.py
@@ -152,6 +152,12 @@ def Page():
         hist_viewers = (all_student_hist_viewer, class_hist_viewer)
         for att in ('x_min', 'x_max'):
             link((all_student_hist_viewer.state, att), (class_hist_viewer.state, att))
+
+        # This looks weird, and it kinda is!
+        # The idea here is that the all students viewer will always have a wider range than the all classes viewer
+        # So we force the home tool of the class viewer to limit-resetting based on the students viewer
+        class_hist_viewer.toolbar.tools["plotly:home"].activate = all_student_hist_viewer.toolbar.tools["plotly:home"].activate
+
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,
                                             handler=partial(_update_bins, hist_viewers),
                                             filter=lambda msg: msg.data.label == "Student Summaries")

--- a/src/hubbleds/viewers/hubble_scatter_viewer.py
+++ b/src/hubbleds/viewers/hubble_scatter_viewer.py
@@ -1,6 +1,6 @@
 from echo import delay_callback
 from glue_plotly.viewers.scatter import PlotlyScatterView
-from cosmicds.viewers import CDSScatterViewerState
+from cosmicds.viewers import CDSHistogramViewerState, CDSScatterViewerState, PlotlyHistogramView
 from cosmicds.viewers import cds_viewer
 
 __all__ = [
@@ -16,6 +16,14 @@ class HubbleScatterViewerState(CDSScatterViewerState):
             self.y_min = min(self.y_min, 0) if self.y_min is not None else 0
 
 
+class HubbleHistogramViewerState(CDSHistogramViewerState):
+
+    def reset_limits(self, visible_only=True):
+        with delay_callback(self, 'x_min', 'x_max'):
+            super().reset_limits(visible_only=visible_only)
+            self.x_min = round(self.x_min, 0) - 2.5 if self.x_min is not None else 0
+            self.x_max = round(self.x_max, 0) + 2.5 if self.x_max is not None else 0
+
 
 HubbleScatterView = cds_viewer(
     PlotlyScatterView,
@@ -27,4 +35,16 @@ HubbleScatterView = cds_viewer(
     ],
     label='Scatter View',
     state_cls=HubbleScatterViewerState
+)
+
+
+HubbleHistogramView = cds_viewer(
+    PlotlyHistogramView,
+    name="HubbleHistogramView",
+    viewer_tools=[
+        'plotly:home',
+        'plotly:hzoom',
+    ],
+    label="Histogram",
+    state_cls=HubbleHistogramViewerState
 )


### PR DESCRIPTION
This is intended to resolve #509. This adds some extra padding to the histogram viewers, and links the bounds of the two histograms that appear together, both when glue data changes and when the student uses either the home or zoom tool.