### PR TITLE
Load global state in layout

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -49,7 +49,6 @@ def Layout(children=[]):
 
         solara.lab.use_task(_load_measurements, dependencies=[])
 
-    solara.lab.use_task(_load_measurements, dependencies=[student_id.value])
     # solara.use_memo(_load_local_state, dependencies=[student_id.value])
 
     async def _write_local_global_states():
@@ -74,5 +73,6 @@ def Layout(children=[]):
         children=children,
         story_name=LOCAL_STATE.value.story_id,
         story_title=LOCAL_STATE.value.title,
+        on_student_info_loaded=_on_student_info_loaded,
     ):
         pass


### PR DESCRIPTION
This PR is a companion to  https://github.com/cosmicds/cosmicds/pull/316. The idea here is to load in the global state after the student ID has already been loaded, and then load in the measurements once we've got the student's story state.