### PR TITLE
Update stage 4 viewer styling

### DIFF
--- a/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
+++ b/src/hubbleds/components/line_draw_viewer/LineDrawPlot.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
   name: "LineDrawPlot",
-  props: ["chart_id", "active", "fit_active", "line_drawn", "line_fit", "plot_data", "x_axis_label", "y_axis_label"],
+  props: ["chart_id", "active", "fit_active", "line_drawn", "line_fit", "plot_data", "x_axis_label", "y_axis_label", "height", "margin"],
   async mounted() {
     await window.plotlyPromise;
 
@@ -22,10 +22,12 @@ export default {
       }
     }
     const layout = this.chart.layout;
-    layout.xaxis.range = [xmin, xmax];
-    layout.yaxis.range = [ymin, ymax];
+    layout.xaxis.range = [0, xmax*1.1];
+    layout.yaxis.range = [0, ymax*1.1];
     layout.xaxis.title = { text: this.x_axis_label };
     layout.yaxis.title = { text: this.y_axis_label };
+    layout.height = this.height;
+    layout.margin = this.margins;
 
     Plotly.newPlot(this.$refs[this.chart_id], this.chart.traces, layout, this.chart.config)
       .then(() => {

--- a/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
+++ b/src/hubbleds/components/line_draw_viewer/line_draw_viewer.py
@@ -11,7 +11,9 @@ def LineDrawPlot(chart_id: str,
                  event_line_fit: Optional[Callable[[list[float]], None]]=None,
                  plot_data: Optional[list[dict]]=None,
                  x_axis_label: Optional[str]=None,
-                 y_axis_label: Optional[str]=None
+                 y_axis_label: Optional[str]=None,
+                 height: Optional[int]=None,
+                 margins: Optional[dict]=None,
 ):
     pass
 
@@ -19,8 +21,11 @@ def LineDrawPlot(chart_id: str,
 @solara.component
 def LineDrawViewer(chart_id: str,
                    plot_data: Optional[list[dict]]=None,
+                   title: Optional[str]="Line Draw Viewer",
                    x_axis_label: Optional[str]=None,
                    y_axis_label: Optional[str]=None,
+                   viewer_height: Optional[int]=None,
+                   plot_margins: Optional[dict]=None,
                    on_line_drawn: Optional[Callable]=None,
                    on_line_fit: Optional[Callable[[list[float]], None]]=None):
 
@@ -42,8 +47,8 @@ def LineDrawViewer(chart_id: str,
 
     with rv.Card():
         with rv.Toolbar(class_="toolbar", dense=True):
-            with rv.ToolbarTitle(class_="toolbar"):
-                solara.Text("LINE DRAW VIEWER")
+            with rv.ToolbarTitle(class_="toolbar toolbar-title"):
+                solara.Text(title)
 
             rv.Spacer()
 
@@ -58,5 +63,7 @@ def LineDrawViewer(chart_id: str,
                      event_line_fit=on_line_fit,
                      plot_data=plot_data,
                      x_axis_label=x_axis_label,
-                     y_axis_label=y_axis_label
+                     y_axis_label=y_axis_label,
+                     height=viewer_height,
+                     margins=plot_margins,
         )

--- a/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
+++ b/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
@@ -4,30 +4,29 @@
     light
     variant="outlined"
     color="white"
-    class="layer_toggle"
   >
     <v-list-item-group
       multiple
       v-model="selected"
     >
       <v-list-item
-        v-for="(layer, index) in layer_indices"
-        :key="index"
-        :value="index"
+        v-for="(layer, index) in reversedLayerIndices"
+        :key="layer_indices.length - 1 - index"
+        :value="layer_indices.length - 1 - index"
         color="black"
-        @click="toggleVisibility(index)"
+        @click="toggleVisibility(layer_indices.length - 1 - index)"
       >
         <template v-slot:default="{ active }">
           <v-list-item-content
             class="font-weight-bold"
           >
-            {{ labels[index] }}
+            {{ labels[layer_indices.length - 1 - index] }}
           </v-list-item-content>
 
           <v-list-item-action>
             <v-checkbox
-              :input-value="selected.includes(index)"
-              :color="colors[index]"
+              :input-value="selected.includes(layer_indices.length - 1 - index)"
+              :color="colors[layer_indices.length - 1 - index]"
             />
           </v-list-item-action>
         </template>
@@ -52,6 +51,11 @@ export default {
     this.getElement();
     this.selected = this.initial_selected || Array.from({length: this.layer_indices.length}, (x, i) => true);
   },
+  computed: {
+  reversedLayerIndices() {
+    return this.layer_indices.slice().reverse();
+  }
+  },  
   methods: {
     getElement() {
       this.element = document.getElementById(this.chart_id);

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -97,6 +97,9 @@ def Page():
         race_viewer.state.y_att = race_data.id["Velocity (km/hr)"]
         race_viewer.state.x_max = 1.1 * race_viewer.state.x_max
         race_viewer.state.y_max = 1.1 * race_viewer.state.y_max
+        race_viewer.state.x_min = 0
+        race_viewer.state.y_min = 0
+        race_viewer.state.title = "Race Data"
 
         layer_viewer = gjapp.new_data_viewer(HubbleScatterView, show=False)
 
@@ -130,7 +133,8 @@ def Page():
         layer_viewer.state.x_att = class_data.id['est_dist_value']
         layer_viewer.state.y_att = class_data.id['velocity_value']
         layer_viewer.state.x_axislabel = "Distance (Mpc)"
-        layer_viewer.state.y_axislabel = "Velocity"
+        layer_viewer.state.y_axislabel = "Velocity (km/s)"
+        layer_viewer.state.title = "Our Data"
 
         class_plot_data.set(class_data_points)
 
@@ -359,7 +363,7 @@ def Page():
                                            plot_data=plot_data,
                                            on_line_fit=line_fit_cb,
                                            x_axis_label="Distance (Mpc)",
-                                           y_axis_label="Velocity (km / s)",
+                                           y_axis_label="Velocity (km/s)",
                                            viewer_height=VIEWER_HEIGHT,
                                            plot_margins=PLOTLY_MARGINS)
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -333,25 +333,29 @@ def Page():
         with rv.Col(class_="no-padding"):
             if COMPONENT_STATE.value.current_step_between(Marker.tre_dat1, Marker.sho_est2):
                 with solara.Columns([3,9], classes=["no-padding"]):
-                    colors = ("blue", "red")
+                    colors = ("#3A86FF", "#FB5607")
+                    sizes = (8, 12)
+                    layers_visible = (False, True)
                     with rv.Col(class_="no-padding"):
                         PlotlyLayerToggle(chart_id="line-draw-viewer",
                                           layer_indices=(3, 4),
-                                          initial_selected=(0, 1),
+                                          initial_selected=(1, 1),
                                           colors=colors,
                                           labels=("Class Data", "My Data"))
                     with rv.Col(class_="no-padding"):
                         if student_plot_data.value and class_plot_data.value:
                             # Note the ordering here - we want the student data on top
                             layers = (class_plot_data.value, student_plot_data.value)
+
                             plot_data=[
                                 {
                                     "x": [t.est_dist_value for t in data],
                                     "y": [t.velocity_value for t in data],
                                     "mode": "markers",
-                                    "marker": { "color": color, "size": 12 },
+                                    "marker": { "color": color, "size": size },
+                                    "visible": visibility,    
                                     "hoverinfo": "none"
-                                } for data, color in zip(layers, colors)
+                                } for data, color, size, visibility in zip(layers, colors, sizes, layers_visible)
                             ]
 
                             best_fit_slope = Ref(LOCAL_STATE.fields.best_fit_slope)

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -16,7 +16,7 @@ from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, StudentMeasurement, get_mu
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
 from hubbleds.remote import LOCAL_API
-from hubbleds.utils import AGE_CONSTANT, models_to_glue_data
+from hubbleds.utils import AGE_CONSTANT, models_to_glue_data, VIEWER_HEIGHT, PLOTLY_MARGINS
 
 from cosmicds.logger import setup_logger
 
@@ -355,10 +355,13 @@ def Page():
                                 # The student data is second in our tuple above
                                 best_fit_slope.set(slopes[1])
                             LineDrawViewer(chart_id="line-draw-viewer",
+                                           title="Our Data",
                                            plot_data=plot_data,
                                            on_line_fit=line_fit_cb,
                                            x_axis_label="Distance (Mpc)",
-                                           y_axis_label="Velocity (km / s)")
+                                           y_axis_label="Velocity (km / s)",
+                                           viewer_height=VIEWER_HEIGHT,
+                                           plot_margins=PLOTLY_MARGINS)
 
             with rv.Col(cols=10, offset=1):
                 if COMPONENT_STATE.value.current_step_at_or_after(

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -1,4 +1,4 @@
-from cosmicds.utils import empty_data_from_model_class
+from cosmicds.utils import empty_data_from_model_class, DEFAULT_VIEWER_HEIGHT
 from cosmicds.viewers import CDSScatterView
 from glue.core import Data
 from glue_jupyter import JupyterApplication
@@ -16,7 +16,7 @@ from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, StudentMeasurement, get_mu
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
 from hubbleds.remote import LOCAL_API
-from hubbleds.utils import AGE_CONSTANT, models_to_glue_data, VIEWER_HEIGHT, PLOTLY_MARGINS
+from hubbleds.utils import AGE_CONSTANT, models_to_glue_data, PLOTLY_MARGINS
 
 from cosmicds.logger import setup_logger
 
@@ -368,7 +368,7 @@ def Page():
                                            on_line_fit=line_fit_cb,
                                            x_axis_label="Distance (Mpc)",
                                            y_axis_label="Velocity (km/s)",
-                                           viewer_height=VIEWER_HEIGHT,
+                                           viewer_height=DEFAULT_VIEWER_HEIGHT,
                                            plot_margins=PLOTLY_MARGINS)
 
             with rv.Col(cols=10, offset=1):

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -52,7 +52,6 @@ MG_REST_LAMBDA = 5172  # The value used by SDSS is actually 5176.7, but that wav
 GALAXY_FOV = 1.5 * u.arcmin
 FULL_FOV = 60 * u.deg
 
-VIEWER_HEIGHT = 300
 PLOTLY_MARGINS = {"l": 60, "r": 20, "t": 20, "b": 60}
 
 IMAGE_BASE_URL = "https://cosmicds.github.io/cds-website/hubbleds_images"

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -52,6 +52,9 @@ MG_REST_LAMBDA = 5172  # The value used by SDSS is actually 5176.7, but that wav
 GALAXY_FOV = 1.5 * u.arcmin
 FULL_FOV = 60 * u.deg
 
+VIEWER_HEIGHT = 300
+PLOTLY_MARGINS = {"l": 60, "r": 20, "t": 20, "b": 60}
+
 IMAGE_BASE_URL = "https://cosmicds.github.io/cds-website/hubbleds_images"
 
 


### PR DESCRIPTION
This goes with https://github.com/cosmicds/cosmicds/pull/317.

This updates Stage 4 viewer content to match the voila version as much as possible. This includes:
- marker styling
- viewer height
- titles
- axis limits
- axis labels

Note in the layer toggler, the class data was appearing in the legend above the student data, so I reversed them (via some hacky code from github copilot). I'm not sure if that's always what we want to have happen in a general case, but I decided we can undo this if need be, if we decide to move the component from hubbleds to cosmicds).

This PR does not yet handle anything to do with marker gates and when tools become available.

Also, per #515, I had to locally revert the merge of #513 and https://github.com/cosmicds/cosmicds/pull/316 to test this.