### PR TITLE
Pass local state into base layout

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -19,35 +19,31 @@ def Layout(children=[]):
     student_id = Ref(GLOBAL_STATE.fields.student.id)
     loaded_states = solara.use_reactive(False)
 
-    async def _load_measurements():
-  
-        # Load in the student's measurements
-        measurements = LOCAL_API.get_measurements(GLOBAL_STATE, LOCAL_STATE)
-        sample_measurements = LOCAL_API.get_sample_measurements(
-            GLOBAL_STATE, LOCAL_STATE
-        )
-
-        logger.info("Finished loading measurements.")
-        loaded_states.set(True)
-
-        Ref(LOCAL_STATE.fields.measurements_loaded).set(True)
-
-    def _on_student_info_loaded():
+    async def _load_global_local_states():
         if not GLOBAL_STATE.value.student.id:
-            logger.warning("Failed to load app and story states: no student was found.")
+            logger.warning("Failed to load measurements: no student was found.")
             return
 
         logger.info(
-            "Loading app and story states for user `%s`.",
+            "Loading story stage and measurements for user `%s`.",
             GLOBAL_STATE.value.student.id,
         )
 
         # Retrieve the student's app and local states
         LOCAL_API.get_app_story_states(GLOBAL_STATE, LOCAL_STATE)
 
-        logger.info("Finished loading state.")
+        # Load in the student's measurements
+        measurements = LOCAL_API.get_measurements(GLOBAL_STATE, LOCAL_STATE)
+        sample_measurements = LOCAL_API.get_sample_measurements(
+            GLOBAL_STATE, LOCAL_STATE
+        )
 
-        solara.lab.use_task(_load_measurements, dependencies=[])
+        logger.info("Finished loading state.")
+        loaded_states.set(True)
+
+        Ref(LOCAL_STATE.fields.measurements_loaded).set(True)
+
+    solara.lab.use_task(_load_global_local_states, dependencies=[student_id.value])
 
     # solara.use_memo(_load_local_state, dependencies=[student_id.value])
 
@@ -70,9 +66,9 @@ def Layout(children=[]):
     )
 
     with BaseLayout(
+        local_state=LOCAL_STATE,
         children=children,
         story_name=LOCAL_STATE.value.story_id,
         story_title=LOCAL_STATE.value.title,
-        on_student_info_loaded=_on_student_info_loaded,
     ):
         pass


### PR DESCRIPTION
This PR, together with https://github.com/cosmicds/cosmicds/pull/318, is intended to help resolve #515. This PR updates the interaction with the base layout. This removes the passing in of a callable to use after the student data has loaded and uses our previous loading mechanism (which seems to work fine), and also now passes in the story state so that we can grab its piggybank total in the layout.