### PR TITLE
Updates to stage 6 legend

### DIFF
--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -10,6 +10,7 @@ from cosmicds.components import (
     ViewerLayout
 )
 from cosmicds.logger import setup_logger
+from cosmicds.utils import show_legend, show_layer_traces_in_legend
 
 # hubbleds
 from hubbleds.remote import LOCAL_API
@@ -24,7 +25,7 @@ from hubbleds.state import (
     fr_callback, 
     get_free_response, 
     get_multiple_choice
-    )
+)
 
 from ...utils import HST_KEY_AGE
 
@@ -115,7 +116,6 @@ def Page():
         
         return gjapp, viewer
     
-    
 
     gjapp, viewer = solara.use_memo(_glue_setup)
 
@@ -153,26 +153,11 @@ def Page():
         
         viewer.state.reset_limits()
     
-    def show_legend(viewer, show=True):
-        layout_update = {"showlegend": show}
-        if show:
-            layout_update["legend"] = {
-                'yanchor': 'top',
-                'xanchor': 'left',
-                "y": 0.99,
-                "x": 0.01
-            }
-        viewer.figure.update_layout(**layout_update)
-        return
 
-    def legend_hide_layer_traces(viewer):
-        for layer in viewer.layers:
-            for trace in layer.traces():
-                trace.update(showlegend=False)
 
     # viewer.toolbar.set_tool_enabled("hubble:linefit", False)
     add_data_by_marker(viewer)
-    legend_hide_layer_traces(viewer)
+    show_layer_traces_in_legend(viewer)
     show_legend(viewer, show=True)
     
     # print('\n =============  setting up mc scoring ============= \n')

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -129,7 +129,7 @@ def Page():
     solara.use_memo(_state_callback_setup)    
     
     
-    def add_data_by_marker(viewer ):
+    def add_data_by_marker(viewer):
         
         if COMPONENT_STATE.value.current_step.value == Marker.pro_dat1.value:
             data = gjapp.data_collection[HUBBLE_1929_DATA_LABEL]
@@ -140,7 +140,6 @@ def Page():
                 viewer.add_data(data)
                 viewer.state.x_att = data.id['Distance (Mpc)']
                 viewer.state.y_att = data.id['Tweaked Velocity (km/s)']
-                layer = viewer.layer_artist_for_data(data)
                 
         if COMPONENT_STATE.value.current_step.value == Marker.pro_dat5.value:
             data = gjapp.data_collection[HUBBLE_KEY_DATA_LABEL]
@@ -151,7 +150,6 @@ def Page():
                 viewer.add_data(data)
                 viewer.state.x_att = data.id['Distance (Mpc)']
                 viewer.state.y_att = data.id['Velocity (km/s)']
-                layer = viewer.layer_artist_for_data(data)
         
         viewer.state.reset_limits()
     

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -108,7 +108,7 @@ def Page():
         add_link(HUBBLE_1929_DATA_LABEL, 'Distance (Mpc)', HUBBLE_KEY_DATA_LABEL, 'Distance (Mpc)')
         add_link(HUBBLE_1929_DATA_LABEL, 'Tweaked Velocity (km/s)', HUBBLE_KEY_DATA_LABEL, 'Velocity (km/s)')
 
-        viewer = cast(PlotlyBaseView,gjapp.new_data_viewer(HubbleFitView, show=False))
+        viewer = cast(PlotlyBaseView, gjapp.new_data_viewer(HubbleFitView, show=False))
         viewer.state.title = "Professional Data"
         viewer.figure.update_xaxes(showline=True, mirror=False)
         viewer.figure.update_yaxes(showline=True, mirror=False)
@@ -156,15 +156,15 @@ def Page():
         viewer.state.reset_limits()
     
     def show_legend(viewer, show=True):
-        viewer.figure.update_layout(showlegend=show)
+        layout_update = {"showlegend": show}
         if show:
-            viewer.figure.update_layout(
-            legend = {
+            layout_update["legend"] = {
                 'yanchor': 'top',
                 'xanchor': 'left',
                 "y": 0.99,
                 "x": 0.01
-            })
+            }
+        viewer.figure.update_layout(**layout_update)
         return
     # viewer.toolbar.set_tool_enabled("hubble:linefit", False)
     add_data_by_marker(viewer)

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -166,8 +166,15 @@ def Page():
             }
         viewer.figure.update_layout(**layout_update)
         return
+
+    def legend_hide_layer_traces(viewer):
+        for layer in viewer.layers:
+            for trace in layer.traces():
+                trace.update(showlegend=False)
+
     # viewer.toolbar.set_tool_enabled("hubble:linefit", False)
     add_data_by_marker(viewer)
+    legend_hide_layer_traces(viewer)
     show_legend(viewer, show=True)
     
     # print('\n =============  setting up mc scoring ============= \n')


### PR DESCRIPTION
This PR resolves #424 by making it so that only the fit line traces show up in the viewer legend, and each line trace will only show up when it's visible (and if the figure legend is turned on, which we always have set). This is accomplished via the fact that each `glue-plotly` layer artist knows which traces belong to it, so we can set all of those traces to have `showlegend=False`.

Additionally, this combines the two layout updates that are currently happening when showing the legend into one.

Relies on https://github.com/cosmicds/cosmicds/pull/319.