### PR TITLE
Bump glue-plotly version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.7.5
+    glue-plotly[jupyter]>=0.8.1
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
This PR bumps the required version of glue-plotly so that we can get some new fixes for problems that we were seeing.