### PR TITLE
Add stage 4 waiting room

### DIFF
--- a/src/hubbleds/components/__init__.py
+++ b/src/hubbleds/components/__init__.py
@@ -21,3 +21,4 @@ from .dotplot_tutorial_slideshow import DotplotTutorialSlideshow
 from .id_slider import IdSlider
 from .line_draw_viewer import LineDrawViewer
 from .plotly_layer_toggle import PlotlyLayerToggle
+from .stage_4_waiting_screen import Stage4WaitingScreen

--- a/src/hubbleds/components/stage_4_waiting_screen/__init__.py
+++ b/src/hubbleds/components/stage_4_waiting_screen/__init__.py
@@ -1,0 +1,38 @@
+from ipywwt import WWTWidget
+import reacton.ipyvuetify as rv
+import solara
+from typing import Callable
+
+
+@solara.component
+def Stage4WaitingScreen(
+    can_advance: bool,
+    on_advance_click: Callable,
+):
+
+    with rv.Card():
+        with rv.Toolbar(color="warning", dense=True, dark=True):
+            rv.ToolbarTitle(class_="text-h6 text-uppercase font-weight-regular",
+                                 children=["Take a quick break"])
+            rv.Spacer()
+
+        with rv.CardText():
+            with rv.Container():
+                with solara.Row():
+                   solara.HTML(
+                        unsafe_innerHTML=
+                        """
+                        <p>You and your classmates will be comparing your measurements in the next section, but we need to wait a few moments for more of them to catch up.</p>
+                        <p>While you wait, you can explore the same sky viewer you saw in the introduction.</p>
+                        <p>You will be able to advance when enough classmates are ready to proceed.</p>
+                        """
+                    )
+
+                WWTWidget.element()
+
+                with solara.Row():
+                    solara.Button(label="Advance",
+                                  on_click=on_advance_click,
+                                  disabled=not can_advance)
+
+                   

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -4,7 +4,6 @@ from cosmicds.viewers import CDSScatterView
 from glue.core import Data
 from glue_jupyter import JupyterApplication
 from hubbleds.base_component_state import transition_next, transition_previous
-from ipywwt import WWTWidget
 import numpy as np
 from pathlib import Path
 import reacton.ipyvuetify as rv
@@ -13,7 +12,7 @@ from solara.toestand import Ref
 from typing import Dict, List, Tuple
 
 from cosmicds.components import ScaffoldAlert, StateEditor, ViewerLayout
-from hubbleds.components import DataTable, HubbleExpUniverseSlideshow, LineDrawViewer, PlotlyLayerToggle
+from hubbleds.components import DataTable, HubbleExpUniverseSlideshow, LineDrawViewer, PlotlyLayerToggle, Stage4WaitingScreen
 from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, StudentMeasurement, get_multiple_choice, get_free_response, mc_callback, fr_callback
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
@@ -69,8 +68,7 @@ def Page():
         measurements.set(class_measurements)
     
         class_data_points = [m for m in class_measurements if m.student_id in student_ids.value]
-        # Ref(LOCAL_STATE.fields.enough_students_ready).set(len(class_data_points) >= min(100, 5 * GLOBAL_STATE.value.classroom.size))
-        Ref(LOCAL_STATE.fields.enough_students_ready).set(len(class_data_points) >= 100)
+        Ref(LOCAL_STATE.fields.enough_students_ready).set(len(class_data_points) >= min(50, 5 * GLOBAL_STATE.value.classroom.size))
             
         return class_data_points
 
@@ -81,18 +79,21 @@ def Page():
             points = load_class_data()
             count += 1
             ready = len(points) >= 100 - 10 * count
-            if ready != enough_students_ready.value:
-                enough_students_ready.set(ready)
+            logger.info(100 - 10 * count)
+            logger.info(ready)
+            logger.info(enough_students_ready.value)
+            logger.info("======")
+            if ready:
+                enough_students_ready.set(True)
             await asyncio.sleep(10)
 
     solara.lab.use_task(keep_checking_class_data, dependencies=[])
 
     if COMPONENT_STATE.value.current_step == Marker.wwt_wait:
-        with rv.Card():
-            WWTWidget.element()
-            solara.Button(label="Advance",
-                          on_click=lambda: transition_next(COMPONENT_STATE),
-                          disabled=not LOCAL_STATE.value.enough_students_ready)
+        Stage4WaitingScreen(
+            can_advance=LOCAL_STATE.value.enough_students_ready,
+            on_advance_click=lambda: transition_next(COMPONENT_STATE),
+        )
         return
 
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -1,8 +1,10 @@
+import asyncio
 from cosmicds.utils import empty_data_from_model_class, DEFAULT_VIEWER_HEIGHT
 from cosmicds.viewers import CDSScatterView
 from glue.core import Data
 from glue_jupyter import JupyterApplication
 from hubbleds.base_component_state import transition_next, transition_previous
+from ipywwt import WWTWidget
 import numpy as np
 from pathlib import Path
 import reacton.ipyvuetify as rv
@@ -25,24 +27,12 @@ logger = setup_logger("STAGE 4")
 GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 
 
-@solara.lab.task
-async def load_class_data():
-    logger.info("Loading class data")
-    class_measurements = LOCAL_API.get_class_measurements(GLOBAL_STATE, LOCAL_STATE)
-    logger.info(len(class_measurements))
-    measurements = Ref(LOCAL_STATE.fields.class_measurements)
-    student_ids = Ref(LOCAL_STATE.fields.stage_4_class_data_students)
-    if class_measurements and not student_ids.value:
-        ids = [int(id) for id in np.unique([m.student_id for m in class_measurements])]
-        student_ids.set(ids)
-    measurements.set(class_measurements)
-
-    class_data_points = [m for m in class_measurements if m.student_id in student_ids.value]
-    return class_data_points
-
-
 @solara.component
 def Page():
+
+    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
+
+
     loaded_component_state = solara.use_reactive(False)
 
     async def _load_component_state():
@@ -66,6 +56,45 @@ def Page():
         logger.info("Wrote component state to database.")
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
+
+    def load_class_data():
+        logger.info("Loading class data")
+        class_measurements = LOCAL_API.get_class_measurements(GLOBAL_STATE, LOCAL_STATE)
+        logger.info(len(class_measurements))
+        measurements = Ref(LOCAL_STATE.fields.class_measurements)
+        student_ids = Ref(LOCAL_STATE.fields.stage_4_class_data_students)
+        if class_measurements and not student_ids.value:
+            ids = [int(id) for id in np.unique([m.student_id for m in class_measurements])]
+            student_ids.set(ids)
+        measurements.set(class_measurements)
+    
+        class_data_points = [m for m in class_measurements if m.student_id in student_ids.value]
+        # Ref(LOCAL_STATE.fields.enough_students_ready).set(len(class_data_points) >= min(100, 5 * GLOBAL_STATE.value.classroom.size))
+        Ref(LOCAL_STATE.fields.enough_students_ready).set(len(class_data_points) >= 100)
+            
+        return class_data_points
+
+    async def keep_checking_class_data():
+        count = 0
+        enough_students_ready = Ref(LOCAL_STATE.fields.enough_students_ready)
+        while not enough_students_ready.value:
+            points = load_class_data()
+            count += 1
+            ready = len(points) >= 100 - 10 * count
+            if ready != enough_students_ready.value:
+                enough_students_ready.set(ready)
+            await asyncio.sleep(10)
+
+    solara.lab.use_task(keep_checking_class_data, dependencies=[])
+
+    if COMPONENT_STATE.value.current_step == Marker.wwt_wait:
+        with rv.Card():
+            WWTWidget.element()
+            solara.Button(label="Advance",
+                          on_click=lambda: transition_next(COMPONENT_STATE),
+                          disabled=not LOCAL_STATE.value.enough_students_ready)
+        return
+
 
     class_plot_data = solara.use_reactive([])
 
@@ -112,9 +141,6 @@ def Page():
 
     gjapp, viewers = solara.use_memo(glue_setup, dependencies=[])
 
-    if not (load_class_data.value or load_class_data.pending):
-        load_class_data()
-
     def _on_class_data_loaded(class_data_points: List[StudentMeasurement]):
         logger.info("Setting up class glue data")
         if not class_data_points:
@@ -137,11 +163,6 @@ def Page():
         layer_viewer.state.title = "Our Data"
 
         class_plot_data.set(class_data_points)
-
-    if load_class_data.value:
-        _on_class_data_loaded(load_class_data.value)
-
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -31,7 +31,6 @@ def Page():
 
     StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
-
     loaded_component_state = solara.use_reactive(False)
 
     async def _load_component_state():
@@ -73,18 +72,9 @@ def Page():
         return class_data_points
 
     async def keep_checking_class_data():
-        count = 0
         enough_students_ready = Ref(LOCAL_STATE.fields.enough_students_ready)
         while not enough_students_ready.value:
-            points = load_class_data()
-            count += 1
-            ready = len(points) >= 100 - 10 * count
-            logger.info(100 - 10 * count)
-            logger.info(ready)
-            logger.info(enough_students_ready.value)
-            logger.info("======")
-            if ready:
-                enough_students_ready.set(True)
+            load_class_data()
             await asyncio.sleep(10)
 
     solara.lab.use_task(keep_checking_class_data, dependencies=[])

--- a/src/hubbleds/pages/04-explore-data/component_state.py
+++ b/src/hubbleds/pages/04-explore-data/component_state.py
@@ -12,6 +12,7 @@ import enum
 from typing import Any
 
 class Marker(enum.Enum, BaseMarker):
+    wwt_wait = enum.auto()
     exp_dat1 = enum.auto()
     tre_dat1 = enum.auto() # MC tre-dat-mc1
     tre_dat2 = enum.auto()


### PR DESCRIPTION
This PR adds an implementation of the stage 4 waiting room. The behavior here differs slightly from the Voila version in that we now activate the advance button when enough students have completed their data, rather than the abrupt transition in the Voila version.

At the moment this si a bit difficult to test. I was able to test the class data polling functionality by continually using a dynamic checking condition:

```python
    async def keep_checking_class_data():
        count = 0
        enough_students_ready = Ref(LOCAL_STATE.fields.enough_students_ready)
        while not enough_students_ready.value:
            points = load_class_data()
            count += 1
            ready = len(points) >= 100 - 10 * count
            # Some logging statements for checking values
            logger.info(100 - 10 * count)
            logger.info(ready)
            logger.info(enough_students_ready.value)
            logger.info("======")
            if ready:
                enough_students_ready.set(True)
            await asyncio.sleep(2)  # This sets how often (in seconds) we re-check the class data
```

Also, if you then want to reset the `enough_students_ready` in your student's story state, you can run

```sql
UPDATE cosmicds_db.StoryStates 
SET story_state = JSON_SET(story_state, '$.story.enough_students_ready', false)
WHERE student_id = <your-student-id>;
```