### PR TITLE
Support transitioning between pages

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -657,9 +657,7 @@ def Page():
                     ]
                 else:
                     viewer_data = [gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]]
-                DotplotViewer(
-                    gjapp,  # component_id=DB_VELOCITY_FIELD  # data=viewer_data,
-                )
+                DotplotViewer(gjapp, data=viewer_data, component_id=DB_VELOCITY_FIELD)
 
             if COMPONENT_STATE.value.is_current_step(Marker.ref_dat1):
                 show_reflection_dialog = Ref(

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -57,6 +57,7 @@ def selected_measurement():
 @solara.component
 def Page():
     loaded_component_state = solara.use_reactive(False)
+    router = solara.use_router()
 
     async def _load_component_state():
         # Load stored component state from database, measurement data is
@@ -379,7 +380,7 @@ def Page():
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineEndStage1.vue",
-                event_next_callback=lambda _: print("Transition next stage."),
+                event_next_callback=lambda _: router.push("02-distance-introduction"),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.end_sta1),
@@ -535,9 +536,7 @@ def Page():
                 max_step_completed_5 = Ref(
                     COMPONENT_STATE.fields.doppler_state.max_step_completed_5
                 )
-                student_c = Ref(
-                    COMPONENT_STATE.fields.doppler_state.student_c
-                )
+                student_c = Ref(COMPONENT_STATE.fields.doppler_state.student_c)
                 velocity_calculated = Ref(
                     COMPONENT_STATE.fields.doppler_state.velocity_calculated
                 )
@@ -584,9 +583,11 @@ def Page():
                     event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                     event_mc_callback=lambda event: mc_callback(event, LOCAL_STATE),
                     state_view={
-                        "mc_score": get_multiple_choice(LOCAL_STATE, "interpret-velocity"),
-                        "score_tag": "interpret-velocity"
-                    }                    
+                        "mc_score": get_multiple_choice(
+                            LOCAL_STATE, "interpret-velocity"
+                        ),
+                        "score_tag": "interpret-velocity",
+                    },
                 )
 
             if COMPONENT_STATE.value.current_step_between(
@@ -629,10 +630,11 @@ def Page():
                             example_measurements_glue.style.color = "red"
                             gjapp.data_collection.append(example_measurements_glue)
                         else:
-                            example_measurements_glue = gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
+                            example_measurements_glue = gjapp.data_collection[
+                                EXAMPLE_GALAXY_MEASUREMENTS
+                            ]
                             example_measurements_glue.style.color = "red"
 
-                
                         egsd = gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
                         add_link(
                             egsd,
@@ -655,11 +657,17 @@ def Page():
                     ]
                 else:
                     viewer_data = [gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]]
-                DotplotViewer(gjapp, data=viewer_data, component_id=DB_VELOCITY_FIELD)
+                DotplotViewer(
+                    gjapp,  # component_id=DB_VELOCITY_FIELD  # data=viewer_data,
+                )
 
             if COMPONENT_STATE.value.is_current_step(Marker.ref_dat1):
-                show_reflection_dialog=Ref(COMPONENT_STATE.fields.show_reflection_dialog)
-                reflect_step = Ref(COMPONENT_STATE.fields.velocity_reflection_state.step)
+                show_reflection_dialog = Ref(
+                    COMPONENT_STATE.fields.show_reflection_dialog
+                )
+                reflect_step = Ref(
+                    COMPONENT_STATE.fields.velocity_reflection_state.step
+                )
                 reflect_max_step_completed = Ref(
                     COMPONENT_STATE.fields.velocity_reflection_state.max_step_completed
                 )
@@ -667,7 +675,7 @@ def Page():
 
                 ReflectVelocitySlideshow(
                     length=8,
-                    titles= [
+                    titles=[
                         "Reflect on your data",
                         "What would a 1920's scientist wonder?",
                         "Observed vs. rest wavelengths",
@@ -675,29 +683,35 @@ def Page():
                         "Do your data agree with 1920's thinking?",
                         "Do your data agree with 1920's thinking?",
                         "Did your peers find what you found?",
-                        "Reflection complete"
+                        "Reflection complete",
                     ],
                     interact_steps=[2, 3, 4, 5, 6],
                     require_responses=True,
-
-                    dialog = COMPONENT_STATE.value.show_reflection_dialog,
-                    step=COMPONENT_STATE.value.velocity_reflection_state.step, 
+                    dialog=COMPONENT_STATE.value.show_reflection_dialog,
+                    step=COMPONENT_STATE.value.velocity_reflection_state.step,
                     max_step_completed=COMPONENT_STATE.value.velocity_reflection_state.max_step_completed,
                     reflection_complete=COMPONENT_STATE.value.reflection_complete,
                     state_view={
-                        "mc_score_2": get_multiple_choice(LOCAL_STATE, "wavelength-comparison"),
+                        "mc_score_2": get_multiple_choice(
+                            LOCAL_STATE, "wavelength-comparison"
+                        ),
                         "score_tag_2": "wavelength-comparison",
                         "mc_score_3": get_multiple_choice(LOCAL_STATE, "galaxy-motion"),
                         "score_tag_3": "galaxy-motion",
-                        "mc_score_4": get_multiple_choice(LOCAL_STATE, "steady-state-consistent"),
+                        "mc_score_4": get_multiple_choice(
+                            LOCAL_STATE, "steady-state-consistent"
+                        ),
                         "score_tag_4": "steady-state-consistent",
-                        "mc_score_5": get_multiple_choice(LOCAL_STATE, "moving-randomly-consistent"),
+                        "mc_score_5": get_multiple_choice(
+                            LOCAL_STATE, "moving-randomly-consistent"
+                        ),
                         "score_tag_5": "moving-randomly-consistent",
-                        "mc_score_6": get_multiple_choice(LOCAL_STATE, "peers-data-agree"),
+                        "mc_score_6": get_multiple_choice(
+                            LOCAL_STATE, "peers-data-agree"
+                        ),
                         "score_tag_6": "peers-data-agree",
-                    },  
-
-                    event_set_dialog = show_reflection_dialog.set,
+                    },
+                    event_set_dialog=show_reflection_dialog.set,
                     event_mc_callback=lambda event: mc_callback(event, LOCAL_STATE),
                     # These are numbered based on window-item value
                     event_set_step=reflect_step.set,


### PR DESCRIPTION
This PR adds support to transition to stage 2 after stage 1. I'm running into an issue when attempting to use a more intelligence path resolution, but for now, we can use a straight-forward method:

1. Make sure to define `router = solara.use_router()` somewhere in the top-level of the page.
2. To transition, push the new route to the router; e.g. `router.push("02-distance-introduction`)