### PR TITLE
Don't scroll to guideline when measuring button is pressed

### DIFF
--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -474,6 +474,7 @@ def Page():
                 event_back_callback=lambda _: transition_to(COMPONENT_STATE, Marker.dot_seq5),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.rep_rem1),
+                scroll_on_mount=False,
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineRepeatRemainingGalaxies.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineRepeatRemainingGalaxies.vue
@@ -14,6 +14,7 @@
     @back="back_callback()"
     @next="next_callback()"
     :can-advance="can_advance"
+    :scroll-on-mount="scroll_on_mount"
   >
     <template #before-next>
       <!-- <span v-if="!state.bad_angsize">


### PR DESCRIPTION
This PR, together with https://github.com/cosmicds/cosmicds/pull/323, resolves #540 by making the guideline that's visible when using the measuring tool have the auto-scroll behavior disabled.