### PR TITLE
Improve mathjax rendering in doppler dialogs

### DIFF
--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -41,722 +41,748 @@
         <v-window-item :value="0"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <p>
-              Great! Now we'll continue the velocity calculation process in the sequence of this pop-up window to give
-              ourselves some more space to work.
-            </p>
-            <p>
-              You can click the header and drag if you want to move the pop-up around to see content behind it.
-            </p>
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
+          <v-lazy>
+            <v-card-text
+                v-intersect="typesetMathJax"
+                class="pt-8"
             >
-              $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#FFAB91}{ {{ lambda_obs }} }} \text{
-              &#8491;}}{\textcolor{black}{\colorbox{#FFAB91}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
-              <v-divider role="presentation"></v-divider>
-              <div
-                  class="font-weight-medium mt-3"
+              <p>
+                Great! Now we'll continue the velocity calculation process in the sequence of this pop-up window to give
+                ourselves some more space to work.
+              </p>
+              <p>
+                You can click the header and drag if you want to move the pop-up around to see content behind it.
+              </p>
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
               >
-                Click <b>CALCULATE</b> to compute the value of the fraction you entered.
-              </div>
-            </v-card>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
+                $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#FFAB91}{ {{ lambda_obs }} }} \text{
+                &#8491;}}{\textcolor{black}{\colorbox{#FFAB91}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
                 >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
-                    >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
+                  Click <b>CALCULATE</b> to compute the value of the fraction you entered.
+                </div>
+              </v-card>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
+                  >
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
 
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    rest wavelength of spectral line
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card>
-          </v-card-text>
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
 
 
         <v-window-item :value="1"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <v-card
-                class="JaxEquation past_block pa-3"
+          <v-lazy>
+            <v-card-text
+                v-intersect="typesetMathJax"
+                class="pt-8"
             >
-              $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{
-              &#8491;}}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
-            </v-card>
-            <p>
-              Dividing the fraction gives you <b>{{ (lambda_obs / lambda_rest).toFixed(4) }}</b>.
-              Now we have:
-            </p>
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
-            >
-              $$ v = c \times \left( \textcolor{black}{\colorbox{#FFAB91}{
-              {{ (lambda_obs / lambda_rest).toFixed(4) }} } } - 1 \right) $$
-              <v-divider role="presentation"></v-divider>
-              <div
-                  class="font-weight-medium mt-3"
+              <v-card
+                  class="JaxEquation past_block pa-3"
               >
-                Click <b>CALCULATE</b> to perform the subtraction.
-              </div>
-            </v-card>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
+                $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{
+                &#8491;}}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
+              </v-card>
+              <p>
+                Dividing the fraction gives you <b>{{ (lambda_obs / lambda_rest).toFixed(4) }}</b>.
+                Now we have:
+              </p>
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
+              >
+                $$ v = c \times \left( \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest).toFixed(4) }} } } - 1 \right) $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
                 >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
-                    >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
+                  Click <b>CALCULATE</b> to perform the subtraction.
+                </div>
+              </v-card>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
+                  >
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
 
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    rest wavelength of spectral line
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card>
-          </v-card-text>
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
 
 
         <v-window-item :value="2"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <v-card
-                class="JaxEquation past_block pa-3"
+          <v-lazy>
+            <v-card-text
+                v-intersect="typesetMathJax"
+                class="pt-8"
             >
-              $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{
-              &#8491;}}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
-
-              $$ v = c \times \left( \textcolor{black}{\colorbox{#DDD}{
-              {{ (lambda_obs / lambda_rest).toFixed(4) }} } } - 1 \right) $$
-            </v-card>
-            <p>
-              Subtracting 1 gives you <b>{{ (lambda_obs / lambda_rest - 1).toFixed(4) }}</b>. Now
-              we are left with:
-            </p>
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
-            >
-              $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
-              {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-              <v-divider role="presentation"></v-divider>
-              <div
-                  class="font-weight-medium mt-3"
+              <v-card
+                  class="JaxEquation past_block pa-3"
               >
-                Click <b>NEXT</b> to continue.
-              </div>
-            </v-card>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
-                >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
-                    >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
+                $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{
+                &#8491;}}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
 
-                  >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
+                $$ v = c \times \left( \textcolor{black}{\colorbox{#DDD}{
+                {{ (lambda_obs / lambda_rest).toFixed(4) }} } } - 1 \right) $$
+              </v-card>
+              <p>
+                Subtracting 1 gives you <b>{{ (lambda_obs / lambda_rest - 1).toFixed(4) }}</b>. Now
+                we are left with:
+              </p>
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
+              >
+                $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
                 >
-                  <v-col
-                      cols="2"
+                  Click <b>NEXT</b> to continue.
+                </div>
+              </v-card>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
                   >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    rest wavelength of spectral line
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card>
-          </v-card-text>
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
 
 
         <v-window-item :value="3"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
+          <v-lazy>
+            <v-card-text
+                v-intersect="typesetMathJax"
+                class="pt-8"
             >
-              $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
-              {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-            </v-card>
-            <v-container>
-              <v-row>
-                <v-col>
-                  <p class="mb-0">
-                    Reflect for a bit on what this means. How does the velocity of the galaxy relate to the speed of
-                    light?
-                  </p>
-                  <mc-radiogroup
-                      :correct-answers="[1]"
-                      :feedbacks="[
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
+              >
+                $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+              </v-card>
+              <v-container>
+                <v-row>
+                  <v-col>
+                    <p class="mb-0">
+                      Reflect for a bit on what this means. How does the velocity of the galaxy relate to the speed of
+                      light?
+                    </p>
+                    <mc-radiogroup
+                        :correct-answers="[1]"
+                        :feedbacks="[
                       'Try again. The equation describes a relationship between the galaxy\'s velocity and the speed of light.',
                       'Correct. The fraction is the ratio of the observed wavelength of my spectral line over the line\'s rest wavelength minus 1. This will be the case for all of your galaxies.',
                       'Try again. You are multiplying the speed of light by a value that is smaller than 1.'
                     ]"
-                      :radio-options="[
+                        :radio-options="[
                       'There is no relationship between the galaxy\’s velocity and the speed of light.',
                       'The galaxy\’s velocity is a fraction of the speed of light. ',
                       'The galaxy\’s velocity is greater than the speed of light.'
                     ]"
-                      @select="(_state) => { if (_state.correct) { set_max_step_completed_5(Math.max(max_step_completed_5, 3)); } }"
-                      @mc-emit="mc_callback($event)"
-                      :initialization="state_view.mc_score"
-                      :score-tag="state_view.score_tag"
-                  >
-                  </mc-radiogroup>
-                </v-col>
-              </v-row>
-            </v-container>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
-                >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
+                        @select="(_state) => { if (_state.correct) { set_max_step_completed_5(Math.max(max_step_completed_5, 3)); } }"
+                        @mc-emit="mc_callback($event)"
+                        :initialization="state_view.mc_score"
+                        :score-tag="state_view.score_tag"
                     >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-
-                  >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    rest wavelength of spectral line
+                    </mc-radiogroup>
                   </v-col>
                 </v-row>
               </v-container>
-            </v-card>
-          </v-card-text>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
+                  >
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
+
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
+                  >
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
 
 
         <v-window-item :value="4"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <p>
-              Now enter the <b>speed of light</b> in <b>km/s</b> in the empty box below.
-            </p>
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
+          <v-lazy>
+            <v-card-text
+                v-intersect="typesetMathJax"
+                class="pt-8"
             >
-              $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
-              {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-              $$ v = \bbox[#FBE9E7]{\input[speed_light][]{}} \text{ km/s} \times \textcolor{black}{\colorbox{#FFAB91}{
-              {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-              <v-divider role="presentation"></v-divider>
-              <div
-                  class="font-weight-medium mt-3"
+              <p>
+                Now enter the <b>speed of light</b> in <b>km/s</b> in the empty box below.
+              </p>
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
               >
-                Click <b>CALCULATE</b> to multiply through and obtain the speed of this galaxy.
-              </div>
-              <v-alert
-                  v-if="failed_validation_5"
-                  class="my-3"
-                  color="info darken-1"
-                  dense
-                  style="font-size: 16px;"
-              >
-                Try again. Check that you are using <b>km/s</b>, and make sure you have the correct number of
-                zeroes. The speed of light is highlighted in yellow below.
-              </v-alert>
-            </v-card>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
+                $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+                $$ v = \bbox[#FBE9E7]{\input[speed_light][]{}} \text{ km/s} \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
                 >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
-                    >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-
-                  >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    v-if="!failed_validation_5"
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
-                  >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
+                  Click <b>CALCULATE</b> to multiply through and obtain the speed of this galaxy.
+                </div>
+                <v-alert
                     v-if="failed_validation_5"
-                    v-intersect="typesetMathJax"
-                    class="my-1 yellow--text font-weight-bold"
-                    no-gutters
+                    class="my-3"
+                    color="info darken-1"
+                    dense
+                    style="font-size: 16px;"
                 >
-                  <v-col
-                      cols="2"
+                  Try again. Check that you are using <b>km/s</b>, and make sure you have the correct number of
+                  zeroes. The speed of light is highlighted in yellow below.
+                </v-alert>
+              </v-card>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
                   >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      v-if="!failed_validation_5"
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      v-if="failed_validation_5"
+
+                      class="my-1 yellow--text font-weight-bold"
+                      no-gutters
                   >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    rest wavelength of spectral line
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card>
-          </v-card-text>
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
 
         <v-window-item :value="5"
                        class="no-transition"
         >
-          <v-card-text
-              v-intersect="typesetMathJax"
-              class="pt-8"
-          >
-            <v-card
-                class="JaxEquation past_block pa-3"
+          <v-lazy>
+            <v-card-text
+                class="pt-8"
+                v-intersect="typesetMathJax"
             >
-              $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{
-              &#8491;}}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491;}} - 1 \right) $$
-
-              $$ v = c \times \left( \textcolor{black}{\colorbox{#DDD}{
-              {{ (lambda_obs / lambda_rest).toFixed(4) }} } } - 1 \right) $$
-
-              $$ v = c \times \textcolor{black}{\colorbox{#DDD}{
-              {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-
-              $$ v = \textcolor{black}{\colorbox{#DDD}{ {{ student_c.toLocaleString() }} } }
-              \text{ km/s} \times
-              \textcolor{black}{\colorbox{#DDD}{ {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
-            </v-card>
-            <p>
-              Great work. Your galaxy's velocity is <b>{{ (student_c * (lambda_obs / lambda_rest - 1) ).toFixed(0).toLocaleString() }}</b>
-              km/s.
-            </p>
-            <v-card
-                class="JaxEquation pa-3"
-                color="info"
-            >
-              $$ v = \textcolor{black}{\colorbox{#FFAB91}{ {{ (student_c * (lambda_obs / lambda_rest - 1) ).toFixed(0).toLocaleString() }} } }
-              \text{ km/s} $$
-              <v-divider role="presentation"></v-divider>
-              <div
-                  class="font-weight-medium mt-3"
+              <v-card
+                  class="past_block pa-3"
               >
-                Click <b>DONE</b> to close this pop-up window. The velocity will be filled in in the table for this galaxy.
-              </div>
-            </v-card>
-            <v-divider role="presentation"></v-divider>
-            <v-card
-                class="legend mt-8"
-            >
-              <v-container>
-                <v-row
-                    no-gutters
-                >
-                  <v-col>
-                    <div
-                        class="JaxEquation"
-                    >
-                      $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
-                    </div>
-                  </v-col>
-                </v-row>
-                <v-divider></v-divider>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
+                <!-- First equation -->
+                <div class="JaxEquation">
+                  $$ v = c \times \left( \frac{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_obs }} }} \text{ &#8491;
+                  }}{\textcolor{black}{\colorbox{#DDD}{ {{ lambda_rest }} }} \text{ &#8491; }} - 1 \right) $$
+                </div>
 
-                  >
-                    \(v\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    velocity of the galaxy, in km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
+                <!-- Second equation -->
+                <div class="JaxEquation">
+                  $$ v = c \times \left( \textcolor{black}{\colorbox{#DDD}{ {{ (lambda_obs / lambda_rest).toFixed(4) }}
+                  }} - 1 \right) $$
+                </div>
+
+                <!-- Third equation -->
+                <div class="JaxEquation">
+                  $$ v = c \times \textcolor{black}{\colorbox{#DDD}{ {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} }}
+                  $$
+                </div>
+
+                <!-- Fourth equation -->
+                <div class="JaxEquation">
+                  $$ v = \textcolor{black}{\colorbox{#DDD}{ {{ student_c.toLocaleString() }} }} \text{ km/s} \times
+                  \textcolor{black}{\colorbox{#DDD}{ {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} }} $$
+                </div>
+              </v-card>
+              <p>
+                Great work. Your galaxy's velocity is
+                <b>{{ (student_c * (lambda_obs / lambda_rest - 1)).toFixed(0).toLocaleString() }}</b>
+                km/s.
+              </p>
+              <v-card
+                  class="JaxEquation pa-3"
+                  color="info"
+              >
+                $$ v = \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (student_c * (lambda_obs / lambda_rest - 1)).toFixed(0).toLocaleString() }} } }
+                \text{ km/s} $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
                 >
-                  <v-col
-                      cols="2"
+                  Click <b>DONE</b> to close this pop-up window. The velocity will be filled in in the table for this
+                  galaxy.
+                </div>
+              </v-card>
+              <v-divider role="presentation"></v-divider>
+              <v-card
+                  class="legend mt-8"
+              >
+                <v-container>
+                  <v-row
+                      no-gutters
                   >
-                    \(c\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col>
+                      <div
+                          class="JaxEquation"
+                      >
+                        $$ v = c \times \left( \frac{\lambda_{\text{obs}}}{\lambda_{\text{rest}}} - 1 \right) $$
+                      </div>
+                    </v-col>
+                  </v-row>
+                  <v-divider></v-divider>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    speed of light, 300,000 km/s
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+
+                    >
+                      \(v\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      velocity of the galaxy, in km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{obs}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
+                    <v-col
+                        cols="2"
+                    >
+                      \(c\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      speed of light, 300,000 km/s
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    observed wavelength of spectral line in the galaxy
-                  </v-col>
-                </v-row>
-                <v-row
-                    class="my-1"
-                    no-gutters
-                >
-                  <v-col
-                      cols="2"
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{obs}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      observed wavelength of spectral line in the galaxy
+                    </v-col>
+                  </v-row>
+                  <v-row
+                      class="my-1"
+                      no-gutters
                   >
-                    \(\lambda_{\text{rest}}\)
-                  </v-col>
-                  <v-col
-                      cols="10"
-                  >
-                    rest wavelength of spectral line
-                  </v-col>
-                </v-row>
-              </v-container>
-            </v-card>
-          </v-card-text>
+                    <v-col
+                        cols="2"
+                    >
+                      \(\lambda_{\text{rest}}\)
+                    </v-col>
+                    <v-col
+                        cols="10"
+                    >
+                      rest wavelength of spectral line
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-card>
+            </v-card-text>
+          </v-lazy>
         </v-window-item>
       </v-window>
 
@@ -876,11 +902,13 @@ mjx-mpadded {
 
 
 <script>
-module.exports = {
+export default {
   methods: {
     typesetMathJax(entries, _observer, intersecting) {
       if (intersecting) {
-        MathJax.typesetPromise(entries.map(entry => entry.target));
+        this.$nextTick(() => {
+          MathJax.typesetPromise(entries.map(entry => entry.target));
+        });
       }
     },
 
@@ -903,11 +931,6 @@ module.exports = {
         return value <= 3e5 && value >= 299790;
       });
     }
-  },
-  computed: {
-    // step() {
-    //   return this.step_proxy;
-    // }
   },
   watch: {
     step(newStep, oldStep) {

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
@@ -152,7 +152,7 @@ mjx-mstyle {
 
 
 <script>
-module.exports = {
+export default {
   data: () => ({
     state_view: {
       failed_validation_4: false
@@ -161,7 +161,9 @@ module.exports = {
   methods: {
     typesetMathJax(entries, _observer, intersecting) {
       if (intersecting) {
-        MathJax.typesetPromise(entries.map(entry => entry.target));
+        this.$nextTick(() => {
+          MathJax.typesetPromise(entries.map(entry => entry.target));
+        });
       }
     },
 


### PR DESCRIPTION
This adds in a few fallbacks to and attempts to trigger rendering only when needed. I had though that perhaps the duplicate rendering was due to subsequent pages in the stepper of the doppler slideshow being mounted by "hidden", and that causes repeated calls to the intersection observer. The improvements in this PR do seem to help for the most part, but unfortunately, on the last step of the slideshow, I can sometimes get it so that there's two equations: one that's unrendered (just the raw latex), but with the rendered version right under.

Unfortunately, I don't think I can fix it before tomorrow, but it should not significantly hinder the students.