### PR TITLE
Put team interface content under if statements

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -222,7 +222,8 @@ def Page():
             measurement.student_id = GLOBAL_STATE.value.student.id
         Ref(LOCAL_STATE.fields.measurements).set(dummy_measurements)
 
-    solara.Button(label="Fill data points", on_click=_fill_data_points)
+    if (GLOBAL_STATE.value.show_team_interface):
+        solara.Button(label="Fill data points", on_click=_fill_data_points)
     
 
     def num_bad_velocities():
@@ -249,8 +250,8 @@ def Page():
                 num += 1
         obs_wave_total.set(num)
     
-
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
+    if (GLOBAL_STATE.value.show_team_interface):
+        StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
     with rv.Row():
         with rv.Col(cols=4):

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -185,8 +185,8 @@ def Page():
         
     solara.use_memo(_state_callback_setup)
 
-
-    StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API)
+    if (GLOBAL_STATE.value.show_team_interface):
+        StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API)
     
 
     def put_measurements(samples):
@@ -539,7 +539,7 @@ def Page():
                     put_measurements(samples=False)
                     distances_total.set(count)
 
-                if COMPONENT_STATE.value.current_step_at_or_after(Marker.fil_rem1):
+                if (COMPONENT_STATE.value.current_step_at_or_after(Marker.fil_rem1) and GLOBAL_STATE.value.show_team_interface):
                     solara.Button("Fill Galaxy Distances", on_click=lambda: fill_galaxy_distances())
 
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -147,7 +147,8 @@ def Page():
     if load_class_data.value:
         _on_class_data_loaded(load_class_data.value)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
+    if (GLOBAL_STATE.value.show_team_interface):
+        StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -301,7 +301,8 @@ def Page():
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
+    if (GLOBAL_STATE.value.show_team_interface):
+        StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
     def _on_component_state_loaded(value: bool):
         if not value:

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -246,7 +246,8 @@ def Page():
 
     loaded_component_state.subscribe(_on_component_state_loaded) 
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
+    if (GLOBAL_STATE.value.show_team_interface):
+        StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
     
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():


### PR DESCRIPTION
This resolves #551.

Note that `show_team_interface` is set to False in the cosmicds `GLOBAL_STATE`, so you will need to change the value if you need to see the team interface. BUT if I change it locally to True in my cosmicds/state.py file, the value keeps getting overwritten from the db back to False, so in the short term, you will likely need to edit your story state to get it to stick.  (I think this was the same thing that was originally happening with the piggybank total)?

I'll open an issue to set up a better long term fix for this.