### PR TITLE
A few HubbleDS fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.7.2
+  - glue-plotly==0.9.0
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.8.1
+    glue-plotly[jupyter]>=0.9.0
     ipyvue
     ipyvuetify
     ipywidgets

--- a/src/hubbleds/base_component_state.py
+++ b/src/hubbleds/base_component_state.py
@@ -9,8 +9,10 @@ from cosmicds.logger import setup_logger
 
 logger = setup_logger("STATE")
 
+from typing import TypeVar
+BaseComponentStateT = TypeVar('BaseComponentStateT', bound='BaseComponentState')
 
-def transition_to(component_state: Reactive[BaseState], step: BaseMarker, force=False):
+def transition_to(component_state: Reactive[BaseComponentStateT], step: BaseMarker, force=False):
     if component_state.value.can_transition(step) or force:
         Ref(component_state.fields.current_step).set(step)
     else:
@@ -20,14 +22,14 @@ def transition_to(component_state: Reactive[BaseState], step: BaseMarker, force=
         )
 
 
-def transition_next(component_state: Reactive[BaseState], force=False):
+def transition_next(component_state: Reactive[BaseComponentStateT], force=False):
     next_marker = component_state.value.current_step.next(
         component_state.value.current_step
     )
     transition_to(component_state, next_marker, force=force)
 
 
-def transition_previous(component_state: Reactive[BaseState], force=True):
+def transition_previous(component_state: Reactive[BaseComponentStateT], force=True):
     previous_marker = component_state.value.current_step.previous(
         component_state.value.current_step
     )

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -232,10 +232,11 @@ def DotplotViewer(
                         layer.state.zorder = zorder[i]
                         print(f"Layer {layer} zorder: {layer.state.zorder}")
             
-            def extend_the_tools():         
+            def extend_the_tools():  
+                print("Extending the tools")       
                 extend_tool(dotplot_view, 'plotly:home', activate_cb=apply_zorder)
                 extend_tool(dotplot_view, 'hubble:wavezoom', deactivate_cb=apply_zorder)
-            solara.use_memo(extend_the_tools, dependencies=[])
+            extend_the_tools()
             tool = dotplot_view.toolbar.tools['plotly:home']
             if tool:
                 tool.activate()

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -9,7 +9,7 @@ from cosmicds.viewers.dotplot.state import DotPlotViewerState
 
 from glue.viewers.common.viewer import Viewer
 from glue_plotly.viewers.common import PlotlyBaseView
-from cosmicds.utils import vertical_line_mark
+from cosmicds.utils import vertical_line_mark, extend_tool
 from itertools import chain
 from uuid import uuid4
 from plotly.graph_objects import Scatter
@@ -32,7 +32,8 @@ def DotplotViewer(
     vertical_line_visible: Union[Reactive[bool], bool] = Reactive(True),
     unit: Optional[str] = None,
     x_label: Optional[str] = None,
-    y_label: Optional[str] = None
+    y_label: Optional[str] = None,
+    zorder: Optional[list[int]] = None
     ):
     
     """
@@ -221,6 +222,24 @@ def DotplotViewer(
             # special treatment for go.Heatmap from https://stackoverflow.com/questions/58630928/how-to-hide-the-colorbar-and-legend-in-plotly-express-bar-graph#comment131880779_68555667
             dotplot_view.selection_layer.update(visible=True, z = [list(range(201))], opacity=0, coloraxis='coloraxis')
             dotplot_view.figure.update_coloraxes(showscale=False)
+            
+
+            def apply_zorder():
+                #enumerate dotplot_view.layers
+                if zorder:
+                    print("Applying zorder")
+                    for i, layer in enumerate(dotplot_view.layers):
+                        layer.state.zorder = zorder[i]
+                        print(f"Layer {layer} zorder: {layer.state.zorder}")
+            
+            def extend_the_tools():         
+                extend_tool(dotplot_view, 'plotly:home', activate_cb=apply_zorder)
+                extend_tool(dotplot_view, 'hubble:wavezoom', deactivate_cb=apply_zorder)
+            solara.use_memo(extend_the_tools, dependencies=[])
+            tool = dotplot_view.toolbar.tools['plotly:home']
+            if tool:
+                tool.activate()
+            
 
             
             

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -16,10 +16,16 @@ def SpectrumViewer(
     on_obs_wave_measured: Callable = None,
     on_obs_wave_tool_clicked: Callable = lambda: None,
     on_zoom_tool_clicked: Callable = lambda: None,
+    add_marker_here: float | None = None,
 ):
 
     vertical_line_visible = solara.use_reactive(False)
     toggle_group_state = solara.use_reactive([])
+
+    
+    def _on_change_marker_here():
+       print('add_marker_here', add_marker_here)
+    solara.use_effect(_on_change_marker_here, [add_marker_here])
 
     x_bounds = solara.use_reactive([])
     y_bounds = solara.use_reactive([])
@@ -137,6 +143,14 @@ def SpectrumViewer(
             # annotation_position="top right",
             visible=vertical_line_visible.value and obs_wave > 0.0,
         )
+
+        fig.add_vline(
+            x = add_marker_here,
+            line_width = 1,
+            line_color = "green",
+            visible = add_marker_here is not None
+        )
+        
 
         fig.add_shape(
             editable=False,

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -267,6 +267,9 @@ def Page():
     def print_selected_example_galaxy(galaxy):
         print('selected example galaxy is now:', galaxy)
     Ref(COMPONENT_STATE.fields.selected_example_galaxy).subscribe(print_selected_example_galaxy)
+    
+    sync_spectrum_line = Ref(COMPONENT_STATE.fields.sync_spectrum_line)
+    sync_dotplot_line = Ref(COMPONENT_STATE.fields.sync_dotplot_line) 
 
     StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API)
 
@@ -744,8 +747,7 @@ def Page():
                     ),
                 )
                 
-                sync_spectrum_line = Ref(COMPONENT_STATE.fields.sync_spectrum_line)
-                sync_dotplot_line = Ref(COMPONENT_STATE.fields.sync_dotplot_line) 
+                
                 def sync_dotplot_to_spectrum(velocity):
                     print('====================', velocity)
                     if len(LOCAL_STATE.value.example_measurements) > 0:

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -743,8 +743,19 @@ def Page():
                         True
                     ),
                 )
-
-                                
+                
+                sync_spectrum_line = Ref(COMPONENT_STATE.fields.sync_spectrum_line)
+                sync_dotplot_line = Ref(COMPONENT_STATE.fields.sync_dotplot_line) 
+                def sync_dotplot_to_spectrum(velocity):
+                    print('====================', velocity)
+                    if len(LOCAL_STATE.value.example_measurements) > 0:
+                        lambda_rest = LOCAL_STATE.value.example_measurements[0].rest_wave_value
+                        lambda_obs = lambda_rest * ((velocity / 3e5) + 1)
+                        print('lambda_obs:', lambda_obs)
+                        sync_spectrum_line.set(lambda_obs)
+                    
+                sync_dotplot_line.subscribe(sync_dotplot_to_spectrum)
+                       
                 def create_dotplot_viewer():
                     if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
                         viewer_data = [
@@ -756,7 +767,9 @@ def Page():
                     return DotplotViewer(gjapp,
                                          data=viewer_data,
                                          component_id=DB_VELOCITY_FIELD,
-                                         vertical_line_visible=False,
+                                         vertical_line_visible=COMPONENT_STATE.value.current_step_between(Marker.dot_seq2, Marker.dot_seq6),
+                                         line_marker_at=sync_dotplot_line,
+                                         on_click_callback=lambda _1, point, _2: sync_dotplot_to_spectrum(point.xs[0]),
                                          unit="km / s",
                                          x_label="Velocity (km/s)",
                                          y_label="Number")
@@ -980,6 +993,7 @@ def Page():
                             True
                         ),
                         on_zoom_tool_clicked=lambda: zoom_tool_activated.set(True),
+                        add_marker_here=sync_spectrum_line.value,
                     )
 
                     spectrum_tutorial_opened = Ref(

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -409,7 +409,16 @@ def Page():
 
                 selected_galaxy = Ref(COMPONENT_STATE.fields.selected_galaxy)
                 selected_galaxy.set(galaxy_data.id)
+            
 
+            show_example_data_table = COMPONENT_STATE.value.current_step_between(
+            Marker.cho_row1, Marker.dot_seq12
+            )
+            if show_example_data_table:
+                selection_tool_galaxy = selected_example_measurement
+            else:
+                selection_tool_galaxy= selected_measurement
+            
             SelectionTool(
                 show_galaxies=COMPONENT_STATE.value.current_step_in(
                     [Marker.sel_gal2, Marker.not_gal_tab, Marker.sel_gal3]
@@ -417,8 +426,8 @@ def Page():
                 galaxy_selected_callback=_galaxy_selected_callback,
                 galaxy_added_callback=_galaxy_added_callback,
                 selected_measurement=(
-                    selected_measurement.value.dict()
-                    if selected_measurement.value is not None
+                    selection_tool_galaxy.value.dict()
+                    if selection_tool_galaxy.value is not None
                     else None
                 ),
             )
@@ -788,8 +797,8 @@ def Page():
                 def create_dotplot_viewer():
                     if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
                         viewer_data = [
-                            gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA],
                             gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS],
+                            gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA],
                         ]
                     else:
                         viewer_data = [gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]]
@@ -801,7 +810,9 @@ def Page():
                                          on_click_callback=lambda _1, point, _2: sync_example_velocity_to_wavelength(point.xs[0]),
                                          unit="km / s",
                                          x_label="Velocity (km/s)",
-                                         y_label="Number")
+                                         y_label="Number",
+                                         zorder=[5,1]
+                                         )
                 
                 
                 if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -316,7 +316,14 @@ def Page():
             )
 
         with rv.Col(cols=8):
-
+            
+            show_snackbar = Ref(LOCAL_STATE.fields.show_snackbar)
+            async def snackbar_off(value = None):
+                if show_snackbar.value:
+                    await asyncio.sleep(3)
+                    show_snackbar.set(False)
+            solara.lab.use_task(snackbar_off, dependencies=[show_snackbar])
+            
             def _galaxy_added_callback(galaxy_data: GalaxyData):
                 already_exists = galaxy_data.id in [
                     x.galaxy_id for x in LOCAL_STATE.value.measurements
@@ -333,6 +340,7 @@ def Page():
                     snackbar_message.set(
                         "You've already selected 5 galaxies. Continue forth!"
                     )
+                    logger.info("Attempted to add more than 5 galaxies.")
                     return
 
                 logger.info("Adding galaxy `%s` to measurements.", galaxy_data.id)
@@ -366,7 +374,7 @@ def Page():
 
             SelectionTool(
                 show_galaxies=COMPONENT_STATE.value.current_step_in(
-                    [Marker.sel_gal2, Marker.sel_gal3]
+                    [Marker.sel_gal2, Marker.not_gal_tab, Marker.sel_gal3]
                 ),
                 galaxy_selected_callback=_galaxy_selected_callback,
                 galaxy_added_callback=_galaxy_added_callback,
@@ -376,6 +384,9 @@ def Page():
                     else None
                 ),
             )
+            
+            if show_snackbar.value:
+                solara.Info(label=LOCAL_STATE.value.snackbar_message)        
 
     with rv.Row():
         with rv.Col(cols=4):

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 from cosmicds.state import BaseState
 from hubbleds.base_marker import BaseMarker
 import enum
@@ -113,6 +113,8 @@ class ComponentState(BaseComponentState, BaseState):
     show_reflection_dialog: bool = False
     velocity_reflection_state: VelocityReflection = VelocityReflection()
     reflection_complete: bool = False
+    sync_spectrum_line: float = Field(6565, exclude = True) # won't be saved to the database
+    sync_dotplot_line: float = Field(0.0, exclude = True) # won't be saved to the database
 
     @field_validator("current_step", mode="before")
     def convert_int_to_enum(cls, v: Any) -> Marker:

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -113,8 +113,8 @@ class ComponentState(BaseComponentState, BaseState):
     show_reflection_dialog: bool = False
     velocity_reflection_state: VelocityReflection = VelocityReflection()
     reflection_complete: bool = False
-    sync_spectrum_line: float = Field(6565, exclude = True) # won't be saved to the database
-    sync_dotplot_line: float = Field(0.0, exclude = True) # won't be saved to the database
+    sync_wavelength_line: float = Field(6565, exclude = True) # won't be saved to the database
+    sync_velocity_line: float = Field(0.0, exclude = True) # won't be saved to the database
 
     @field_validator("current_step", mode="before")
     def convert_int_to_enum(cls, v: Any) -> Marker:

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
@@ -72,6 +72,12 @@
         to reset the view and choose a different green dot.
       </p>
     </div>
+    <div v-if="state_view.total_galaxies ==5">
+      <!-- we should never get here -->
+      <p>
+        You have already selected the maximum number of galaxies ({{ state_view.total_galaxies }} / 5). Click next to proceed to the next step.
+      </p>
+    </div>
   </scaffold-alert>
 </template>
 <script setup>

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -733,8 +733,8 @@ def Page():
                     if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
                         DotplotViewer(gjapp, 
                                         data = [
-                                            gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA], 
-                                            gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
+                                            gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS],
+                                            gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
                                             ],
                                             component_id="est_dist_value",
                                             vertical_line_visible=show_dotplot_lines,
@@ -743,12 +743,13 @@ def Page():
                                             unit="Mpc",
                                             x_label="Distance (Mpc)",
                                             y_label="Number",
+                                            zorder=[5,1],
                                             )
                         if COMPONENT_STATE.value.current_step_at_or_after(Marker.dot_seq4a):
                             DotplotViewer(gjapp, 
                                             data = [
-                                                gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA], 
-                                                gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
+                                                gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS],
+                                                gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA] 
                                                 ],
                                                 component_id="ang_size_value",
                                                 vertical_line_visible=show_dotplot_lines,
@@ -757,6 +758,7 @@ def Page():
                                                 unit="arcsec",
                                                 x_label="Angular Size (arcsec)",
                                                 y_label="Number",
+                                                zorder=[5,1],
                                                 )
                     else:
                         # raise ValueError("Example galaxy measurements not found in glue data collection")

--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -390,7 +390,7 @@ class LocalAPI(BaseAPI):
     def get_example_seed_measurement(
             self, 
             local_state: Reactive[LocalState],
-            which="first"
+            which="second"
             ) -> list[dict[str, Any]]:
         url = f"{self.API_URL}/{local_state.value.story_id}/sample-measurements"
         r = self.request_session.get(url)


### PR DESCRIPTION
This fixes a couple issues encountered in stage 1
- It makes sure the example galaxy is selected when returning to stage 1. 
   - A remaining issue is that the Data Table can't receive a selection from the front end, so the example galaxy doesn't look selected, it just is in the python-side. 
- Sets up the 'snack bar' for students selecting galaxies
- Tries to sync a red line between the `SpectrumViewer` and `Dotplot`. I have most of the required setup, but I could not get `SpectrumViewer` to redraw the line, it would render the initial value but not update it. @nmearl, do you have ideas?
- Fixes the re-render issue with the `mc-radio-group`. Updating it is no longer reactive, like the `free-response`, it did not need to be. 
- Address #583 by updating to `glue-plotly=0.9.0`
- Address #575 by reordering the Dotplot Data so that the single point data set is loaded first, and a zorder is applied ([63ced77](https://github.com/cosmicds/hubbleds/pull/585/commits/63ced77090f39c19580ed175b82d353138c4f8b8))