### PR TITLE
Remove icon alerts for unfilled values in stage 1

### DIFF
--- a/src/hubbleds/components/data_table/data_table.py
+++ b/src/hubbleds/components/data_table/data_table.py
@@ -12,13 +12,13 @@ DEFAULT_HEADERS = [
     {"text": "Element", "value": "element"},
     {
         "text": "&lambda;<sub>rest</sub> (&Aring;)",
-        "value": "rest_wave",
+        "value": "rest_wave_value",
     },
     {
         "text": "&lambda;<sub>obs</sub> (&Aring;)",
-        "value": "obs_wave",
+        "value": "obs_wave_value",
     },
-    {"text": "Velocity (km/s)", "value": "velocity"},
+    {"text": "Velocity (km/s)", "value": "velocity_value"},
 ]
 
 


### PR DESCRIPTION
This PR fixes the issue with alert icons appearing in the stage 1 data table.

The reason this was happening is that the field names in the default table header didn't match those in the measurement class, so Vuetify was complaining because not because the relevant object fields were `None` (or `null` JS-side, probably), but because they just didn't exist on the object. We didn't notice this in stage 3 because there we set the table headers explicitly rather than relying on the defaults.