### PR TITLE
Shortcut buttons for stages 1 & 3

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -229,6 +229,17 @@ def Page():
                                                    galaxy=measurement.galaxy))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
 
+    def _fill_stage1_go_stage3():
+        dummy_measurements = LOCAL_API.get_dummy_data()
+        measurements = []
+        for measurement in dummy_measurements:
+            measurements.append(StudentMeasurement(student_id=GLOBAL_STATE.value.student.id,
+                                                   obs_wave_value=measurement.obs_wave_value,
+                                                   galaxy=measurement.galaxy,
+                                                   velocity_value=measurement.velocity_value))
+        Ref(LOCAL_STATE.fields.measurements).set(measurements)
+        router.push("03-distance-measurements")
+
 
     def _select_random_galaxies():
         pass
@@ -319,8 +330,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Fill galaxies", on_click=_fill_galaxies)
-            solara.Button(label="Fill lambdas", on_click=_fill_lambdas)
+            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
 
     with rv.Row():
         with rv.Col(cols=4):
@@ -366,8 +376,8 @@ def Page():
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.sel_gal4),
             )
-            if COMPONENT_STATE.value.current_step_at_or_after(Marker.sel_gal3):
-                solara.Button(label="Quick pick: fill random galaxies", on_click=_select_random_galaxies)
+            if COMPONENT_STATE.value.is_current_step(Marker.sel_gal3):
+                solara.Button(label="Shortcut: Use 5 random galaxies", on_click=_fill_galaxies)
 
         with rv.Col(cols=8):
             
@@ -544,6 +554,8 @@ def Page():
                     ),
                 },
             )
+            if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
+                solara.Button(label="Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -191,6 +191,7 @@ def Page():
             measurement.student_id = GLOBAL_STATE.value.student.id
         Ref(LOCAL_STATE.fields.measurements).set(dummy_measurements)
         Ref(COMPONENT_STATE.fields.angular_sizes_total).set(5)
+        router.push("04-explore-data")
 
     def _fill_thetas():
         dummy_measurements = LOCAL_API.get_dummy_data()
@@ -202,13 +203,13 @@ def Page():
                                                    ang_size_value=measurement.ang_size_value,
                                                    galaxy=measurement.galaxy))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
+        Ref(COMPONENT_STATE.fields.angular_sizes_total).set(5)
 
     with solara.Row():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Fill data points", on_click=_fill_data_points)
-            solara.Button(label="Fill thetas", on_click=_fill_thetas)
+            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 
@@ -531,6 +532,8 @@ def Page():
                     "bad_angsize": False
                 }
             )
+            if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
+                solara.Button(label="Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),


### PR DESCRIPTION
Buttons behave as follows:
- Stages 1 & 3 both have a "fill everything in this stage & move on to next stage" button at the top.
- Stage 1 - while user is on marker sel_gal3 to choose 5 galaxies, shortcut button picks galaxies for you.
- Stage 1 - on marker rep_rem1, shortcut button can fill all lambdas for you.
- Stage 3 - on marker rem_gal1, shortcut button can fill all thetas for you.

Can someone go through and check that it makes sense?