### PR TITLE
Allow specifying initial data table selection

### DIFF
--- a/src/hubbleds/components/data_table/DataTable.vue
+++ b/src/hubbleds/components/data_table/DataTable.vue
@@ -80,12 +80,30 @@
 </style>
 <script setup>
 module.exports = {
+  data() {
+    return {
+      selected: [],
+    };
+  },
   computed: {
-    indexedItems () {
+    indexedItems() {
       return this.items.map((item, index) => ({
         id: item.galaxy.name,
         ...item
       }))
+    }
+  },
+  methods: {
+    updateSelected(indices) {
+      this.selected = this.indexedItems.filter((element, index) => indices.includes(index));
+    }
+  },
+  watch: {
+    selected_indices(indices) {
+      this.updateSelected(indices);
+    },
+    items(newItems) {
+      this.updateSelected(this.selected_indices);
     }
   }
 }

--- a/src/hubbleds/components/data_table/data_table.py
+++ b/src/hubbleds/components/data_table/data_table.py
@@ -25,7 +25,7 @@ DEFAULT_HEADERS = [
 @solara.component_vue("DataTable.vue")
 def DataTable(
     title: str = "",
-    headers: dict = DEFAULT_HEADERS,
+    headers: list[dict] = DEFAULT_HEADERS,
     items: list = [],
     selected: list = [],
     highlighted: bool = False,

--- a/src/hubbleds/components/data_table/data_table.py
+++ b/src/hubbleds/components/data_table/data_table.py
@@ -27,7 +27,7 @@ def DataTable(
     title: str = "",
     headers: list[dict] = DEFAULT_HEADERS,
     items: list = [],
-    selected: list = [],
+    selected_indices: list[int] = [],
     highlighted: bool = False,
     button_icon: str = "",
     show_button: bool = False,


### PR DESCRIPTION
This PR is intended to solve #584. A few notes here:

* I tried passing in a `selected` list as a slice of the `items` list, but the selected items aren't the same objects that are in the table array JS-side, so that doesn't work. So I ended up making the Python-side prop be `selected_indices`, since then we don't have the same identity issues JS-side since we're looking at primitives
* I would've preferred to run the logic that updates `selected` JS-side in the component's mounted hook, but it seemed that the values coming from Solara hadn't been populated yet (I am not sure why). The solution that I used here is to use watchers on the props. I suspect there's no way to know which one will get populated first, so this just runs the logic in both watchers.

So as an example, if you wanted the data table to have the first item selected, you would pass in `selected_indices=[0]` to the `DataTable` component.