### PR TITLE
Re-bin dotplot on a zoom

### DIFF
--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -99,8 +99,6 @@ def DotplotViewer(
             
             viewer.figure.add_trace(line)
             
-        
-            
 
         def _add_viewer():
             if data is None:
@@ -240,8 +238,11 @@ def DotplotViewer(
             tool = dotplot_view.toolbar.tools['plotly:home']
             if tool:
                 tool.activate()
-            
 
+            zoom_tool = dotplot_view.toolbar.tools['hubble:wavezoom']
+            def on_zoom(bounds_old, bounds_new):
+                dotplot_view.state._update_bins()
+            zoom_tool.on_zoom = on_zoom
             
             
             if line_marker_at.value is not None:


### PR DESCRIPTION
This PR is intended to resolve #575. The approach here is to use the `on_zoom` member that the wavelength zoom tool exposes.

Here's what it looks like for me:

https://github.com/user-attachments/assets/d5bd9047-adcb-401c-8de8-9395e029c0bf

