### PR TITLE
Use "minimal" version of data from other students/classes

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -31,7 +31,7 @@ def Layout(children=[]):
 
         # Retrieve the student's app and local states
         LOCAL_API.get_app_story_states(GLOBAL_STATE, LOCAL_STATE)
-        Ref(GLOBAL_STATE.fields.update_db).set(False)
+        Ref(GLOBAL_STATE.fields.update_db).set(True)
 
         # Load in the student's measurements
         measurements = LOCAL_API.get_measurements(GLOBAL_STATE, LOCAL_STATE)

--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -313,7 +313,7 @@ class LocalAPI(BaseAPI):
         self,
         local_state: Reactive[LocalState],
     ) -> tuple[list[StudentMeasurement], list[StudentSummary], list[ClassSummary]]:
-        url = f"{self.API_URL}/{local_state.value.story_id}/all-data"
+        url = f"{self.API_URL}/{local_state.value.story_id}/all-data?minimal=True"
         r = self.request_session.get(url)
         res_json = r.json()
 

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -69,7 +69,7 @@ class StudentMeasurement(BaseModel):
     obs_wave_value: float | None = None
     obs_wave_unit: str = "angstrom"
     velocity_value: float | None = None
-    velocity_unit: str = "km/s"
+    velocity_unit: str = "km / s"
     ang_size_value: float | None = None
     ang_size_unit: str = "arcsecond"
     est_dist_value: float | None = None
@@ -97,11 +97,11 @@ class StudentMeasurement(BaseModel):
 
 
 class BaseSummary(BaseModel):
-    hubble_fit_value: float
-    hubble_fit_unit: str
+    hubble_fit_value: Optional[float] = None
+    hubble_fit_unit: str = "km / s"
     age_value: float
-    age_unit: str
-    last_data_update: datetime.datetime
+    age_unit: str = "Gyr"
+    last_data_update: Optional[datetime.datetime] = None
 
 
 class StudentSummary(BaseSummary):


### PR DESCRIPTION
This updates stage 5 to take advantage of the ability to query the more lightweight "minimal" version from the `/all-data` endpoint introduced in https://github.com/cosmicds/cds-api/pull/134.