### PR TITLE
change class data loaded check from value to finished

### DIFF
--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -114,7 +114,7 @@ def Page():
 
     gjapp, viewers = solara.use_memo(glue_setup, dependencies=[])
 
-    if not (load_class_data.value or load_class_data.pending):
+    if not (load_class_data.finished or load_class_data.pending):
         load_class_data()
 
     def _on_class_data_loaded(class_data_points: List[StudentMeasurement]):
@@ -144,7 +144,7 @@ def Page():
 
         class_plot_data.set(class_data_points)
 
-    if load_class_data.value:
+    if load_class_data.finished:
         _on_class_data_loaded(load_class_data.value)
 
     StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)


### PR DESCRIPTION
In reference to #618, @nmearl pointed out that we should be checking whether the class data load was finished, not whether it has a value. This PR makes that update.

Nick, please take a look to see if I made these changes in the right places. It would probably also be worth checking to make sure we don't have similar errors elsewhere. Thanks!