### PR TITLE
Update behavior of x button in all slideshows

### DIFF
--- a/src/hubbleds/components/angsize_dosdonts_slideshow/AngsizeDosDontsSlideshow.vue
+++ b/src/hubbleds/components/angsize_dosdonts_slideshow/AngsizeDosDontsSlideshow.vue
@@ -36,18 +36,14 @@
           :speak-flag="dialog"
           :selectors="['div.v-toolbar__title', 'div.v-card__text.black--text', 'h3', 'h4', 'p']"
           /> -->
-        <span
-          @click="
-            () => {
-              $emit('close');
+        <span>
+          <v-btn
+            icon
+            @click="() => {
               dialog = false;
-              if (step == 8) {
-                step = 0;
-              }
-            }
-          "
-        >
-          <v-btn icon>
+              step === (length-1) ? step = 0 : null;
+            }"
+          >
             <v-icon> mdi-close </v-icon>
           </v-btn>
         </span>
@@ -607,7 +603,6 @@
           depressed
           @click="
             () => {
-              $emit('close');
               dialog = false;
               step = 0;
             }

--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -18,11 +18,18 @@
           {{ titles[step] }}
         </v-toolbar-title>
         <v-spacer></v-spacer>
-        <span
-            @click="() => { set_dialog(false); if (step === length-1)  {set_step(0)}; }"
-        >
+        <span>
           <v-btn
               icon
+              @click="() => { 
+                set_dialog(false); 
+                if (step === length-1) 
+                  { 
+                    set_student_vel_calc(true);
+                    set_step(0);
+                    next_callback();
+                  }
+              }"
           >
             <v-icon>
               mdi-close
@@ -848,14 +855,14 @@
           calculate
         </v-btn>
         <v-btn
-            v-if="step === 5"
+            v-if="step === length-1"
             class="black--text"
             color="accent"
             depressed
             @click="() => {
               set_dialog(false);
-              set_step(0);
               set_student_vel_calc(true);
+              set_step(0);
               next_callback();
             }"
         >

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
@@ -40,7 +40,14 @@
           />
         <v-btn
           icon
-          @click="closeDialog()"
+          @click="() => { 
+            dialog = false; 
+            if (step === length-1) 
+              { 
+                tutorial_finished(); 
+                set_step(0);  
+              }
+          }"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -178,7 +185,11 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { $emit('close'); dialog = false, tutorial_finished() }"
+          @click="() => { 
+            dialog = false; 
+            tutorial_finished();
+            set_step(0); 
+          }"
         >
           Done
         </v-btn>

--- a/src/hubbleds/components/hubble_exp_universe_slideshow/HubbleExpUniverseSlideshow.vue
+++ b/src/hubbleds/components/hubble_exp_universe_slideshow/HubbleExpUniverseSlideshow.vue
@@ -39,7 +39,14 @@
           /> -->
         <v-btn
           icon
-          @click="set_dialog(false);"
+          @click="() => { 
+            dialog = set_dialog(false);
+            if (step === length-1) 
+              { 
+                on_slideshow_finished()
+                set_step(0);  
+              }
+          }"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -240,7 +247,11 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { $emit('close'); set_dialog(false); set_step(0); on_slideshow_finished(); }"
+          @click="() => { 
+            set_dialog(false); 
+            on_slideshow_finished(); 
+            set_step(0); 
+          }"
         >
           Done
         </v-btn>

--- a/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
+++ b/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
@@ -45,10 +45,18 @@
           :selectors="['label > div', 'div.v-toolbar__title', 'div.v-card__text.black--text', 'h3', 'p']"
         >
         </speech-synthesizer> -->
-        <span
-          @click="() => set_dialog(false)"
-        >
-          <v-btn icon>
+        <span>
+          <v-btn
+            icon
+            @click="() => { 
+            dialog = set_dialog(false);
+            if (step === length-1) 
+              { 
+                on_reflection_complete();
+                set_step(0);  
+              }
+            }"
+          >
             <v-icon> mdi-close </v-icon>
           </v-btn>
         </span>
@@ -390,7 +398,7 @@
         </v-item-group>
         <v-spacer></v-spacer>
         <v-btn
-          v-if="step < 7"
+          v-if="step < length-1"
           :disabled="require_responses && step > max_step_completed"
           class="black--text"
           color="accent"
@@ -400,11 +408,15 @@
           Next
         </v-btn>
         <v-btn
-          v-if="step >= 7"
+          v-if="step === length-1"
           color="accent"
           class="black--text"
           depressed
-          @click="() => { set_dialog(false); set_step(0); on_reflection_complete()}"
+          @click="() => { 
+            set_dialog(false);
+            on_reflection_complete();
+            set_step(0); 
+          }"
         >
           Done
         </v-btn>

--- a/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
@@ -37,18 +37,16 @@
 <!--          :speak-flag="dialog"-->
 <!--          :selectors="['div.v-toolbar__title', 'div.v-card__text.black&#45;&#45;text', 'h3', 'p']"-->
 <!--          />-->
-        <span
-          @click="
-            () => {
-              $emit('close');
+        <span>
+          <v-btn
+            icon
+            @click="() => {
               dialog = false;
-              if (step === 8) {
+              if (step === length-1) {
                 step = 0;
               }
-            }
-          "
-        >
-          <v-btn icon>
+            }"
+          >
             <v-icon> mdi-close </v-icon>
           </v-btn>
         </span>
@@ -676,7 +674,7 @@
         </v-item-group>
         <v-spacer></v-spacer>
         <v-btn
-          v-if="step < 10"
+          v-if="step < length-1"
           class="black--text"
           color="accent"
           depressed
@@ -685,13 +683,11 @@
           next
         </v-btn>
         <v-btn
-          v-if="step >= 10"
+          v-if="step === length-1"
           color="accent"
           class="black--text"
           depressed
-          @click="
-            () => {
-              $emit('close');
+          @click="() => {
               dialog = false;
               step = 0;
             }

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -40,8 +40,12 @@
         <v-btn
           icon
           @click="() => { 
-          dialog = false;
-          step == (length-1) ? on_slideshow_finished() : null;
+            dialog = false;
+            if (step === length-1) 
+              { 
+                on_slideshow_finished();
+                step = 0;  
+              }
           }"
         >
           <v-icon>mdi-close</v-icon>
@@ -399,7 +403,11 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { $emit('close'); dialog = false; step = 0; on_slideshow_finished(); }"
+          @click="() => { 
+            dialog = false; 
+            on_slideshow_finished();
+            step = 0; 
+          }"
         >
           Done
         </v-btn>


### PR DESCRIPTION
This standardizes how we handle closing of the slideshows throughout the Data Story and resolves #568.

Intended behavior for x button in dialogs:
- If you are at any slide other than the last slide, the x button simply closes the dialog. (If there is a gate that requires the whole slideshow to be completed, closing the dialog before the last slide does not open the gate).
- If you are on the last slide, the x button also performs whatever actions the "done" button does, including resetting the step to 0.

Other things tidied up:
- For a lot of the dialogs, the @click handling was in the `span` div around the button. That seemed weird to me, so I moved all the @click's to within the `v-btn`.
- We hard-coded a lot of length values within the slideshows which led to some errors, so I changed all the last slide conditions to be for `n === length - 1`. 
- A few slideshows had `$emit('close')` in the "done" sequences, but we think those don't do anything in Solara, so I removed them.
- Note, for slideshows that are purely informational, where we don't require students to complete the entire slideshow, we do not track their steps in the state. If they close the dialog and reopen without switching stages, the front end remembers their step number, but if they reload the stage, their location is forgotten. I think that's ok, but we can change those to be tracked in the state if we have time.