### PR TITLE
Display "my velocity" as scatter layer

### DIFF
--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -128,7 +128,13 @@ def DotplotViewer(
             line_ids.append(line_id)
             
             viewer.figure.add_trace(line)
-            
+
+        
+        def _add_data(viewer: PlotlyBaseView, data: Union[Data, tuple]):
+            if isinstance(data, Data):
+                viewer.add_data(data)
+            else:
+                viewer.add_data(data[0], layer_type=data[1])
 
         def _add_viewer():
             logger.info(f"\n ====== ({title}) Dotplot _add_viewer() ====== \n")
@@ -138,12 +144,15 @@ def DotplotViewer(
             else: 
                 if isinstance(data, Data):
                     viewer_data = data
-                elif isinstance(data, list):
+                else:
                     viewer_data = data[0]
             
             dotplot_view: HubbleDotPlotViewer = gjapp.new_data_viewer(
-                HubbleDotPlotView, data=viewer_data, show=False) # type: ignore
+                HubbleDotPlotView, show=False) # type: ignore
 
+            _add_data(dotplot_view, viewer_data)
+            if isinstance(viewer_data, tuple):
+                viewer_data = viewer_data[0]
             
             if component_id is not None:
                 dotplot_view.state.x_att = viewer_data.id[component_id]
@@ -151,7 +160,7 @@ def DotplotViewer(
             if isinstance(data, list):
                 if len(data) > 1:
                     for viewer_data in data[1:]:
-                        dotplot_view.add_data(viewer_data)
+                        _add_data(dotplot_view, viewer_data)
 
             dotplot_view.state.hist_n_bin = nbin
             if x_bounds.value is not None:

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -389,21 +389,23 @@ def Page():
         show = COMPONENT_STATE.value.current_step >= Marker.int_dot1
         if show and (EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection):
             viewer_data = [
-                gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS],
+                (gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS], "scatter"),
                 gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA],
             ]
+            first_data = gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
             zorder = [5, 1]
         else:
             viewer_data = [gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]]
+            first_data = gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
             zorder = None
 
         ignore = [gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]]
         if COMPONENT_STATE.value.current_step >= Marker.dot_seq9:
-            first = subset_by_label(viewer_data[0], "first measurement")
+            first = subset_by_label(first_data, "first measurement")
             if first is not None:
                 ignore.append(first)
         else:
-            second = subset_by_label(viewer_data[0], "second measurement")
+            second = subset_by_label(first_data, "second measurement")
             if second is not None:
                 ignore.append(second)
         

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -392,20 +392,22 @@ def Page():
                 (gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS], "scatter"),
                 gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA],
             ]
-            first_data = gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
+            # If the student has made a measurement, that is the 0th layer.
+            layer0 = gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]
             zorder = [5, 1]
         else:
             viewer_data = [gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]]
-            first_data = gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
+            # If the student has NOT made a measurement, the seed data is the 0th layer.
+            layer0 = gjapp.data_collection[EXAMPLE_GALAXY_SEED_DATA]
             zorder = None
 
         ignore = [gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS]]
         if COMPONENT_STATE.value.current_step >= Marker.dot_seq9:
-            first = subset_by_label(first_data, "first measurement")
+            first = subset_by_label(layer0, "first measurement")
             if first is not None:
                 ignore.append(first)
         else:
-            second = subset_by_label(first_data, "second measurement")
+            second = subset_by_label(layer0, "second measurement")
             if second is not None:
                 ignore.append(second)
         


### PR DESCRIPTION
This PR brings the changes from https://github.com/cosmicds/cosmicds/pull/343 into the Hubble story. Here's an example of what this looks like for me:

![Screenshot from 2024-10-09 13-27-31](https://github.com/user-attachments/assets/dc9825f5-ac90-4fe3-95fe-43facd46f00c)

Size and color are easy to change, but the main thing is that the velocity scatter point is not bound by the dotplot bins.

Not sure if this is generally the case, but I needed the updates from `glue-plotly==0.10.0` to avoid getting a `NaN` value for the dot radius calculation.