### PR TITLE
Bump glue-plotly version and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ or
 - From the command line:
    `$ cosmicds hubble`
 
+# Development environment
+
+In order to keep consistency with development, this repository contains an environment file that specifies dependency versions.
+You can create a conda environment using this file via
+
+```bash
+conda env create --name <env-name> --file environment.yml
+```
+
+To re-create the environment file using the packages in your current environment, you can run the `make_environment.py` script. Note that this file
+will make sure that we install the `ipywwt` package from its git repository. It also removes any references to `cosmicds` and `hubbleds`, as this is supposed
+to generate a development environment for the `hubbleds` package. This script only retains information about Python packages installed via pip; other conda
+dependencies may differ between machines and aren't important for our purposes.
+
 
 ## Note
 This project has been set up using PyScaffold 4.5. For details and usage

--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.9.0
+  - glue-plotly==0.10.0
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4


### PR DESCRIPTION
This PR addresses #648 by bumping our version of `glue-plotly` and adding some information about our environment file setup in the README.