### PR TITLE
add demo label in css; don't retrieve db data

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -248,7 +248,7 @@ footer .v-card__text {
     DEMO VERSION TAG
     ================================
 *****/
-.app-title {
+header.cosmicds-appbar > div.v-toolbar__content > h3 {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -272,6 +272,8 @@ header.cosmicds-appbar > div.v-toolbar__content > h3::after {
     padding-block: 5px;
     border-radius: 10px;
     margin-left: 25px;  
+    
+    line-height: 1;
 }
 
 /***** 

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -248,9 +248,18 @@ footer .v-card__text {
     DEMO VERSION TAG
     ================================
 *****/
+.app-title {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
 header.cosmicds-appbar > div.v-toolbar__content > h3::after {
-    content: "DEMO Version: Progress and measurements are not saved";
-    font-size: 20px;
+    content: "Shortened DEMO Version:\AProgress and measurements are NOT saved";
+    white-space: pre-wrap;
+    display: block;
+    text-align: center;
+    font-size: 0.8em;
     font-weight: bold;
     color: white;
     background-color: red;
@@ -259,10 +268,10 @@ header.cosmicds-appbar > div.v-toolbar__content > h3::after {
     top: 100%;
     left: 0%; */
   
-    padding-inline: 20px;
-    padding-block: 10px;
-    border-radius: 40px;
-    margin-left: 20px;  
+    padding-inline: 15px;
+    padding-block: 5px;
+    border-radius: 10px;
+    margin-left: 25px;  
 }
 
 /***** 

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -273,7 +273,7 @@ header.cosmicds-appbar > div.v-toolbar__content > h3::after {
     border-radius: 10px;
     margin-left: 25px;  
     
-    line-height: 1;
+    line-height: 1.2;
 }
 
 /***** 

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -245,6 +245,28 @@ footer .v-card__text {
 
 /***** 
     ================================
+    DEMO VERSION TAG
+    ================================
+*****/
+header.cosmicds-appbar > div.v-toolbar__content > h3::after {
+    content: "DEMO Version: Progress and measurements are not saved";
+    font-size: 20px;
+    font-weight: bold;
+    color: white;
+    background-color: red;
+  
+    /* position: absolute;
+    top: 100%;
+    left: 0%; */
+  
+    padding-inline: 20px;
+    padding-block: 10px;
+    border-radius: 40px;
+    margin-left: 20px;  
+}
+
+/***** 
+    ================================
     Solara/Vuetify default overrides 
     ================================
 *****/


### PR DESCRIPTION
Addresses first 2 items in #659  Adds a simple demo label using `::after` CSS psuedo-class, along with a companion cosmicds PR https://github.com/cosmicds/cosmicds/pull/345

<img width="797" alt="image" src="https://github.com/user-attachments/assets/3301c6f4-bbdd-49e3-9e8f-4dea4e160bc6">
