### PR TITLE
Add histogram hovertext

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -116,7 +116,7 @@ def Page():
             "class_hist": class_hist_viewer
         }
 
-        hist_viewers = (all_student_hist_viewer, class_hist_viewer)
+        two_hist_viewers = (all_student_hist_viewer, class_hist_viewer)
         for att in ('x_min', 'x_max'):
             link((all_student_hist_viewer.state, att), (class_hist_viewer.state, att))
 
@@ -245,11 +245,11 @@ def Page():
         # So we force the home tool of the class viewer to limit-resetting based on the students viewer
         class_hist_viewer.toolbar.tools["plotly:home"].activate = all_student_hist_viewer.toolbar.tools["plotly:home"].activate
 
-        for viewer in hist_viewers:
+        for viewer in (student_hist_viewer, all_student_hist_viewer, class_hist_viewer):
             viewer.figure.update_layout(hovermode="closest")
 
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,
-                                            handler=partial(_update_bins, hist_viewers),
+                                            handler=partial(_update_bins, two_hist_viewers),
                                             filter=lambda msg: msg.data.label == "Student Summaries")
 
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -22,7 +22,8 @@ from hubbleds.components import UncertaintySlideshow, IdSlider
 from hubbleds.tools import *  # noqa
 from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, StudentMeasurement, get_free_response, get_multiple_choice, mc_callback, fr_callback
 from hubbleds.utils import make_summary_data, models_to_glue_data
-from hubbleds.viewers.hubble_scatter_viewer import HubbleHistogramView, HubbleScatterView
+from hubbleds.viewers.hubble_histogram_viewer import HubbleHistogramView
+from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
 from hubbleds.remote import LOCAL_API
 
@@ -243,6 +244,9 @@ def Page():
         # The idea here is that the all students viewer will always have a wider range than the all classes viewer
         # So we force the home tool of the class viewer to limit-resetting based on the students viewer
         class_hist_viewer.toolbar.tools["plotly:home"].activate = all_student_hist_viewer.toolbar.tools["plotly:home"].activate
+
+        for viewer in hist_viewers:
+            viewer.figure.update_layout(hovermode="closest")
 
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,
                                             handler=partial(_update_bins, hist_viewers),
@@ -637,6 +641,7 @@ def Page():
 
             with rv.Col():
                 ViewerLayout(viewer=viewers["student_hist"])
+
 
     ScaffoldAlert(
         GUIDELINE_ROOT / "GuidelineMostLikelyValueReflect4.vue",

--- a/src/hubbleds/viewers/__init__.py
+++ b/src/hubbleds/viewers/__init__.py
@@ -1,3 +1,4 @@
 from .hubble_dotplot import *
+from .hubble_histogram_viewer import *
 from .hubble_scatter_viewer import *
 from .hubble_fit_viewer import *

--- a/src/hubbleds/viewers/hubble_histogram_viewer.py
+++ b/src/hubbleds/viewers/hubble_histogram_viewer.py
@@ -1,0 +1,29 @@
+from echo import delay_callback
+from cosmicds.viewers import CDSHistogramViewerState, PlotlyHistogramView
+from cosmicds.viewers import cds_viewer
+
+
+__all__ = [
+    "HubbleHistogramView",
+]
+
+
+class HubbleHistogramViewerState(CDSHistogramViewerState):
+
+    def reset_limits(self, visible_only=True):
+        with delay_callback(self, 'x_min', 'x_max'):
+            super().reset_limits(visible_only=visible_only)
+            self.x_min = round(self.x_min, 0) - 2.5 if self.x_min is not None else 0
+            self.x_max = round(self.x_max, 0) + 2.5 if self.x_max is not None else 0
+
+
+HubbleHistogramView = cds_viewer(
+    PlotlyHistogramView,
+    name="HubbleHistogramView",
+    viewer_tools=[
+        'plotly:home',
+        'plotly:hzoom',
+    ],
+    label="Histogram",
+    state_cls=HubbleHistogramViewerState
+)

--- a/src/hubbleds/viewers/hubble_histogram_viewer.py
+++ b/src/hubbleds/viewers/hubble_histogram_viewer.py
@@ -1,6 +1,7 @@
 from echo import delay_callback
 from cosmicds.viewers import CDSHistogramViewerState, PlotlyHistogramView
 from cosmicds.viewers import cds_viewer
+from glue_plotly.viewers.histogram import PlotlyHistogramLayerArtist
 
 
 __all__ = [
@@ -27,3 +28,14 @@ HubbleHistogramView = cds_viewer(
     label="Histogram",
     state_cls=HubbleHistogramViewerState
 )
+
+
+class HubbleHistogramLayerArtist(PlotlyHistogramLayerArtist):
+
+    def _update_data(self):
+        super()._update_data()
+        for bar in self.traces():
+            bar.update(hovertemplate="<b>Age</b>: %{x:,.0f} Gyr<extra></extra>")
+
+HubbleHistogramView._data_artist_cls = HubbleHistogramLayerArtist
+HubbleHistogramView._subset_artist_cls = HubbleHistogramLayerArtist

--- a/src/hubbleds/viewers/hubble_scatter_viewer.py
+++ b/src/hubbleds/viewers/hubble_scatter_viewer.py
@@ -1,6 +1,6 @@
 from echo import delay_callback
 from glue_plotly.viewers.scatter import PlotlyScatterView
-from cosmicds.viewers import CDSHistogramViewerState, CDSScatterViewerState, PlotlyHistogramView
+from cosmicds.viewers import CDSScatterViewerState
 from cosmicds.viewers import cds_viewer
 
 __all__ = [
@@ -16,15 +16,6 @@ class HubbleScatterViewerState(CDSScatterViewerState):
             self.y_min = min(self.y_min, 0) if self.y_min is not None else 0
 
 
-class HubbleHistogramViewerState(CDSHistogramViewerState):
-
-    def reset_limits(self, visible_only=True):
-        with delay_callback(self, 'x_min', 'x_max'):
-            super().reset_limits(visible_only=visible_only)
-            self.x_min = round(self.x_min, 0) - 2.5 if self.x_min is not None else 0
-            self.x_max = round(self.x_max, 0) + 2.5 if self.x_max is not None else 0
-
-
 HubbleScatterView = cds_viewer(
     PlotlyScatterView,
     name="HubbleScatterView",
@@ -38,13 +29,3 @@ HubbleScatterView = cds_viewer(
 )
 
 
-HubbleHistogramView = cds_viewer(
-    PlotlyHistogramView,
-    name="HubbleHistogramView",
-    viewer_tools=[
-        'plotly:home',
-        'plotly:hzoom',
-    ],
-    label="Histogram",
-    state_cls=HubbleHistogramViewerState
-)


### PR DESCRIPTION
This PR adds the histogram hovertext requested in #661.

Note that we can't just manipulate the traces that correspond to the layers directly in the `glue_setup` function, because there's no guarantee that these traces will persist - anything that triggers a redraw in the viewer will cause new traces to get created (and in my testing, this does happen). Thus, I've made a quick subclass of the histogram layer artist that does what we want and attached that to our CDS-wrapped histogram viewer.