### PR TITLE
fix #671 make sure log messages to show consistent messages

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -33,7 +33,7 @@ def Layout(children=[]):
 
         # Retrieve the student's app and local states
         LOCAL_API.get_app_story_states(GLOBAL_STATE, LOCAL_STATE)
-        Ref(GLOBAL_STATE.fields.update_db).set(True)
+
 
         # Load in the student's measurements
         measurements = LOCAL_API.get_measurements(GLOBAL_STATE, LOCAL_STATE)
@@ -55,14 +55,17 @@ def Layout(children=[]):
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_story_state(GLOBAL_STATE, LOCAL_STATE)
+        put_state = LOCAL_API.put_story_state(GLOBAL_STATE, LOCAL_STATE)
 
         # Be sure to write the measurement data separately since it's stored
         #  in another location in the database
-        LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
-        LOCAL_API.put_sample_measurements(GLOBAL_STATE, LOCAL_STATE)
-
-        logger.info("Wrote state to database.")
+        put_meas = LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
+        put_samp = LOCAL_API.put_sample_measurements(GLOBAL_STATE, LOCAL_STATE)
+        
+        if put_state and put_meas and put_samp:
+            logger.info("Wrote state to database.")
+        else:
+            logger.info(f"Did not write {'story state' if not put_state else ''} {'measurements' if not put_meas else ''} {'sample measurements' if not put_samp else ''} to database.")
 
     solara.lab.use_task(
         _write_local_global_states, dependencies=[GLOBAL_STATE.value, LOCAL_STATE.value]

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -93,9 +93,11 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
-
-        logger.info("Wrote component state to database.")
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        if res:
+            logger.info("Wrote component state to database.")
+        else:
+            logger.info("Did not write component state to database.")
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
 

--- a/src/hubbleds/pages/02-distance-introduction/__init__.py
+++ b/src/hubbleds/pages/02-distance-introduction/__init__.py
@@ -33,9 +33,14 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        
+        if res:
+            logger.info("Wrote component state for stage 2 to database.")
+        else:
+            logger.info("Did not write component state for stage 2 to database.")
 
-        logger.info("Wrote component state for stage 2 to database.")
+        
 
     logger.info("Trying to write component state for stage 2.")
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -166,9 +166,11 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
-
-        logger.info("Wrote component state to database.")
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        if res:
+            logger.info("Wrote component state for stage 3 to database.")
+        else:
+            logger.info("Did not write component state for stage 3 to database.")
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -63,9 +63,12 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        if res:
+            logger.info("Wrote component state for stage 4 to database.")
+        else:
+            logger.info("Did not write component state for stage 4 to database.")
 
-        logger.info("Wrote component state to database.")
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
 

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -56,9 +56,14 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        if res:
+            logger.info("Wrote stage 5 component state to database.")
+        else:
+            logger.info("Did not write stage 5 component state to database.")
 
-        logger.info("Wrote stage 5 component state to database.")
+
+        
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -80,9 +80,11 @@ def Page():
             return
 
         # Listen for changes in the states and write them to the database
-        LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
-
-        logger.info("Wrote component state to database.")
+        res = LOCAL_API.put_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
+        if res:
+            logger.info("Wrote stage 6 component state to database.")
+        else:
+            logger.info("Did not write stage 6 component state to database.")
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     

--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -173,7 +173,7 @@ class LocalAPI(BaseAPI):
         
         if not GLOBAL_STATE.value.update_db: 
             logger.info('Skipping DB write')
-            return
+            return False
         
         url = f"{self.API_URL}/{local_state.value.story_id}/submit-measurement/"
 
@@ -191,13 +191,14 @@ class LocalAPI(BaseAPI):
             "Stored measurements for student `%s`.",
             global_state.value.student.id,
         )
+        return True
 
     def put_sample_measurements(
         self, global_state: Reactive[GlobalState], local_state: Reactive[LocalState]
     ):
         if not GLOBAL_STATE.value.update_db: 
             logger.info('Skipping DB write')
-            return
+            return False
         
         url = f"{self.API_URL}/{local_state.value.story_id}/sample-measurement/"
     
@@ -222,6 +223,7 @@ class LocalAPI(BaseAPI):
                 "Stored example measurements for student %s.",
                 global_state.value.student.id,
             )
+        return True
 
     def get_measurement(
         self,
@@ -370,7 +372,7 @@ class LocalAPI(BaseAPI):
     ):
         if not GLOBAL_STATE.value.update_db: 
             logger.info('Skipping DB write')
-            return
+            return False
         
         logger.info("Serializing stage state into DB.")
 
@@ -390,6 +392,9 @@ class LocalAPI(BaseAPI):
         if r.status_code != 200:
             logger.error("Failed to write story state to database.")
             logger.error(r.text)
+            return False
+        
+        return True
 
     def put_story_state(
         self,
@@ -398,7 +403,7 @@ class LocalAPI(BaseAPI):
     ):
         if not GLOBAL_STATE.value.update_db: 
             logger.info('Skipping DB write')
-            return
+            return False
         
         logger.info("Serializing state into DB.")
 
@@ -417,6 +422,9 @@ class LocalAPI(BaseAPI):
         if r.status_code != 200:
             logger.error("Failed to write story state to database.")
             logger.error(r.text)
+            return False
+        
+        return True
 
 
     def get_example_seed_measurement(


### PR DESCRIPTION
This modifes the logged messages depending on if the database is being updated. It adds a boolean return value from the `LOCAL_API.put_*` functions to signal if some thing was written. 