### PR TITLE
Highlight Messier buttons in intro

### DIFF
--- a/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
+++ b/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
@@ -933,7 +933,7 @@
       </v-btn>
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
-        v-if="step < length-1 && show_team_interface"
+        v-if="step < length-1 && debug"
         color="success"
         class="black--text"
         depressed

--- a/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
+++ b/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
@@ -320,7 +320,7 @@
               <v-btn
                 color="accent"
                 class="mx-4 black--text"
-                @click="{
+                @click="() => {
                   timerComplete[0] = false;
                   step++;
                 }"
@@ -540,7 +540,7 @@
               <v-btn
                 color="accent"
                 class="mx-4 black--text"
-                @click="{
+                @click="() => {
                   timerComplete[1] = false;
                   step++;
                 }"
@@ -718,7 +718,7 @@
               <v-btn
                 color="accent"
                 class="mx-4 black--text"
-                @click="{
+                @click="() => {
                   timerComplete[2] = false;
                   step++;
                 }"

--- a/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
+++ b/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
@@ -378,8 +378,8 @@
                                 dec: 22.014,
                                 fov: 350, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M1', // name of object
                               });
+                              target = 'M1';
                               startTimerIfNeeded(1);
                             }"
                             color="warning"
@@ -402,8 +402,8 @@
                                 dec: 36.46,
                                 fov: 700, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M13', // name of object
                               });
+                              target = 'M13';
                               startTimerIfNeeded(1);
                             }"
                             color="warning"
@@ -426,8 +426,8 @@
                                 dec: 41.27,
                                 fov: 6000, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M31' // name of object
                               });
+                              target = 'M31';
                               startTimerIfNeeded(1);
                             }"
                             color="warning"
@@ -450,8 +450,8 @@
                                 dec: -5.39,
                                 fov:7500, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M42' // name of object
                               });
+                              target = 'M42';
                               startTimerIfNeeded(1);  
                             }"
                             color="warning"
@@ -474,8 +474,8 @@
                                 dec: 47.195,
                                 fov: 700, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M51' // name of object
                               });
+                              target = 'M51';
                               startTimerIfNeeded(1);
                             }"
                             color="warning"
@@ -498,8 +498,8 @@
                                 dec: 69.68,
                                 fov: 400, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M82' // name of object
                               });
+                              target = 'M82';
                               startTimerIfNeeded(1);
                             }"
                             color="warning"
@@ -626,8 +626,8 @@
                                 dec: 41.27,
                                 fov: 6000, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M31' // name of object
                               });
+                              target = 'M31';
                               startTimerIfNeeded(2);
                             }"
                             color="warning"
@@ -663,8 +663,8 @@
                                 dec: 47.195,
                                 fov: 700, // optional, in arcseconds, default is 90
                                 instant: false, // also optional, false by default
-                                target: 'M51', // name of object
                               });
+                              target = 'M51';
                               startTimerIfNeeded(2);
                             }"
                             color="warning"
@@ -864,8 +864,8 @@
               dec: 41.27,
               fov: 6000, // optional, in arcseconds, default is 90
               instant: true, // also optional, false by default
-              target: 'M31' // name of object
             };
+            target = 'M31';
           }
           go_to_location(options)
         }"
@@ -923,8 +923,8 @@
               dec: 41.27,
               fov: 6000, // optional, in arcseconds, default is 90
               instant: true, // also optional, false by default
-              target: 'M31' // name of object
             };
+            target = 'M31';
           }
           go_to_location(options)
         }"
@@ -986,7 +986,7 @@
 
 <script>
 module.exports = {
-  props: ["continueText", "target"],
+  props: ["continueText"],
   data() {
     return {
       target: '',

--- a/src/hubbleds/components/intro_slideshow_vue/intro_slideshow.py
+++ b/src/hubbleds/components/intro_slideshow_vue/intro_slideshow.py
@@ -1,7 +1,6 @@
 
 import solara
 import reacton.ipyvuetify as rv
-from ipyvuetify import VuetifyTemplate
 
 @solara.component_vue("IntroSlideshow.vue")
 def IntroSlideshowVue(


### PR DESCRIPTION
This PR updates the intro slideshow so that the Messier buttons highlight when clicked like they did in the voila version. This also fixes up a couple of other minor issues with the template.