### PR TITLE
send brightness to db with each ang size measurement

### DIFF
--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -334,7 +334,7 @@ def Page():
         else:
             LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
             
-    def _update_angular_size(update_example: bool, galaxy, angular_size, count, meas_num = 'first'):
+    def _update_angular_size(update_example: bool, galaxy, angular_size, count, meas_num = 'first', brightness = 1.0):
         # if bool(galaxy) and angular_size is not None:
         arcsec_value = int(angular_size.to(u.arcsec).value)
         if update_example:
@@ -345,7 +345,8 @@ def Page():
                 measurement.set(
                     measurement.value.model_copy(
                         update={
-                            "ang_size_value": arcsec_value
+                            "ang_size_value": arcsec_value,
+                            "brightness": brightness
                             }
                         )
                 )
@@ -361,7 +362,8 @@ def Page():
                 measurement.set(
                     measurement.value.model_copy(
                         update={
-                            "ang_size_value": arcsec_value
+                            "ang_size_value": arcsec_value,
+                            "brightness": brightness
                             }
                         )
                 )
@@ -416,6 +418,7 @@ def Page():
     ang_size_dotplot_range = solara.use_reactive([])
     dist_dotplot_range = solara.use_reactive([])
     fill_galaxy_pressed = solara.use_reactive(COMPONENT_STATE.value.distances_total >= 5)
+    current_brightness = solara.use_reactive(1.0)
     
     @solara.lab.computed
     def sync_dotplot_axes():
@@ -563,7 +566,7 @@ def Page():
                 """
                 data = current_data.value
                 count = Ref(COMPONENT_STATE.fields.example_angular_sizes_total) if on_example_galaxy_marker.value else Ref(COMPONENT_STATE.fields.angular_sizes_total)
-                _update_angular_size(on_example_galaxy_marker.value, current_galaxy.value, angle, count, example_galaxy_measurement_number.value)
+                _update_angular_size(on_example_galaxy_marker.value, current_galaxy.value, angle, count, example_galaxy_measurement_number.value, brightness = current_brightness.value)
                 put_measurements(samples=on_example_galaxy_marker.value)
                 if on_example_galaxy_marker.value:
                     value = int(angle.to(u.arcsec).value)
@@ -608,6 +611,11 @@ def Page():
             def _get_ruler_clicks_cb(count):
                 ruler_click_count = Ref(COMPONENT_STATE.fields.ruler_click_count)
                 ruler_click_count.set(count)
+            
+            def brightness_callback(brightness):
+                logger.info(f'Brightness: {brightness}')
+                current_brightness.set(brightness / 100)
+                
 
             DistanceToolComponent(
                 galaxy=current_galaxy.value,
@@ -616,7 +624,7 @@ def Page():
                 ruler_count_callback=_get_ruler_clicks_cb,
                 bad_measurement_callback=_bad_measurement_cb,
                 use_guard=True,
-                brightness_callback=lambda b: logger.info(f'Update Brightness: {b}'),
+                brightness_callback=brightness_callback,
                 reset_canvas=reset_canvas
             )
             


### PR DESCRIPTION
This PR fixes #684. It sends the brightness to the db along with each measurement of the angular size. If tracks the currently set brightness with `current_brightness` reactive variable, and that is passed to the angular size callback to be added in the measurement update