### PR TITLE
Fix #679 by adding button to show doppler slideshow

### DIFF
--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -3,6 +3,19 @@
       v-model="dialog"
       max-width="800px"
   >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        v-if="show_button"
+        v-bind="attrs"
+        v-on="on"
+        block
+        color="secondary"
+        elevation="2"
+        @click.stop="() => { opened = true; dialog_opened_callback() }"
+      >
+        View Doppler Calculation
+      </v-btn>
+    </template>
     <v-card
         class="mx-auto"
     >

--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -532,8 +532,9 @@
                 Now enter the <b>speed of light</b> in <b>km/s</b> in the empty box below.
               </p>
               <v-card
-                  class="JaxEquation pa-3"
-                  color="info"
+                v-if="student_c==0"
+                class="JaxEquation pa-3"
+                color="info"
               >
                 $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
                 {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
@@ -556,6 +557,23 @@
                   zeroes. The speed of light is highlighted in yellow below.
                 </v-alert>
               </v-card>
+              <v-card
+                v-else
+                class="JaxEquation pa-3"
+                color="info"
+              >
+                $$ v = c \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+                $$ v = \textcolor{black}{\colorbox{#FFAB91}{ {{ student_c.toLocaleString() }} }}\text{ km/s} \times \textcolor{black}{\colorbox{#FFAB91}{
+                {{ (lambda_obs / lambda_rest - 1).toFixed(4) }} } } $$
+                <v-divider role="presentation"></v-divider>
+                <div
+                    class="font-weight-medium mt-3"
+                >
+                  Click <b>CALCULATE</b> to multiply through and obtain the speed of this galaxy.
+                </div>              
+              </v-card>
+
               <v-divider role="presentation"></v-divider>
               <v-card
                   class="legend mt-8"

--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -3,19 +3,6 @@
       v-model="dialog"
       max-width="800px"
   >
-    <template v-slot:activator="{ on, attrs }">
-      <v-btn
-        v-if="show_button"
-        v-bind="attrs"
-        v-on="on"
-        block
-        color="secondary"
-        elevation="2"
-        @click.stop="() => { opened = true; dialog_opened_callback() }"
-      >
-        View Doppler Calculation
-      </v-btn>
-    </template>
     <v-card
         class="mx-auto"
     >
@@ -35,11 +22,14 @@
           <v-btn
               icon
               @click="() => { 
-                set_dialog(false); 
+                set_dialog(false);
+                if (step < length-1) 
+                  { 
+                    back_callback(); // if user closes dialog, this is equivalent to going back to dop_cal4
+                  }
                 if (step === length-1) 
                   { 
                     set_student_vel_calc(true);
-                    set_step(0);
                     next_callback();
                   }
               }"
@@ -810,10 +800,19 @@
 
       <v-card-actions>
         <v-btn
-            :disabled="step === 0"
             class="black--text"
             color="accent"
-            @click="set_step(step - 1)"
+            @click="() => { 
+                if (step === 0) 
+                  { 
+                    set_dialog(false);
+                    back_callback(); // If on first step, send back to dop_cal4
+                  }
+                else 
+                  { 
+                    set_step(step - 1)
+                  }
+              }"
         >
           Back
         </v-btn>
@@ -834,7 +833,7 @@
                 :disabled="n > max_step_completed_5 + 2"
                 :input-value="active"
                 icon
-                @click="toggle"
+                @click="toggle; set_step(n-1)"
             >
               <v-icon>mdi-record</v-icon>
             </v-btn>
@@ -875,14 +874,13 @@
             @click="() => {
               set_dialog(false);
               set_student_vel_calc(true);
-              set_step(0);
               next_callback();
             }"
         >
           Done
         </v-btn>
         <v-btn
-            class="black--text"
+            class="demo-button"
             color="error"
             depressed
             @click="() => {
@@ -890,7 +888,6 @@
               set_student_c(300000);
               storeStudentVel(300000, [lambda_obs, lambda_rest]);
               set_student_vel_calc(true);
-              set_step(0);
               next_callback();
             }"
         >

--- a/src/hubbleds/components/doppler_slideshow/doppler_slideshow.py
+++ b/src/hubbleds/components/doppler_slideshow/doppler_slideshow.py
@@ -26,6 +26,7 @@ def DopplerSlideshow(
     event_set_student_c,
     event_next_callback,
     event_mc_callback,
-    state_view
+    state_view,
+    show_button,
 ):
     pass

--- a/src/hubbleds/components/doppler_slideshow/doppler_slideshow.py
+++ b/src/hubbleds/components/doppler_slideshow/doppler_slideshow.py
@@ -24,9 +24,9 @@ def DopplerSlideshow(
     event_set_student_vel_calc,
     event_set_student_vel,
     event_set_student_c,
+    event_back_callback,
     event_next_callback,
     event_mc_callback,
     state_view,
-    show_button,
 ):
     pass

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -721,9 +721,15 @@ def Page():
             )
 
             # This whole slideshow is basically dop_cal5
-            if COMPONENT_STATE.value.current_step_between(
-                Marker.dop_cal4, Marker.che_mea1
-            ):
+            if (
+                (
+                    show_values.value and COMPONENT_STATE.value.current_step_between(
+                    Marker.dop_cal4, Marker.dop_cal5
+                ) 
+                or 
+                    COMPONENT_STATE.value.current_step_between(
+                    Marker.dop_cal4, Marker.che_mea1))
+                ):
                 show_doppler_dialog = Ref(COMPONENT_STATE.fields.show_doppler_dialog)
                 step = Ref(COMPONENT_STATE.fields.doppler_state.step)
                 validation_5_failed = Ref(
@@ -761,6 +767,7 @@ def Page():
                         add_example_measurements_to_glue()
 
                 DopplerSlideshow(
+                    show_button=show_values.value and COMPONENT_STATE.value.current_step_between(Marker.dop_cal4, Marker.dop_cal5),
                     dialog=COMPONENT_STATE.value.show_doppler_dialog,
                     titles=COMPONENT_STATE.value.doppler_state.titles,
                     step=COMPONENT_STATE.value.doppler_state.step,

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineDopplerCalc4.vue
@@ -9,10 +9,13 @@
       :can-advance="can_advance"
       @next="() =>
       {
-        if (state_view.fill_values) {
-          next_callback();
+        // If answers have already been entered, bypass the validator
+        if (state_view.fill_values) { 
+          on_validate_transition(true); // This automatically advances marker to dop_cal5 and opens the dialog
           return;
         }
+
+        // For first time through, don't allow advancing until answer has been validated
         const expectedAnswers = [state_view.lambda_obs, state_view.lambda_rest];
         const isValidated = !!validateAnswersJS(['lam_obs', 'lam_rest'], expectedAnswers);
         on_validate_transition(isValidated);
@@ -197,7 +200,6 @@ export default {
       return inputIDs.every((id, index) => {
         const value = this.parseAnswer(id);
         console.log(id, index, value, expectedAnswers[index], value && value === expectedAnswers[index]);
-        // this.failed_validation_4_callback((!(value && value === expectedAnswers[index])));
         return value && value === expectedAnswers[index];
       });
     }


### PR DESCRIPTION
This PR fixes #679 adds a button, only visible during dop_cal4, and dop_cal5, for displaying the doppler calculation slideshow. It is only visible if `show_dop_cal4_values` has been set to true. The interface currently looks like

<img width="368" alt="image" src="https://github.com/user-attachments/assets/85787210-1fe7-4ed2-87ee-e93f0e742382">
