### PR TITLE
Ignore current class data from all data

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -137,7 +137,7 @@ def Page():
             student_ids.set(ids)
         measurements.set(class_measurements)
 
-        all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(LOCAL_STATE)
+        all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(GLOBAL_STATE, LOCAL_STATE)
         all_meas = Ref(LOCAL_STATE.fields.all_measurements)
         all_stu_summaries = Ref(LOCAL_STATE.fields.student_summaries)
         all_cls_summaries = Ref(LOCAL_STATE.fields.class_summaries)

--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -9,7 +9,6 @@ from cosmicds.remote import BaseAPI
 from cosmicds.state import GlobalState, BaseState, GLOBAL_STATE
 from solara import Reactive
 from solara.toestand import Ref
-from functools import cached_property
 from cosmicds.logger import setup_logger
 from typing import List
 
@@ -328,9 +327,12 @@ class LocalAPI(BaseAPI):
 
     def get_all_data(
         self,
+        global_state: Reactive[GlobalState],
         local_state: Reactive[LocalState],
     ) -> tuple[list[StudentMeasurement], list[StudentSummary], list[ClassSummary]]:
         url = f"{self.API_URL}/{local_state.value.story_id}/all-data?minimal=True"
+        if global_state.value.classroom.class_info is not None:
+            url += f"&class_id={global_state.value.classroom.class_info['id']}"
         r = self.request_session.get(url)
         res_json = r.json()
 


### PR DESCRIPTION
This PR updates our "all data" request to pass in the current class ID so that we don't get data from the current class (and any merged with in). This is using the functionality introduced on the backend in https://github.com/cosmicds/cds-api/pull/160.