### PR TITLE
Add class info to all data

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -143,6 +143,8 @@ def Page():
             class_velocities = [velocity for m in class_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value is not None))]
             my_class_h0, my_class_age = create_single_summary(distances=class_distances, velocities=class_velocities)
             class_summaries.append(ClassSummary(class_id=GLOBAL_STATE.value.classroom.class_info["id"], hubble_fit_value=my_class_h0, age_value=my_class_age))
+            all_measurements.extend(class_measurements)
+
         all_meas = Ref(LOCAL_STATE.fields.all_measurements)
         all_stu_summaries = Ref(LOCAL_STATE.fields.student_summaries)
         all_cls_summaries = Ref(LOCAL_STATE.fields.class_summaries)

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -137,7 +137,7 @@ def Page():
             student_ids.set(ids)
         measurements.set(class_measurements)
 
-        all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(LOCAL_STATE)
+        all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(GLOBAL_STATE, LOCAL_STATE)
         all_meas = Ref(LOCAL_STATE.fields.all_measurements)
         all_stu_summaries = Ref(LOCAL_STATE.fields.student_summaries)
         all_cls_summaries = Ref(LOCAL_STATE.fields.class_summaries)

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -140,7 +140,7 @@ def Page():
         all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(GLOBAL_STATE, LOCAL_STATE)
         if GLOBAL_STATE.value.classroom.class_info is not None:
             class_distances = [distance for m in class_measurements if ((distance := m.est_dist_value) is not None and m.velocity_value is not None)]
-            class_velocities = [velocity for m in class_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value is not None))]
+            class_velocities = [velocity for m in class_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value) is not None)]
             my_class_h0, my_class_age = create_single_summary(distances=class_distances, velocities=class_velocities)
             class_summaries.append(ClassSummary(class_id=GLOBAL_STATE.value.classroom.class_info["id"], hubble_fit_value=my_class_h0, age_value=my_class_age))
             all_measurements.extend(class_measurements)

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -20,8 +20,8 @@ from cosmicds.viewers import CDSHistogramView
 from hubbleds.base_component_state import transition_next, transition_previous
 from hubbleds.components import UncertaintySlideshow, IdSlider
 from hubbleds.tools import *  # noqa
-from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, StudentMeasurement, get_free_response, get_multiple_choice, mc_callback, fr_callback
-from hubbleds.utils import make_summary_data, models_to_glue_data
+from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, ClassSummary, StudentMeasurement, get_free_response, get_multiple_choice, mc_callback, fr_callback
+from hubbleds.utils import age_in_gyr_simple, create_single_summary, make_summary_data, models_to_glue_data
 from hubbleds.viewers.hubble_histogram_viewer import HubbleHistogramView
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
@@ -138,6 +138,11 @@ def Page():
         measurements.set(class_measurements)
 
         all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(GLOBAL_STATE, LOCAL_STATE)
+        if GLOBAL_STATE.value.classroom.class_info is not None:
+            class_distances = [distance for m in class_measurements if ((distance := m.est_dist_value) is not None and m.velocity_value is not None)]
+            class_velocities = [velocity for m in class_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value is not None))]
+            my_class_h0, my_class_age = create_single_summary(distances=class_distances, velocities=class_velocities)
+            class_summaries.append(ClassSummary(class_id=GLOBAL_STATE.value.classroom.class_info["id"], hubble_fit_value=my_class_h0, age_value=my_class_age))
         all_meas = Ref(LOCAL_STATE.fields.all_measurements)
         all_stu_summaries = Ref(LOCAL_STATE.fields.student_summaries)
         all_cls_summaries = Ref(LOCAL_STATE.fields.class_summaries)

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -139,10 +139,13 @@ def Page():
 
         all_measurements, student_summaries, class_summaries = LOCAL_API.get_all_data(GLOBAL_STATE, LOCAL_STATE)
         if GLOBAL_STATE.value.classroom.class_info is not None:
+            class_id = GLOBAL_STATE.value.classroom.class_info["id"]
             class_distances = [distance for m in class_measurements if ((distance := m.est_dist_value) is not None and m.velocity_value is not None)]
             class_velocities = [velocity for m in class_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value) is not None)]
             my_class_h0, my_class_age = create_single_summary(distances=class_distances, velocities=class_velocities)
-            class_summaries.append(ClassSummary(class_id=GLOBAL_STATE.value.classroom.class_info["id"], hubble_fit_value=my_class_h0, age_value=my_class_age))
+            class_summaries.append(ClassSummary(class_id=class_id, hubble_fit_value=my_class_h0, age_value=my_class_age))
+            for measurement in class_measurements:
+                measurement.class_id = class_id
             all_measurements.extend(class_measurements)
 
         all_meas = Ref(LOCAL_STATE.fields.all_measurements)

--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -9,7 +9,6 @@ from cosmicds.remote import BaseAPI
 from cosmicds.state import GlobalState, BaseState, GLOBAL_STATE
 from solara import Reactive
 from solara.toestand import Ref
-from functools import cached_property
 from cosmicds.logger import setup_logger
 from typing import List
 
@@ -328,9 +327,12 @@ class LocalAPI(BaseAPI):
 
     def get_all_data(
         self,
+        global_state: Reactive[GlobalState],
         local_state: Reactive[LocalState],
     ) -> tuple[list[StudentMeasurement], list[StudentSummary], list[ClassSummary]]:
         url = f"{self.API_URL}/{local_state.value.story_id}/all-data?minimal=True"
+        if global_state.value.classroom.class_info is not None:
+            url += f"&class_id={global_state.value.classroom.class_info['id']}"
         r = self.request_session.get(url)
         res_json = r.json()
 


### PR DESCRIPTION
This PR adds the student's class info to the "all data" datasets:
* Calculate the age value from the class's measurements and add it to the "all class summaries" dataset
* Add all of the individual measurements from the class to the "all measurements" dataset

This builds off of #687 and addresses a couple of the points in #660.