### PR TITLE
Bump glue-plotly version to 0.10.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.10.0
+  - glue-plotly==0.10.1
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.9.0
+    glue-plotly[jupyter]>=0.10.1
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
This PR bumps our version of `glue-plotly` to the newly-released 0.10.1. The main change of interest there is https://github.com/glue-viz/glue-plotly/pull/103, which ensures that the selection layer always has the highest z-index whenever it's active. I'm hoping that this will help with https://github.com/cosmicds/hubbleds/issues/617, but it's hard to know for sure since it's not an easily reproducible error.