### PR TITLE
Remove FITS extension from galaxy name in table

### DIFF
--- a/src/hubbleds/components/data_table/DataTable.vue
+++ b/src/hubbleds/components/data_table/DataTable.vue
@@ -50,7 +50,11 @@
       </template>
 
       <template v-slot:item.name="{ item }">
-        {{ item.galaxy.name }}
+        {{
+          item.galaxy.name.endsWith(".fits") ?
+          item.galaxy.name.slice(0, -5) :
+          item.galaxy.name
+        }}
       </template>
 
       <template v-slot:item.element="{ item }">


### PR DESCRIPTION
This PR updates our data table template to remove the `.fits` extension from the galaxy name, which resolves #253.