### PR TITLE
Update stage 1 spectrum viewer and guidelines in demo branch

### DIFF
--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -185,20 +185,23 @@ def SpectrumViewer(
 
         fig.add_shape(
             editable=False,
-            x0=galaxy_data.redshift_rest_wave_value - 1.5,
-            x1=galaxy_data.redshift_rest_wave_value + 1.5,
+            type="line",
+            x0=galaxy_data.redshift_rest_wave_value,
+            x1=galaxy_data.redshift_rest_wave_value,
             y0=0.82,
-            y1=0.95,
-            # xref="x",
-            line_color="red",
-            fillcolor="red",
-            ysizemode="scaled",
+            y1=0.99,
             yref="paper",
+            # xref="x",
+            line=dict(
+                color="red",
+                width=4
+            ),
+            ysizemode="scaled",
         )
 
         fig.add_annotation(
-            x=galaxy_data.redshift_rest_wave_value + 8,
-            y= 0.95,
+            x=galaxy_data.redshift_rest_wave_value + 7,
+            y= 0.99,
             yref="paper",
             text=f"{galaxy_data.element} (observed)",
             showarrow=False,
@@ -223,13 +226,16 @@ def SpectrumViewer(
             line_color="black",
             ysizemode="scaled",
             yref="paper",
-            line=dict(dash="dot"),
+            line=dict(
+                dash="dot",
+                width=4
+            ),
             visible=1 in toggle_group_state.value,
         )
 
         fig.add_annotation(
-            x=galaxy_data.rest_wave_value - 8,
-            y= 0.95,
+            x=galaxy_data.rest_wave_value - 7,
+            y= 0.99,
             yref="paper",
             text=f"{galaxy_data.element} (rest)",
             showarrow=False,

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -185,17 +185,14 @@ def SpectrumViewer(
 
         fig.add_shape(
             editable=False,
-            type="line",
-            x0=galaxy_data.redshift_rest_wave_value,
-            x1=galaxy_data.redshift_rest_wave_value,
+            x0=galaxy_data.redshift_rest_wave_value - 1.5,
+            x1=galaxy_data.redshift_rest_wave_value + 1.5,
             y0=0.82,
             y1=0.99,
             yref="paper",
             # xref="x",
-            line=dict(
-                color="red",
-                width=4
-            ),
+            line_color="red",
+            fillcolor="red",
             ysizemode="scaled",
         )
 

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -78,7 +78,7 @@ def SpectrumViewer(
     def _spectrum_clicked(**kwargs):
         if spectrum_click_enabled:
             vertical_line_visible.set(True)
-            on_obs_wave_measured(round(kwargs["points"]["xs"][0]))
+            on_obs_wave_measured(kwargs["points"]["xs"][0])
 
     with rv.Card():
         with rv.Toolbar(class_="toolbar", dense=True):

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -136,10 +136,11 @@ def SpectrumViewer(
                     hover_data={"wave": True, "flux": False},
                     # line_shape="hvh", # step line plot
                     )
-        fig.update_traces(hovertemplate='Wavelength: %{x:0.1f} Å') #
+        fig.update_traces(hovertemplate='Wavelength: %{x:0.0f} Å') #
         fig.update_layout(
             hoverlabel=dict(
                 font_size=16,
+                bgcolor="white"
             ),
         )
 

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -184,21 +184,31 @@ def SpectrumViewer(
 
         fig.add_shape(
             editable=False,
-            x0=galaxy_data.redshift_rest_wave_value - 5,
-            x1=galaxy_data.redshift_rest_wave_value + 5,
-            y0=0.85,
-            y1=0.9,
-            xref="x",
+            x0=galaxy_data.redshift_rest_wave_value - 1.5,
+            x1=galaxy_data.redshift_rest_wave_value + 1.5,
+            y0=0.82,
+            y1=0.95,
+            # xref="x",
             line_color="red",
             fillcolor="red",
             ysizemode="scaled",
             yref="paper",
-            label={
-                "text": f"{galaxy_data.element} (observed)",
-                "textposition": "top center",
-                "yanchor": "bottom",
-            },
-            # visible=
+        )
+
+        fig.add_annotation(
+            x=galaxy_data.redshift_rest_wave_value + 8,
+            y= 0.95,
+            yref="paper",
+            text=f"{galaxy_data.element} (observed)",
+            showarrow=False,
+            font=dict(
+                family="Arial, sans-serif",
+                size=14,
+                color="red",
+                weight="bold"
+            ),
+            xanchor="left",
+            yanchor="top",
         )
 
         fig.add_shape(
@@ -213,11 +223,23 @@ def SpectrumViewer(
             ysizemode="scaled",
             yref="paper",
             line=dict(dash="dot"),
-            label={
-                "text": f"{galaxy_data.element} (rest)",
-                "textposition": "top center",
-                "yanchor": "bottom",
-            },
+            visible=1 in toggle_group_state.value,
+        )
+
+        fig.add_annotation(
+            x=galaxy_data.rest_wave_value - 8,
+            y= 0.95,
+            yref="paper",
+            text=f"{galaxy_data.element} (rest)",
+            showarrow=False,
+            font=dict(
+                family="Arial, sans-serif",
+                size=14,
+                color="black",
+                weight="bold"
+            ),
+            xanchor="right",
+            yanchor="top",
             visible=1 in toggle_group_state.value,
         )
 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -530,7 +530,7 @@ def Page():
                     [Marker.dop_cal4, Marker.dop_cal5]
                 ),
                 state_view={
-                    "lambda_obs": COMPONENT_STATE.value.obs_wave,
+                    "lambda_obs": round(COMPONENT_STATE.value.obs_wave),
                     "lambda_rest": (
                         selected_example_measurement.value.rest_wave_value
                         if selected_example_measurement.value is not None
@@ -804,7 +804,7 @@ def Page():
                     titles=COMPONENT_STATE.value.doppler_state.titles,
                     step=COMPONENT_STATE.value.doppler_state.step,
                     length=COMPONENT_STATE.value.doppler_state.length,
-                    lambda_obs=COMPONENT_STATE.value.obs_wave,
+                    lambda_obs=round(COMPONENT_STATE.value.obs_wave),
                     lambda_rest=(
                         selected_example_measurement.value.rest_wave_value
                         if selected_example_measurement.value is not None

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -1071,23 +1071,24 @@ def Page():
                                 example_measurement_index
                             ]
                         )
+
+                        obs_wave = Ref(COMPONENT_STATE.fields.obs_wave)
+                        obs_wave.set(value)
                         
                         if example_measurement.value.velocity_value is None:
                             example_measurement.set(
                                 example_measurement.value.model_copy(
-                                    update={"obs_wave_value": value}
+                                    update={"obs_wave_value": round(value)}
                                 )
                             )
                         else:
                             velocity = velocity_from_wavelengths(value, example_measurement.value.rest_wave_value)
                             example_measurement.set(
                                 example_measurement.value.model_copy(
-                                    update={"obs_wave_value": value, "velocity_value": velocity}
+                                    update={"obs_wave_value": round(value), "velocity_value": velocity}
                                 )
                             )
                         obs_wave_tool_used.set(True)
-                        obs_wave = Ref(COMPONENT_STATE.fields.obs_wave)
-                        obs_wave.set(value)
 
                     obs_wave_tool_used = Ref(COMPONENT_STATE.fields.obs_wave_tool_used)
                     obs_wave_tool_activated = Ref(
@@ -1144,6 +1145,10 @@ def Page():
                         num_bad_velocities()
 
                         if not is_bad:
+
+                            obs_wave = Ref(COMPONENT_STATE.fields.obs_wave)
+                            obs_wave.set(value)
+
                             measurement = Ref(
                                 LOCAL_STATE.fields.measurements[measurement_index]
                             )
@@ -1151,7 +1156,7 @@ def Page():
                             if measurement.value.velocity_value is None:
                                 measurement.set(
                                     measurement.value.model_copy(
-                                        update={"obs_wave_value": value}
+                                        update={"obs_wave_value": round(value)}
                                     )
                                 )
                                 
@@ -1159,12 +1164,9 @@ def Page():
                                 velocity = velocity_from_wavelengths(value, measurement.value.rest_wave_value)
                                 measurement.set(
                                     measurement.value.model_copy(
-                                        update={"obs_wave_value": value, "velocity_value": velocity}
+                                        update={"obs_wave_value": round(value), "velocity_value": velocity}
                                     )
                                 )
-
-                            obs_wave = Ref(COMPONENT_STATE.fields.obs_wave)
-                            obs_wave.set(value)
                             
                             set_obs_wave_total()
                             

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineRestwave.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineRestwave.vue
@@ -21,7 +21,7 @@
       <p
         v-if="!state_view.lambda_on"      
       >
-        The galaxy spectrum has {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'a' : 'an' }} {{ state_view.selected_example_galaxy.element }} {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'absorption' : 'emission' }} line marked by a red vertical rectangle on the graph.
+        The galaxy spectrum has {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'a' : 'an' }} {{ state_view.selected_example_galaxy.element }} {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'absorption' : 'emission' }} line marked by a red vertical line on the graph.
       </p>
       <p
         v-if="!state_view.lambda_used"


### PR DESCRIPTION
I made these commits on a branch that is based on `short-demo`, but we will want to bring them over to `main` too if they look right.

This
- improves the spectrum line annotations in the spectrum viewer to make them easier to see and read.
- rounds displayed measured wavelength values to integers
- uses the un-rounded value of the measured wavelength in plotly, so the measured line doesn't appear to jump to the wrong value when students zoom way in. (It still jumps a little bit because the only measurable wavelength values are the values given in the SDSS spectrum data file, but it's less noticeable when we graph unrounded values)