### PR TITLE
Use SDSS 12 in selection and distance tools

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -1,15 +1,10 @@
-from random import randint
 
 import solara
-from solara import Reactive
-from hubbleds.base_component_state import BaseComponentState
-from glue.core import Data
 from reacton import ipyvuetify as rv
 from hubbleds.state import LOCAL_STATE
 from hubbleds.widgets import SelectionToolWidget
 from typing import Callable
-from hubbleds.state import GalaxyData, StudentMeasurement
-from solara.lab import Ref
+from hubbleds.state import GalaxyData
 
 
 @solara.component
@@ -19,7 +14,6 @@ def SelectionTool(
     galaxy_added_callback: Callable,
     deselect_galaxy_callback: Callable,
     selected_measurement: dict | None,
-    dependencies: list = None,
 ):
     with rv.Card() as main:
         with rv.Card(class_="pa-0 ma-0", elevation=0):
@@ -62,9 +56,6 @@ def SelectionTool(
 
         def _update_selection():
             selection_tool_widget = solara.get_widget(tool_container).children[0]
-            selection_tool_widget.widget.foreground = "Black Sky Background"
-            selection_tool_widget.widget.background = "Black Sky Background"
-            selection_tool_widget.widget.background = "SDSS 12"
 
             # Update selection tool
             selection_tool_widget.show_galaxies(show_galaxies)

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -62,6 +62,9 @@ def SelectionTool(
 
         def _update_selection():
             selection_tool_widget = solara.get_widget(tool_container).children[0]
+            selection_tool_widget.widget.foreground = "Black Sky Background"
+            selection_tool_widget.widget.background = "Black Sky Background"
+            selection_tool_widget.widget.background = "SDSS 12"
 
             # Update selection tool
             selection_tool_widget.show_galaxies(show_galaxies)

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from threading import Timer
 
 import astropy.units as u
 import ipyvue as v
@@ -51,7 +52,8 @@ class DistanceTool(v.VueTemplate):
 
     def __init__(self, *args, **kwargs):
         self.widget = WWTWidget()
-        self._setup_widget()
+        timer = Timer(3.0, self._setup_widget)
+        timer.start()
         self.measuring = kwargs.get('measuring', False)
         self.guard = kwargs.get('guard', False)
         self.angular_size = Angle(0, u.deg)
@@ -70,8 +72,8 @@ class DistanceTool(v.VueTemplate):
 
     def _setup_widget(self):
         # Temp update to set background to SDSS. Once we remove galaxies without SDSS WWT tiles from the catalog, make background DSS again, and set wwt.foreground_opacity = 0, per Peter Williams.
-        self.widget.background = 'SDSS: Sloan Digital Sky Survey (Optical)'
-        self.widget.foreground = 'SDSS: Sloan Digital Sky Survey (Optical)'
+        self.widget.background = 'SDSS 12'
+        self.widget.foreground = 'SDSS 12'
         self.widget.center_on_coordinates(self.START_COORDINATES, fov= 42 * u.arcmin, #start in close enough to see galaxies
                                           instant=True)
 

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -35,8 +35,8 @@ class SelectionToolWidget(v.VueTemplate):
     def __init__(self, table_layer_data: dict, *args, **kwargs):
         # self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self.widget = WWTWidget()
-        self.widget.background = "SDSS: Sloan Digital Sky Survey (Optical)"
-        self.widget.foreground = "SDSS: Sloan Digital Sky Survey (Optical)"
+        self.widget.background = "SDSS 12"
+        self.widget.foreground = "SDSS 12"
         self.widget.center_on_coordinates(
             self.START_COORDINATES,
             fov=6 * u.arcmin,  # start in close enough to see galaxies

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -35,8 +35,8 @@ class SelectionToolWidget(v.VueTemplate):
     def __init__(self, table_layer_data: dict, *args, **kwargs):
         # self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self.widget = WWTWidget()
-        self.widget.background = "SDSS 12"
-        self.widget.foreground = "SDSS 12"
+        # self.widget.background = "SDSS 12"
+        # self.widget.foreground = "SDSS 12"
         self.widget.center_on_coordinates(
             self.START_COORDINATES,
             fov=6 * u.arcmin,  # start in close enough to see galaxies

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -37,18 +37,17 @@ class SelectionToolWidget(v.VueTemplate):
         # self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self.widget = WWTWidget()
         
-        def _initialize_imagesets():
+        def _setup():
             self.widget.background = "SDSS 12"
             self.widget.foreground = "SDSS 12"
+            self.widget.center_on_coordinates(
+                self.START_COORDINATES,
+                fov=6 * u.arcmin,  # start in close enough to see galaxies
+                instant=False,
+            )
 
-        timer = Timer(3.0, _initialize_imagesets)
+        timer = Timer(3.0, _setup)
         timer.start()
-
-        self.widget.center_on_coordinates(
-            self.START_COORDINATES,
-            fov=6 * u.arcmin,  # start in close enough to see galaxies
-            instant=False,
-        )
 
         # df = data.to_dataframe()
         self.sdss_table = Table(table_layer_data)

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -1,3 +1,4 @@
+from threading import Timer
 import astropy.units as u
 import ipyvue as v
 from astropy.coordinates import SkyCoord
@@ -35,8 +36,14 @@ class SelectionToolWidget(v.VueTemplate):
     def __init__(self, table_layer_data: dict, *args, **kwargs):
         # self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self.widget = WWTWidget()
-        # self.widget.background = "SDSS 12"
-        # self.widget.foreground = "SDSS 12"
+        
+        def _initialize_imagesets():
+            self.widget.background = "SDSS 12"
+            self.widget.foreground = "SDSS 12"
+
+        timer = Timer(3.0, _initialize_imagesets)
+        timer.start()
+
         self.widget.center_on_coordinates(
             self.START_COORDINATES,
             fov=6 * u.arcmin,  # start in close enough to see galaxies


### PR DESCRIPTION
This PR updates the selection and distance tools to use the SDSS 12 dataset (which is now grabbing its deeper tiles from SkyServer). This PR requires https://github.com/nmearl/ipywwt/pull/5 and so will require a local reinstall of `ipywwt`.

In order to get this to work properly I had to slightly delay the setup of the foreground/background imagesets. Without this, using the SDSS 12 imageset wasn't working for me, and from adding some logging into the WWT JS I could tell that the problem was that the foreground/background update requests were happening before our default surveys WTML had finished being processed. The approach here is to put those calls into a `Timer`. I'm not a huge fan of this, but with the way that things are set up now I'm not sure that there's another option.