### PR TITLE
Add quick skip buttons and explain what is being skipped in Demo Version

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -317,3 +317,9 @@ div.plotly .hoverlayer g.axistext {
     background-color: var(--success) !important;
     color: white !important;
 }
+
+/* Sidebar navigation active item */
+.v-list-item-group .v-list-item--active {
+    color: white;
+    background-color: var(--primary);
+}

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -307,3 +307,13 @@ div.plotly .hoverlayer g.axistext {
     font-weight: bold;
     padding-left: 0;
 }
+
+.theme--dark.demo-button {
+    background-color: var(--success) !important;
+    color: black !important;
+}
+
+.theme--light .demo-button {
+    background-color: var(--success) !important;
+    color: white !important;
+}

--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -319,7 +319,11 @@ div.plotly .hoverlayer g.axistext {
 }
 
 /* Sidebar navigation active item */
-.v-list-item-group .v-list-item--active {
+.v-list-item-group .v-list-item--active:not(.layer_toggle .v-list-item--active) {
     color: white;
     background-color: var(--primary);
+}
+
+.v-application .layer_toggle {
+    border-color: black !important;
 }

--- a/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
+++ b/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
@@ -934,8 +934,7 @@
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
         v-if="step < length-1"
-        color="success"
-        class="black--text"
+        class="demo-button"
         depressed
         @click="() => {
           slideshow_finished();
@@ -943,7 +942,7 @@
           // this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        jump to Stage 1
       </v-btn>
       <v-btn
         v-if="step >= length-1"

--- a/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
@@ -686,8 +686,7 @@
         </v-btn>
         <v-btn
           v-if="step < length-1"
-          color="success"
-          class="black--text"
+          class="demo-button"
           depressed
           @click="() => {
             $emit('close');

--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -832,8 +832,7 @@
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
         v-if="step < 12 && debug"
-        color="success"
-        class="black--text"
+        class="demo-button"
         depressed
         @click="() => {
           slideshow_finished();

--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -841,7 +841,7 @@
           //this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        Jump to Stage 3
       </v-btn>
       
       <v-btn
@@ -856,7 +856,7 @@
           //this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        Stage 3
       </v-btn>
     </v-card-actions>
   </v-card>

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -395,6 +395,20 @@
           {{ step < length-1 ? 'next' : '' }}
         </v-btn>
         <v-btn
+          v-if="step < length-1"
+          class="demo-button"
+          depressed
+          @click="() => {
+            $emit('close');
+            dialog = false;
+            step = 0;
+            on_slideshow_finished();
+            // this.$refs.synth.stopSpeaking();
+          }"
+        >
+          move on
+        </v-btn>        
+        <v-btn
           v-if = "step == length-1"
           color="accent"
           class="black--text"

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -335,7 +335,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
+            solara.Button(label="Demo Shortcut: Fill in galaxy velocity data & Jump to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
 
     with rv.Row():
         with rv.Col(cols=4):
@@ -390,7 +390,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.sel_gal3):
-                solara.Button(label="Demo Shortcut: Use 5 random galaxies", on_click=_fill_galaxies)
+                solara.Button(label="Demo Shortcut: Use 5 random galaxies", on_click=_fill_galaxies, classes=["demo-button"])
 
         with rv.Col(cols=8):
             

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -599,7 +599,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-                solara.Button(label="Demo Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
+                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none")
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -335,7 +335,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
+            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
 
     with rv.Row():
         with rv.Col(cols=4):
@@ -390,7 +390,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.sel_gal3):
-                solara.Button(label="Shortcut: Use 5 random galaxies", on_click=_fill_galaxies)
+                solara.Button(label="Demo Shortcut: Use 5 random galaxies", on_click=_fill_galaxies)
 
         with rv.Col(cols=8):
             
@@ -591,7 +591,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-                solara.Button(label="Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
+                solara.Button(label="Demo Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -233,7 +233,7 @@ def Page():
                                                    galaxy=measurement.galaxy))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
 
-    def _fill_stage1_go_stage3():
+    def _fill_stage1_go_stage2():
         dummy_measurements = LOCAL_API.get_dummy_data()
         measurements = []
         for measurement in dummy_measurements:
@@ -242,7 +242,7 @@ def Page():
                                                    galaxy=measurement.galaxy,
                                                    velocity_value=measurement.velocity_value))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
-        router.push("03-distance-measurements")
+        router.push("02-distance-introduction")
 
 
     def _select_random_galaxies():
@@ -335,7 +335,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
+            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2)
 
     with rv.Row():
         with rv.Col(cols=4):
@@ -619,7 +619,7 @@ def Page():
             # )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineEndStage1.vue",
-                event_next_callback=lambda _: router.push("03-distance-measurements"),
+                event_next_callback=lambda _: router.push("02-distance-introduction"),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.end_sta1),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -456,7 +456,7 @@ def Page():
                 print("is galaxy selected:", galaxy_is_selected.value)             
 
             show_example_data_table = COMPONENT_STATE.value.current_step_between(
-            Marker.cho_row1, Marker.dop_cal5
+            Marker.cho_row1, Marker.exp_ski1
             )
             if show_example_data_table:
                 selection_tool_galaxy = selected_example_measurement
@@ -573,6 +573,14 @@ def Page():
             # )
             set_obs_wave_total()
             ScaffoldAlert(
+                GUIDELINE_ROOT / "GuidelineExplainSkip.vue",
+                event_next_callback=lambda _: transition_next(COMPONENT_STATE),
+                event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
+                can_advance=COMPONENT_STATE.value.can_transition(next=True),
+                show=COMPONENT_STATE.value.is_current_step(Marker.exp_ski1),
+                speech=speech.value,
+            )
+            ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineRemainingGals.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
@@ -624,7 +632,7 @@ def Page():
 
         with rv.Col(cols=8):
             show_example_data_table = COMPONENT_STATE.value.current_step_between(
-                Marker.cho_row1, Marker.dop_cal5 # TODO: change this back to dot_seq14 if we put back 2nd galaxy measurement
+                Marker.cho_row1, Marker.exp_ski1 # TODO: change this back to dot_seq14 if we put back 2nd galaxy measurement
             )
 
             if show_example_data_table:
@@ -1047,7 +1055,7 @@ def Page():
 
         with rv.Col(cols=8):
             show_example_spectrum = COMPONENT_STATE.value.current_step_between(
-                Marker.mee_spe1, Marker.dop_cal5
+                Marker.mee_spe1, Marker.exp_ski1
             )
 
             show_galaxy_spectrum = COMPONENT_STATE.value.current_step_at_or_after(

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -335,7 +335,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2)
+            solara.Button(label="Demo Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
 
     with rv.Row():
         with rv.Col(cols=4):
@@ -599,7 +599,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none")
+                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none;", classes=["demo-button"])
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -56,6 +56,7 @@ class Marker(enum.Enum, BaseMarker):
     # dot_seq13 = enum.auto()
     # dot_seq13a = enum.auto()
     # dot_seq14 = enum.auto()
+    exp_ski1 = enum.auto()
     rem_gal1 = enum.auto()
 
     # skip for short demo

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineExplainSkip.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineExplainSkip.vue
@@ -1,0 +1,24 @@
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Skipped Content"
+    @back="back_callback()"
+    @next="next_callback()"
+    :can-advance="can_advance"
+    :speech="speech"
+  >
+    <div
+      class="mb-4"
+    >
+      <p>
+        Notice your calculated velocity is now in the table.
+      </p>
+      <p>
+        <span style="font-weight:bold">SKIPPED CONTENT:</span> Shortened DEMO version skips a sequence where students compare their velocity measurement with that of their peers using a dot plot, to help them evaluate whether they have accurately measured the observed wavelength of the example galaxy.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -212,7 +212,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
+            solara.Button(label="Demo Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 
@@ -543,7 +543,7 @@ def Page():
                 }
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-                solara.Button(label="Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
+                solara.Button(label="Demo Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -212,7 +212,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
+            solara.Button(label="Demo Shortcut: Fill in distance data & Jump to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -212,7 +212,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
+            solara.Button(label="Demo Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 
@@ -550,7 +550,7 @@ def Page():
                 }
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none")
+                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none", classes=["demo-button"])
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),
@@ -584,7 +584,7 @@ def Page():
                     distances_total.set(count)
 
                 if (COMPONENT_STATE.value.current_step_at_or_after(Marker.fil_rem1) and GLOBAL_STATE.value.show_team_interface):
-                    solara.Button("Fill Galaxy Distances", on_click=lambda: fill_galaxy_distances())
+                    solara.Button("Demo Shortcut: Fill Galaxy Distances", on_click=lambda: fill_galaxy_distances() , classes=["demo-button"])
 
 
                 common_headers = [

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -550,7 +550,7 @@ def Page():
                 }
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-                solara.Button(label="Demo Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
+                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none")
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -511,6 +511,13 @@ def Page():
                     "meas_theta": COMPONENT_STATE.value.meas_theta,
                 },
             )
+            ScaffoldAlert(
+                GUIDELINE_ROOT / "GuidelineExplainSkip.vue",
+                event_next_callback=lambda _: transition_next(COMPONENT_STATE),
+                event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
+                can_advance=COMPONENT_STATE.value.can_transition(next=True),
+                show=COMPONENT_STATE.value.is_current_step(Marker.exp_ski1),
+            )
             # Not doing the 2nd measurement
             # ScaffoldAlert(
             #     # TODO This will need to be wired up once table is implemented
@@ -591,7 +598,7 @@ def Page():
                     { "text": "Distance (Mpc)", "value": "est_dist_value" },
                 ]
 
-            if COMPONENT_STATE.value.current_step_at_or_before(Marker.est_dis4):
+            if COMPONENT_STATE.value.current_step_at_or_before(Marker.exp_ski1):
                 def update_example_galaxy(galaxy):
                     flag = galaxy.get("value", True)
                     value = galaxy["item"]["galaxy"] if flag else None

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -43,6 +43,7 @@ class Marker(enum.Enum, BaseMarker):
     # dot_seq6  = enum.auto()	# MC ang_meas_consensus_2
     # dot_seq7 = enum.auto()
 
+    exp_ski1 = enum.auto()
     rep_rem1 = enum.auto()
     fil_rem1 = enum.auto()
     end_sta3 = enum.auto() #This guideline doesn't actually exist - just including it to allow an exit gate on the previous guideline.

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineExplainSkip.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineExplainSkip.vue
@@ -1,0 +1,27 @@
+<template>
+  <scaffold-alert
+    color="info"
+    class="mb-4 mx-auto"
+    max-width="800"
+    elevation="6"
+    title-text="Skipped Content"
+    @back="back_callback()"
+    @next="next_callback()"
+    :can-advance="can_advance"
+    :speech="speech"
+  >
+    <div
+      class="mb-4"
+    >
+      <p>
+        Notice your calculated distance is now in the table.
+      </p>
+      <p>
+        <span style="font-weight:bold">SKIPPED CONTENT:</span> Shortened DEMO version skips a sequence where students compare their distance measurement with that of their peers using a dot plot, to help them evaluate whether they have accurately measured the angular size of the example galaxy.
+      </p>
+      <p>
+        An angular size "Do's and Don'ts Slideshow" provides additional guidance.
+      </p>
+    </div>
+  </scaffold-alert>
+</template>

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -151,11 +151,14 @@ def Page():
     if load_class_data.value:
         _on_class_data_loaded(load_class_data.value)
 
+    def _jump_stage5():
+        router.push("05-class-results-uncertainty")
+
     with solara.Row():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Jump to Stage 5", on_click=router.push("05-class-results-uncertainty"), classes=["demo-button"])
+            solara.Button(label="Demo Shortcut: Jump to Stage 5", on_click=_jump_stage5, classes=["demo-button"])
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -151,7 +151,11 @@ def Page():
     if load_class_data.value:
         _on_class_data_loaded(load_class_data.value)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+    with solara.Row():
+        with solara.Column():
+            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+        with solara.Column():
+            solara.Button(label="Demo Shortcut: Jump to Stage 5", on_click=router.push("05-class-results-uncertainty"), classes=["demo-button"])
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -311,11 +311,14 @@ def Page():
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
+    def _jump_stage_6():
+        router.push("06-prodata")
+
     with solara.Row():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=router.push("06-prodata"), classes=["demo-button"])
+            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=_jump_stage_6, classes=["demo-button"])
 
     def _on_component_state_loaded(value: bool):
         if not value:

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -311,7 +311,11 @@ def Page():
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+    with solara.Row():
+        with solara.Column():
+            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+        with solara.Column():
+            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=router.push("06-prodata"), classes=["demo-button"])
 
     def _on_component_state_loaded(value: bool):
         if not value:


### PR DESCRIPTION
This will close #690.

This PR does not allow user to skip ahead using left navigation buttons, but there are clear "jump ahead" buttons that will quickly take you to the next stage.

I've added guidelines explaining what is being skipped in Stages 1 & 3.

I've styled the sidebar so the selected stage is more readable.