### PR TITLE
add missing class to layer toggle

### DIFF
--- a/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
+++ b/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
@@ -4,6 +4,7 @@
     light
     variant="outlined"
     color="white"
+    class="layer_toggle"
   >
     <v-list-item-group
       multiple


### PR DESCRIPTION
This fixes a tiny styling error from #695. For some reason, on the demo branch, this component automatically has the class "layer_toggle" applied (even though it is not explicitly set anywhere). The class was not applied to the same component on main, so the wrong styling was applied to the layer toggle.