### PR TITLE
Spectrum toolbar updates

### DIFF
--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -128,6 +128,13 @@ def SpectrumViewer(
 
             rv.Spacer()
 
+            solara.IconButton(
+                flat=True,
+                tile=True,
+                icon_name="mdi-cached",
+                on_click=_on_reset_button_clicked,
+            )
+
             with rv.BtnToggle(
                 v_model=toggle_group_state.value,
                 on_v_model=toggle_group_state.set,
@@ -146,15 +153,6 @@ def SpectrumViewer(
                     icon_name="mdi-lambda",
                     on_click=_rest_wave_tool_toggled,
                 )
-
-            rv.Divider(vertical=True)
-
-            solara.IconButton(
-                flat=True,
-                tile=True,
-                icon_name="mdi-cached",
-                on_click=_on_reset_button_clicked,
-            )
 
         if spec_data_task.value is None:
             with rv.Sheet(

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -22,6 +22,7 @@ def SpectrumViewer(
     on_obs_wave_measured: Callable = None,
     on_rest_wave_tool_clicked: Callable = lambda: None,
     on_zoom_tool_clicked: Callable = lambda: None,
+    on_zoom_tool_toggled: Callable = lambda: None,
     marker_position: Optional[solara.Reactive[float]] = None,
     on_set_marker_position: Callable = lambda x: None,
     spectrum_bounds: Optional[solara.Reactive[list[float]]] = None,
@@ -119,7 +120,10 @@ def SpectrumViewer(
             value = kwargs["points"]["xs"][0]
             marker_position.set(value)
             on_set_marker_position(value)
-            
+
+    def _zoom_button_clicked():
+        on_zoom_tool_clicked()
+        on_zoom_tool_toggled()  
 
     with rv.Card():
         with rv.Toolbar(class_="toolbar", dense=True):
@@ -146,7 +150,7 @@ def SpectrumViewer(
 
                 solara.IconButton(
                     icon_name="mdi-select-search",
-                    on_click=on_zoom_tool_clicked,
+                    on_click=_zoom_button_clicked,
                 )
 
                 solara.IconButton(

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -20,7 +20,7 @@ def SpectrumViewer(
     spectrum_click_enabled: bool = False,
     show_obs_wave_line: bool = True,
     on_obs_wave_measured: Callable = None,
-    on_obs_wave_tool_clicked: Callable = lambda: None,
+    on_rest_wave_tool_clicked: Callable = lambda: None,
     on_zoom_tool_clicked: Callable = lambda: None,
     marker_position: Optional[solara.Reactive[float]] = None,
     on_set_marker_position: Callable = lambda x: None,
@@ -61,8 +61,8 @@ def SpectrumViewer(
             max_spectrum_bounds.set([spec["wave"].min(), spec["wave"].max()])
     
 
-    def _obs_wave_tool_toggled():
-        on_obs_wave_tool_clicked()
+    def _rest_wave_tool_toggled():
+        on_rest_wave_tool_clicked()
 
 
 
@@ -144,7 +144,7 @@ def SpectrumViewer(
 
                 solara.IconButton(
                     icon_name="mdi-lambda",
-                    on_click=_obs_wave_tool_toggled,
+                    on_click=_rest_wave_tool_toggled,
                 )
 
             rv.Divider(vertical=True)

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -372,6 +372,7 @@ def SpectrumViewer(
             dependencies=dependencies,
             config={
                 "displayModeBar": False,
+                "showTips": False 
             },
         )
 

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -23,6 +23,8 @@ def SpectrumViewer(
     on_rest_wave_tool_clicked: Callable = lambda: None,
     on_zoom_tool_clicked: Callable = lambda: None,
     on_zoom_tool_toggled: Callable = lambda: None,
+    on_zoom: Callable = lambda: None,
+    on_reset_tool_clicked: Callable = lambda: None,
     marker_position: Optional[solara.Reactive[float]] = None,
     on_set_marker_position: Callable = lambda x: None,
     spectrum_bounds: Optional[solara.Reactive[list[float]]] = None,
@@ -88,7 +90,7 @@ def SpectrumViewer(
         except:
             x_bounds.set([])
             y_bounds.set([])
-        
+
         if "relayout_data" in event:
             if "xaxis.range[0]" in event["relayout_data"] and "xaxis.range[1]" in event["relayout_data"]:
                 if spectrum_bounds is not None:
@@ -96,6 +98,7 @@ def SpectrumViewer(
                         event["relayout_data"]["xaxis.range[0]"],
                         event["relayout_data"]["xaxis.range[1]"],
                     ])
+                on_zoom()
 
     def _on_reset_button_clicked(*args, **kwargs):
         x_bounds.set([])
@@ -108,6 +111,8 @@ def SpectrumViewer(
                 ])
         except Exception as e:
             print(e)
+
+        on_reset_tool_clicked()
     
     solara.use_effect(_on_reset_button_clicked, dependencies=[galaxy_data])
 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -1211,7 +1211,8 @@ def Page():
                     show=COMPONENT_STATE.value.is_current_step(Marker.obs_wav2),
                     state_view={
                         "selected_example_galaxy": selected_example_galaxy_data,
-                        "zoom_tool_activate": COMPONENT_STATE.value.zoom_tool_activated,
+                        "zoom_tool_activated": COMPONENT_STATE.value.zoom_tool_activated,
+                        "zoom_tool_active": COMPONENT_STATE.value.zoom_tool_active,
                     },
                     speech=speech.value,
                 )
@@ -1345,6 +1346,9 @@ def Page():
                     zoom_tool_activated = Ref(
                         COMPONENT_STATE.fields.zoom_tool_activated
                     )
+                    zoom_tool_active = Ref(
+                        COMPONENT_STATE.fields.zoom_tool_active
+                    )
                     
                     @computed
                     def obs_wav_marker_value():
@@ -1376,6 +1380,7 @@ def Page():
                             True
                         ),
                         on_zoom_tool_clicked=lambda: zoom_tool_activated.set(True),
+                        on_zoom_tool_toggled=lambda: zoom_tool_active.set(not COMPONENT_STATE.value.zoom_tool_active),
                         marker_position=sync_wavelength_line if show_synced_lines.value else None,
                         spectrum_bounds = spectrum_bounds, # type: ignore
                         max_spectrum_bounds=max_spectrum_bounds,

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -1190,8 +1190,7 @@ def Page():
                     show=COMPONENT_STATE.value.is_current_step(Marker.res_wav1),
                     state_view={
                         "selected_example_galaxy": selected_example_galaxy_data,
-                        "lambda_on": COMPONENT_STATE.value.obs_wave_tool_activated,
-                        "lambda_used": COMPONENT_STATE.value.obs_wave_tool_used,
+                        "lambda_on": COMPONENT_STATE.value.rest_wave_tool_activated,
                     },
                     speech=speech.value,
                 )
@@ -1340,8 +1339,8 @@ def Page():
                             sync_velocity_line.set(velocity)
 
                     obs_wave_tool_used = Ref(COMPONENT_STATE.fields.obs_wave_tool_used)
-                    obs_wave_tool_activated = Ref(
-                        COMPONENT_STATE.fields.obs_wave_tool_activated
+                    rest_wave_tool_activated = Ref(
+                        COMPONENT_STATE.fields.rest_wave_tool_activated
                     )
                     zoom_tool_activated = Ref(
                         COMPONENT_STATE.fields.zoom_tool_activated
@@ -1373,7 +1372,7 @@ def Page():
                         or COMPONENT_STATE.value.current_step == Marker.rem_vel1
                         ),
                         on_obs_wave_measured=_example_wavelength_measured_callback,
-                        on_obs_wave_tool_clicked=lambda: obs_wave_tool_activated.set(
+                        on_rest_wave_tool_clicked=lambda: rest_wave_tool_activated.set(
                             True
                         ),
                         on_zoom_tool_clicked=lambda: zoom_tool_activated.set(True),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -1361,6 +1361,13 @@ def Page():
                                 return meas[0].obs_wave_value
                         return COMPONENT_STATE.value.obs_wave
 
+
+                    def _on_zoom():
+                        zoom_tool_activated.set(True)
+                        zoom_tool_active.set(True)
+
+                    def _on_reset():
+                        zoom_tool_active.set(False)
                     
                     SpectrumViewer(
                         galaxy_data=(
@@ -1379,8 +1386,8 @@ def Page():
                         on_rest_wave_tool_clicked=lambda: rest_wave_tool_activated.set(
                             True
                         ),
-                        on_zoom_tool_clicked=lambda: zoom_tool_activated.set(True),
-                        on_zoom_tool_toggled=lambda: zoom_tool_active.set(not COMPONENT_STATE.value.zoom_tool_active),
+                        on_zoom=_on_zoom,
+                        on_reset_tool_clicked=_on_reset,
                         marker_position=sync_wavelength_line if show_synced_lines.value else None,
                         spectrum_bounds = spectrum_bounds, # type: ignore
                         max_spectrum_bounds=max_spectrum_bounds,

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -95,7 +95,7 @@ class ComponentState(BaseComponentState, BaseState):
     selected_example_galaxy: int = 0
     total_galaxies: int = 0
     spectrum_tutorial_opened: bool = False
-    obs_wave_tool_activated: bool = False
+    rest_wave_tool_activated: bool = False
     obs_wave_tool_used: bool = False
     spectrum_clicked: bool = False
     zoom_tool_activated: bool = False
@@ -159,7 +159,7 @@ class ComponentState(BaseComponentState, BaseState):
 
     @property
     def obs_wav1_gate(self) -> bool:
-        return self.obs_wave_tool_activated
+        return self.rest_wave_tool_activated
 
     @property
     def obs_wav2_gate(self) -> bool:

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -98,7 +98,8 @@ class ComponentState(BaseComponentState, BaseState):
     rest_wave_tool_activated: bool = False
     obs_wave_tool_used: bool = False
     spectrum_clicked: bool = False
-    zoom_tool_activated: bool = False
+    zoom_tool_activated: bool = False # has it ever been used?
+    zoom_tool_active: bool = False # is it currently on?
     doppler_calc_reached: bool = False
     obs_wave: float = 0
     show_doppler_dialog: bool = False

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineObswave2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineObswave2.vue
@@ -18,12 +18,12 @@
       class="mb-4"
     >
       <p
-        v-if=!state_view.zoom_tool_activated>  
+        v-if=!state_view.zoom_tool_active>  
         To improve the precision in your measurement, zoom in to the wavelength range around the {{ state_view.selected_example_galaxy.element }} line using the <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-select-search</v-icon></v-btn>  icon in the toolbar.
       </p>
       <p
-        v-if=state_view.zoom_tool_activated>  
-        If you accidentally zoom in too far or in the wrong spot, you can click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-cached</v-icon></v-btn> to reset the view to the full range of wavelengths.
+        v-if=state_view.zoom_tool_active>  
+        Click <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #0277BD; border-radius: 5px;"><v-icon style="color:white!important;">mdi-cached</v-icon></v-btn> to reset the view to the full range of wavelengths.
       </p>
       <p>
         <b>Tip:</b> You can re-measure the wavelength as many times as you like. 

--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineRestwave.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineRestwave.vue
@@ -24,7 +24,7 @@
         The galaxy spectrum has {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'a' : 'an' }} {{ state_view.selected_example_galaxy.element }} {{ state_view.selected_example_galaxy.element == 'Mg-I' ? 'absorption' : 'emission' }} line marked by a red vertical line on the graph.
       </p>
       <p
-        v-if="!state_view.lambda_used"
+        v-if="!state_view.lambda_on"
       >
         The known <b>rest wavelength</b> (&lambda;<sub>rest</sub>) for the line is recorded in your table.
       </p>


### PR DESCRIPTION
This updates the spectrum tools but is currently marked as a draft because there are deeper plotly connections needed that I don't know how to wire up, so I am passing this to @Carifio24.

What this does/intends:
- Put toolbar buttons into order they are used, from right to left.
- Distinguish in state between whether the zoom tool has ever been used (which opens the gate to the guideline after `obs_wav2`) or whether the zoom tool is currently active (which updates the text on the guideline).
- Instead of briefly displaying default plotly snackbar explaining how to unzoom, explain to user how to unzoom using our reset button. (This is the thing we are getting rid of:
<img width="269" alt="Screenshot 2024-12-12 at 7 39 34 PM" src="https://github.com/user-attachments/assets/672fb8bb-13a8-4df0-8bb7-bfb7bc037012" />)

Currently, my state variable are wired up to the toggle state of the zoom button itself, which is not actually connected to whether the user has used the zoom in feature. Per our conversation, Jon will see if it can be wired up correctly.
