### PR TITLE
Cherry pick convenience buttons to main

### DIFF
--- a/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
+++ b/src/hubbleds/components/intro_slideshow_vue/IntroSlideshow.vue
@@ -933,9 +933,8 @@
       </v-btn>
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
-        v-if="step < length-1 && debug"
-        color="success"
-        class="black--text"
+        v-if="step < length-1"
+        class="demo-button"
         depressed
         @click="() => {
           slideshow_finished();
@@ -943,7 +942,7 @@
           // this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        jump to Stage 1
       </v-btn>
       <v-btn
         v-if="step >= length-1"

--- a/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
+++ b/src/hubbleds/components/reflect_velocity_slideshow/ReflectVelocitySlideshow.vue
@@ -408,6 +408,19 @@
           Next
         </v-btn>
         <v-btn
+          v-if="step < length-1"
+          class="demo-button"
+          depressed
+          @click="() => {
+            set_dialog(false);
+            on_reflection_complete();
+            set_step(0); 
+            // this.$refs.synth.stopSpeaking();
+          }"
+        >
+          move on
+        </v-btn>    
+        <v-btn
           v-if="step === length-1"
           color="accent"
           class="black--text"

--- a/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
+++ b/src/hubbleds/components/spectrum_slideshow/SpectrumSlideshow.vue
@@ -683,7 +683,20 @@
           next
         </v-btn>
         <v-btn
-          v-if="step === length-1"
+          v-if="step < length-1"
+          class="demo-button"
+          depressed
+          @click="() => {
+            $emit('close');
+            dialog = false;
+            step = 0;
+            // this.$refs.synth.stopSpeaking();
+          }"
+        >
+          move on
+        </v-btn>
+        <v-btn
+          v-if="step >= 10"
           color="accent"
           class="black--text"
           depressed

--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -832,8 +832,7 @@
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
         v-if="step < 12 && debug"
-        color="success"
-        class="black--text"
+        class="demo-button"
         depressed
         @click="() => {
           slideshow_finished();

--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -841,7 +841,7 @@
           //this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        Jump to Stage 3
       </v-btn>
       
       <v-btn
@@ -856,7 +856,7 @@
           //this.$refs.synth.stopSpeaking();
         }"
       >
-        get started
+        Stage 3
       </v-btn>
     </v-card-actions>
   </v-card>

--- a/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
+++ b/src/hubbleds/components/uncertainty_slideshow/UncertaintySlideshow.vue
@@ -399,6 +399,20 @@
           {{ step < length-1 ? 'next' : '' }}
         </v-btn>
         <v-btn
+          v-if="step < length-1"
+          class="demo-button"
+          depressed
+          @click="() => {
+            $emit('close');
+            dialog = false;
+            step = 0;
+            on_slideshow_finished();
+            // this.$refs.synth.stopSpeaking();
+          }"
+        >
+          move on
+        </v-btn>        
+        <v-btn
           v-if = "step == length-1"
           color="accent"
           class="black--text"

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -508,7 +508,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2)
+            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
 
     with rv.Row():
         with rv.Col(cols=12, lg=4):
@@ -825,7 +825,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none")
+                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none;", classes=["demo-button"])
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -258,7 +258,7 @@ def Page():
                                                    galaxy=measurement.galaxy))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
 
-    def _fill_stage1_go_stage3():
+    def _fill_stage1_go_stage2():
         dummy_measurements = LOCAL_API.get_dummy_data()
         measurements = []
         for measurement in dummy_measurements:
@@ -267,7 +267,7 @@ def Page():
                                                    galaxy=measurement.galaxy,
                                                    velocity_value=measurement.velocity_value))
         Ref(LOCAL_STATE.fields.measurements).set(measurements)
-        router.push("03-distance-measurements")
+        router.push("02-distance-introduction")
 
     def _select_random_galaxies():
         need = 5 - len(LOCAL_STATE.value.measurements)
@@ -508,10 +508,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
-            solara.Button(label="Choose 5 random galaxies", on_click=_select_random_galaxies)
-
-    # WWT Selection Tool Row
+            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2)
 
     with rv.Row():
         with rv.Col(cols=12, lg=4):

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -828,7 +828,7 @@ def Page():
                 speech=speech.value,
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-                solara.Button(label="Demo Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
+                solara.Button(label="DEMO SHORTCUT: FILL λ MEASUREMENTS", on_click=_fill_lambdas, style="text-transform: none")
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -508,7 +508,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Fill default vel & dist measurements", on_click=_fill_galaxies)
+            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 3", on_click=_fill_stage1_go_stage3)
             solara.Button(label="Choose 5 random galaxies", on_click=_select_random_galaxies)
 
     # WWT Selection Tool Row
@@ -827,8 +827,8 @@ def Page():
                 },
                 speech=speech.value,
             )
-            # if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
-            #     solara.Button(label="Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
+            if COMPONENT_STATE.value.is_current_step(Marker.rem_gal1):
+                solara.Button(label="Demo Shortcut: Fill Wavelength Measurements", on_click=_fill_lambdas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineDopplerCalc6.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -509,6 +509,7 @@ def Page():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
             solara.Button(label="Shortcut: Fill in galaxy velocity data & Jump to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
+            solara.Button(label="Choose 5 random galaxies", on_click=_select_random_galaxies, classes=["demo-button"])
 
     with rv.Row():
         with rv.Col(cols=12, lg=4):

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -508,7 +508,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in galaxy/velocity data & Go to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
+            solara.Button(label="Shortcut: Fill in galaxy velocity data & Jump to Stage 2", on_click=_fill_stage1_go_stage2, classes=["demo-button"])
 
     with rv.Row():
         with rv.Col(cols=12, lg=4):

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -324,7 +324,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
+            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 
@@ -729,7 +729,7 @@ def Page():
                 }
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none")
+                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none", classes=["demo-button"])
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),
@@ -764,7 +764,7 @@ def Page():
                     fill_galaxy_pressed.set(True)
 
                 if (COMPONENT_STATE.value.current_step_at_or_after(Marker.fil_rem1) and GLOBAL_STATE.value.show_team_interface):
-                    solara.Button("Fill Galaxy Distances", on_click=lambda: fill_galaxy_distances())
+                    solara.Button("Demo Shortcut: Fill Galaxy Distances", on_click=lambda: fill_galaxy_distances() , classes=["demo-button"])
 
 
                 common_headers = [

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -323,8 +323,8 @@ def Page():
     with solara.Row():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
-        # with solara.Column():
-        #     solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
+        with solara.Column():
+            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points)
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 
@@ -728,8 +728,8 @@ def Page():
                     "bad_angsize": False
                 }
             )
-            # if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-            #     solara.Button(label="Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
+            if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
+                solara.Button(label="Demo Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -324,7 +324,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
-            solara.Button(label="Shortcut: Fill in distance data & Go to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
+            solara.Button(label="Shortcut: Fill in distance data & Jump to Stage 4", on_click=_fill_data_points, classes=["demo-button"])
     # StateEditor(Marker, cast(solara.Reactive[BaseState],COMPONENT_STATE), LOCAL_STATE, LOCAL_API, show_all=False)
     
 

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -729,7 +729,7 @@ def Page():
                 }
             )
             if COMPONENT_STATE.value.is_current_step(Marker.rep_rem1):
-                solara.Button(label="Demo Shortcut: Fill Angular Size Measurements", on_click=_fill_thetas)
+                solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none")
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
                 event_next_callback=lambda _: router.push("04-explore-data"),

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -118,7 +118,7 @@ def Page():
 
     gjapp, viewers = solara.use_memo(glue_setup, dependencies=[])
 
-    if not (load_class_data.value or load_class_data.pending):
+    if not (load_class_data.finished or load_class_data.pending):
         load_class_data()
 
     def _on_class_data_loaded(class_data_points: List[StudentMeasurement]):
@@ -148,7 +148,7 @@ def Page():
 
         class_plot_data.set(class_data_points)
 
-    if load_class_data.value:
+    if load_class_data.finished:
         _on_class_data_loaded(load_class_data.value)
 
     def _jump_stage_5():
@@ -158,7 +158,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Jump to Stage 5", on_click=_jump_stage_5, classes=["demo-button"])
+            solara.Button(label="Shortcut: Jump to Stage 5", on_click=_jump_stage_5, classes=["demo-button"])
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -118,7 +118,7 @@ def Page():
 
     gjapp, viewers = solara.use_memo(glue_setup, dependencies=[])
 
-    if not (load_class_data.finished or load_class_data.pending):
+    if not (load_class_data.value or load_class_data.pending):
         load_class_data()
 
     def _on_class_data_loaded(class_data_points: List[StudentMeasurement]):
@@ -148,10 +148,17 @@ def Page():
 
         class_plot_data.set(class_data_points)
 
-    if load_class_data.finished:
+    if load_class_data.value:
         _on_class_data_loaded(load_class_data.value)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
+    def _jump_stage_5():
+        router.push("05-class-results-uncertainty")
+
+    with solara.Row():
+        with solara.Column():
+            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+        with solara.Column():
+            solara.Button(label="Demo Shortcut: Jump to Stage 5", on_click=_jump_stage_5, classes=["demo-button"])
 
     with solara.ColumnsResponsive(12, large=[4,8]):
         with rv.Col():

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -328,7 +328,7 @@ def Page():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=_jump_stage_6, classes=["demo-button"])
+            solara.Button(label="Shortcut: Jump to Stage 6", on_click=_jump_stage_6, classes=["demo-button"])
 
     def _on_component_state_loaded(value: bool):
         if not value:

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -321,7 +321,11 @@ def Page():
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
-    StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
+    with solara.Row():
+        with solara.Column():
+            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+        with solara.Column():
+            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=router.push("06-prodata"), classes=["demo-button"])
 
     def _on_component_state_loaded(value: bool):
         if not value:

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -321,11 +321,14 @@ def Page():
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
+    def _jump_stage_6():
+        router.push("06-prodata")
+
     with solara.Row():
         with solara.Column():
             StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
         with solara.Column():
-            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=router.push("06-prodata"), classes=["demo-button"])
+            solara.Button(label="Demo Shortcut: Jump to Stage 6", on_click=_jump_stage_6, classes=["demo-button"])
 
     def _on_component_state_loaded(value: bool):
         if not value:


### PR DESCRIPTION
At some point we will have to clear all these convenience buttons from the interface (which maybe we can do by assigning all the team interface content a class that can get a display: none in the deployed version.)

In the meantime, I've cherry picked them over from the demo branch since they are pretty handy for skipping around quickly while testing things, especially now that the left navigation is locked down.