### PR TITLE
Update limits on stage 5 viewers

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -254,6 +254,9 @@ def Page():
         for viewer in (student_hist_viewer, all_student_hist_viewer, class_hist_viewer):
             viewer.figure.update_layout(hovermode="closest")
 
+        for viewer in viewers.values():
+            viewer.state.reset_limits(visible_only=True)
+
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,
                                             handler=partial(_update_bins, two_hist_viewers),
                                             filter=lambda msg: msg.data.label == "Student Summaries")


### PR DESCRIPTION
This PR fixes #711 by resetting the limits of each of the stage 5 viewers at the end of the glue setup.