### PR TITLE
Add layer toggled event to Plotly layer toggle and hook up to `tre_dat3` gate

### DIFF
--- a/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
+++ b/src/hubbleds/components/plotly_layer_toggle/PlotlyLayerToggle.vue
@@ -41,7 +41,15 @@
 
 <script>
 export default {
-  props: ["chart_id", "layer_indices", "initial_selected", "enabled", "colors", "labels", ],
+  props: [
+    "chart_id",
+    "layer_indices",
+    "initial_selected",
+    "enabled",
+    "colors",
+    "labels",
+    "layer_toggled",
+  ],
   data() {
     return {
       element: null,
@@ -67,6 +75,9 @@ export default {
         this.getElement();
       }
       Plotly.restyle(this.element, { visible }, {}, index);
+      if (this.layer_toggled) {
+        this.layer_toggled({ index, visible });
+      }
     },
     toggleVisibility(index) {
       let makeVisible = false;

--- a/src/hubbleds/components/plotly_layer_toggle/plotly_layer_toggle.py
+++ b/src/hubbleds/components/plotly_layer_toggle/plotly_layer_toggle.py
@@ -1,5 +1,5 @@
 import solara
-from typing import Iterable
+from typing import Callable, Iterable
 
 
 @solara.component_vue("PlotlyLayerToggle.vue")
@@ -9,5 +9,6 @@ def PlotlyLayerToggle(chart_id: str,
                       enabled: Iterable[bool],
                       colors: Iterable[str],
                       labels: Iterable[str],
+                      event_layer_toggled: Callable = lambda *args: True,
 ):
     pass

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -156,7 +156,7 @@ def Page():
 
     with solara.Row():
         with solara.Column():
-            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=False)
+            StateEditor(Marker, COMPONENT_STATE, LOCAL_STATE, LOCAL_API, show_all=True)
         with solara.Column():
             solara.Button(label="Shortcut: Jump to Stage 5", on_click=_jump_stage_5, classes=["demo-button"])
 
@@ -398,23 +398,28 @@ def Page():
                     colors = ("#3A86FF", "#FB5607")
                     sizes = (8, 12)
                     with rv.Col(class_="no-padding"):
+
+                        def _layer_toggled(data):
+                            if data["visible"] and data["index"] is 3:
+                                Ref(COMPONENT_STATE.fields.class_data_displayed).set(True)
+
                         PlotlyLayerToggle(chart_id="line-draw-viewer",
-                        # (Plotly calls layers traces, but we'll use layers for consistency with glue).
-                        # For the line draw viewer:
-                        # Layer 0 = line that the student draws
-                        # Layer 1, 2 = fit lines for data layers.
-                        # Layer 3, 4 = data layers.
-                        # Layer 5 = endpoint for drawn line.
-                        # Add Layer 6 = best fit galaxy marker.
+                                          # (Plotly calls layers traces, but we'll use layers for consistency with glue).
+                                          # For the line draw viewer:
+                                          # Layer 0 = line that the student draws
+                                          # Layer 1, 2 = fit lines for data layers.
+                                          # Layer 3, 4 = data layers.
+                                          # Layer 5 = endpoint for drawn line.
+                                          # Add Layer 6 = best fit galaxy marker.
                                           layer_indices=(3, 4),
 
-                        # These are the indices (within the specified tuple, which has 2 data layers) of the layers that we want to have initially checked/displayed. 
-                        # If only 1 layer is selected, you still need the comma, otherwise this will be interpreted as an int instead of a tuple. This means "check & display layer 1, which is the student data layer."
-
+                                          # These are the indices (within the specified tuple, which has 2 data layers) of the layers that we want to have initially checked/displayed. 
+                                          # If only 1 layer is selected, you still need the comma, otherwise this will be interpreted as an int instead of a tuple. This means "check & display layer 1, which is the student data layer."
                                           initial_selected=(1,),
                                           enabled=layers_enabled.value,
                                           colors=colors,
-                                          labels=("Class Data", "My Data"))
+                                          labels=("Class Data", "My Data"),
+                                          event_layer_toggled=_layer_toggled)
                     with rv.Col(class_="no-padding"):
                         if student_plot_data.value and class_plot_data.value:
                             # Note the ordering here - we want the student data on top

--- a/src/hubbleds/pages/04-explore-data/component_state.py
+++ b/src/hubbleds/pages/04-explore-data/component_state.py
@@ -48,6 +48,7 @@ class ComponentState(BaseComponentState, BaseState):
     best_fit_click_count: int = 0
     best_fit_gal_vel: float = 100
     best_fit_gal_dist: float = 8000
+    class_data_displayed: bool = False
 
     @field_validator("current_step", mode="before")
     def convert_int_to_enum(cls, v: Any) -> Marker:
@@ -58,6 +59,10 @@ class ComponentState(BaseComponentState, BaseState):
     @property
     def tre_dat2_gate(self) -> bool:
         return LOCAL_STATE.value.question_completed("tre-dat-mc1")
+
+    @property
+    def tre_dat3_gate(self) -> bool:
+        return COMPONENT_STATE.value.class_data_displayed
     
     @property
     def rel_vel1_gate(self) -> bool:


### PR DESCRIPTION
This PR fixes #724. The approach here is to add an `event_layer_toggled` callback to our Plotly layer toggle component. As a note, I think a callback is the only viable approach here - we aren't using glue here and thus can't listen for messages, and we create the Plotly figure inside the component so I don't see a feasible way to listen Python-side to restyle events that affect the trace visibility (which is probably what one would do JS-side). This is then connected to a new gate for `tre_dat3`.