### PR TITLE
Support path-based routing on deployed server

### DIFF
--- a/.ebextensions/01_install.config
+++ b/.ebextensions/01_install.config
@@ -10,4 +10,4 @@ commands:
   01_install:
     command: |
       cd /var/app/current/
-      pip install git+https://github.com/cosmicds/hubbleds.git@short-demo
+      pip install git+https://github.com/nmearl/hubbleds.git@path-routing

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: solara run hubbleds.pages --theme-variant dark --port=8000 --no-open --production --root-path /hubbleds
+web: uvicorn hubbleds.server:app --port=8000

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata
-    astropy
+    astropy<7.0
     authlib
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     pydantic
     python-dateutil
     reacton
-    solara
+    solara-ui @ git+https://github.com/nmearl/solara.git
     solara-enterprise
     traitlets
 

--- a/src/hubbleds/server.py
+++ b/src/hubbleds/server.py
@@ -1,0 +1,26 @@
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+from solara.server import settings
+
+import solara.server.starlette
+
+
+def root(request: Request):
+    return JSONResponse({"Error Message": "Go back whence ye came."})
+
+
+routes = [
+    Route("/", endpoint=root),
+    # Mount("/hubbles-law/", solara.server.starlette.app),
+    Mount("/hubbles-law/", routes=solara.server.starlette.routes),
+]
+
+# middleware = [
+#     Middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True),
+#     Middleware(SessionMiddleware, secret_key="some-secret", max_age=None),
+# ]
+
+
+app = Starlette(routes=routes, middleware=solara.server.starlette.middleware)


### PR DESCRIPTION
This PR implements the server support for path-based routing used on the AWS server. Also, updates requirements to depend on our fork of solara until widgetti/solara#909 is implemented.