### PR TITLE
Add 'my summary' subset to class ages histogram

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -14,14 +14,14 @@ from pathlib import Path
 import reacton.ipyvuetify as rv
 from typing import Dict, Iterable, Optional, Tuple
 
-from cosmicds.components import PercentageSelector, ScaffoldAlert, StateEditor, StatisticsSelector, ViewerLayout
+from cosmicds.components import LayerToggle, PercentageSelector, ScaffoldAlert, StateEditor, StatisticsSelector, ViewerLayout
 from cosmicds.utils import empty_data_from_model_class, show_legend, show_layer_traces_in_legend
 from cosmicds.viewers import CDSHistogramView
 from hubbleds.base_component_state import transition_next, transition_previous
 from hubbleds.components import UncertaintySlideshow, IdSlider
 from hubbleds.tools import *  # noqa
 from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, ClassSummary, StudentMeasurement, StudentSummary, get_free_response, get_multiple_choice, mc_callback, fr_callback
-from hubbleds.utils import age_in_gyr_simple, create_single_summary, make_summary_data, models_to_glue_data
+from hubbleds.utils import create_single_summary, make_summary_data, models_to_glue_data
 from hubbleds.viewers.hubble_histogram_viewer import HubbleHistogramView
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
 from .component_state import COMPONENT_STATE, Marker
@@ -213,8 +213,14 @@ def Page():
                                                output_id_field="id",
                                                label="Class Summaries")
         class_summary_data = GLOBAL_STATE.value.add_or_update_data(class_summary_data)
-        my_summ_subset_state = RangeSubsetState(student_id, student_id, class_summary_data.id["id"])
-        my_summ_subset = class_summary_data.new_subset(subset=my_summ_subset_state, color="#FB5607", alpha=1)
+        if len(class_summary_data.subsets) == 0:
+            my_summ_subset_state = RangeSubsetState(student_id, student_id, class_summary_data.id["id"])
+            my_summ_subset = class_summary_data.new_subset(subset=my_summ_subset_state,
+                                                           color="#FB5607",
+                                                           alpha=1,
+                                                           label="My Summary")
+        else:
+            my_summ_subset = class_summary_data.subsets[0]
 
         my_measurements = LOCAL_STATE.value.measurements
         my_distances = [distance for m in my_measurements if ((distance := m.est_dist_value) is not None and m.velocity_value is not None)]
@@ -631,6 +637,10 @@ def Page():
             with rv.Col():
                 with rv.Row():
                     class_summary_data = gjapp.data_collection["Class Summaries"]
+                    with rv.Col():
+                        if COMPONENT_STATE.value.current_step.value == Marker.age_dis1.value:
+                            LayerToggle(viewer=viewers["student_hist"])
+
                     with rv.Col():
                         if COMPONENT_STATE.value.current_step_between(Marker.mos_lik2, Marker.con_int3):
                             StatisticsSelector(

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -632,11 +632,15 @@ def Page():
                 )
 
     #--------------------- Row 4: OUR CLASS HISTOGRAM VIEWER -----------------------
+    class_summary_data = gjapp.data_collection["Class Summaries"]
+    def _on_percentage_selected_changed(_option, value):
+        my_summ_subset = class_summary_data.subsets[0]
+        my_summ_subset.style.alpha = 1 - bool(value)
+
     if COMPONENT_STATE.value.current_step_between(Marker.age_dis1, Marker.con_int3):
         with solara.ColumnsResponsive(12, large=[5,7]):
             with rv.Col():
                 with rv.Row():
-                    class_summary_data = gjapp.data_collection["Class Summaries"]
                     with rv.Col():
                         if COMPONENT_STATE.value.current_step.value == Marker.age_dis1.value:
                             LayerToggle(viewer=viewers["student_hist"])
@@ -656,6 +660,7 @@ def Page():
                                 viewers=[viewers["student_hist"]],
                                 glue_data=[class_summary_data],
                                 units=["Gyr"],
+                                on_selected_changed=_on_percentage_selected_changed
                             )
 
                 ScaffoldAlert(

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -20,7 +20,7 @@ from cosmicds.viewers import CDSHistogramView
 from hubbleds.base_component_state import transition_next, transition_previous
 from hubbleds.components import UncertaintySlideshow, IdSlider
 from hubbleds.tools import *  # noqa
-from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, ClassSummary, StudentMeasurement, get_free_response, get_multiple_choice, mc_callback, fr_callback
+from hubbleds.state import LOCAL_STATE, GLOBAL_STATE, ClassSummary, StudentMeasurement, StudentSummary, get_free_response, get_multiple_choice, mc_callback, fr_callback
 from hubbleds.utils import age_in_gyr_simple, create_single_summary, make_summary_data, models_to_glue_data
 from hubbleds.viewers.hubble_histogram_viewer import HubbleHistogramView
 from hubbleds.viewers.hubble_scatter_viewer import HubbleScatterView
@@ -207,17 +207,27 @@ def Page():
         show_layer_traces_in_legend(student_slider_viewer)
         show_legend(student_slider_viewer, show=True)
 
+        student_id = GLOBAL_STATE.value.student.id
         class_summary_data = make_summary_data(class_data,
                                                input_id_field="student_id",
                                                output_id_field="id",
                                                label="Class Summaries")
         class_summary_data = GLOBAL_STATE.value.add_or_update_data(class_summary_data)
+        my_summ_subset_state = RangeSubsetState(student_id, student_id, class_summary_data.id["id"])
+        my_summ_subset = class_summary_data.new_subset(subset=my_summ_subset_state, color="#FB5607", alpha=1)
+
+        my_measurements = LOCAL_STATE.value.measurements
+        my_distances = [distance for m in my_measurements if ((distance := m.est_dist_value) is not None and m.velocity_value is not None)]
+        my_velocities = [velocity for m in my_measurements if (m.est_dist_value is not None and (velocity := m.velocity_value) is not None)]
+        my_h0, my_age = create_single_summary(distances=my_distances, velocities=my_velocities)
+        student_summaries.append(StudentSummary(student_id=student_id, hubble_fit_value=my_h0, age_value=my_age))
 
         student_hist_viewer.add_data(class_summary_data)
         student_hist_viewer.state.x_att = class_summary_data.id['age_value']
         student_hist_viewer.state.x_axislabel = "Age (Gyr)"
         student_hist_viewer.state.title = "My class ages (5 galaxies each)"
-        student_hist_viewer.layers[0].state.color = "#8338EC"
+        student_hist_viewer.layers[0].state.color = "#3A86FF"
+        student_hist_viewer.add_subset(my_summ_subset)
 
         all_data = models_to_glue_data(all_measurements, label="All Measurements")
         all_data = GLOBAL_STATE.value.add_or_update_data(all_data)


### PR DESCRIPTION
This PR resolves #728 by adding a subset for "my age" to the "my class" histogram, as well as a layer toggle component for the class histogram viewer. The "my age" subset will be hidden when one of the percentage intervals is selected. This relies on https://github.com/cosmicds/cosmicds/pull/356.

@patudom I wasn't sure exactly which guidelines we wanted the layer toggle to be visible on, so feel free to adjust the logic that determines when the layer toggle displays. Also, let me know if I forgot to implement something that we wanted.