### PR TITLE
Bump glue-plotly version to 0.12.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.10.1
+  - glue-plotly==0.12.0
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4

--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.12.0
+  - glue-plotly==0.12.1
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.12.0
+    glue-plotly[jupyter]>=0.12.1
     ipyvue
     ipyvuetify
     ipywidgets

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.11.0
+    glue-plotly[jupyter]>=0.12.0
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
This PR bumps our version of `glue-plotly` to 0.12.1 so that we can use the border styling added for scatter layers in that version. The relevant PR is [here](https://github.com/glue-viz/glue-plotly/pull/114), but what's important for us is a few updates to the layer state. In particular:

* `layer.state.border_visible` - set this to `True` to display borders
* `layer.state.border_size` - adjusts the size of the borders
* `layer.state.border_color` - sets the color of the border

For anyone who looks at the linked PR - the `border_color_match_layer` isn't something that we need - the intended use case there is for making the borders match the colors of a colormapped layer if you want to have unfilled circles.