### PR TITLE
Only send necessary fields to WWT selection widget

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -22,8 +22,8 @@ def SelectionTool(
         def _add_widget():
             selection_tool_widget = SelectionToolWidget(
                 table_layer_data={
-                    k: [x.dict()[k] for x in LOCAL_STATE.value.galaxies]
-                    for k in LOCAL_STATE.value.galaxies[0].dict()
+                    k: [x.dict()[k] for x in LOCAL_STATE.value.galaxies.values()]
+                    for k in ["id", "ra", "decl"]
                 }
             )
 
@@ -38,16 +38,21 @@ def SelectionTool(
 
         solara.use_effect(_add_widget, dependencies=[])
 
+        def _on_galaxy_selected(gal: dict):
+            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
+            galaxy_added_callback(data)
+
+        def _on_current_galaxy_changed(change: dict):
+            gal = change["new"]
+            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
+            galaxy_added_callback(data)
+
         def _setup_callbacks():
             selection_tool_widget = solara.get_widget(tool_container).children[0]
 
-            selection_tool_widget.on_galaxy_selected = (
-                lambda gal: galaxy_added_callback(GalaxyData(**gal))
-            )
+            selection_tool_widget.on_galaxy_selected = _on_galaxy_selected
             selection_tool_widget.observe(
-                lambda change: galaxy_selected_callback(
-                    GalaxyData(**change["new"]) if len(change["new"]) > 0 else None
-                ),
+                _on_current_galaxy_changed,
                 ["current_galaxy"],
             )
             selection_tool_widget.deselect_galaxy = deselect_galaxy_callback

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -39,13 +39,13 @@ def SelectionTool(
         solara.use_effect(_add_widget, dependencies=[])
 
         def _on_galaxy_selected(gal: dict):
-            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
+            data = LOCAL_STATE.value.galaxies[int(gal["id"])]
             galaxy_added_callback(data)
 
         def _on_current_galaxy_changed(change: dict):
             gal = change["new"]
-            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
-            galaxy_added_callback(data)
+            data = LOCAL_STATE.value.galaxies[int(gal["id"])]
+            galaxy_selected_callback(data)
 
         def _setup_callbacks():
             selection_tool_widget = solara.get_widget(tool_container).children[0]

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -141,10 +141,11 @@ class LocalState(BaseLocalState):
     last_route: Optional[str] = None
 
     @cached_property
-    def galaxies(self) -> list[GalaxyData]:
+    def galaxies(self) -> dict[int, GalaxyData]:
         from hubbleds.remote import LOCAL_API
 
-        return LOCAL_API.get_galaxies(LOCAL_STATE)
+        gal_data = LOCAL_API.get_galaxies(LOCAL_STATE)
+        return { galaxy.id: galaxy for galaxy in gal_data }
 
     def as_dict(self):
         return self.model_dump(exclude={

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -83,10 +83,9 @@ class SelectionToolWidget(v.VueTemplate):
             source = wwt.most_recent_source
             galaxy = source["layerData"]
 
-            for k in ["ra", "decl", "z"]:
+            for k in ["ra", "decl"]:
                 galaxy[k] = float(galaxy[k])
 
-            galaxy["element"] = galaxy["element"].replace("?", "α")  # Hacky fix for now
             fov = min(wwt.get_fov(), GALAXY_FOV)
 
             self.go_to_location(galaxy["ra"], galaxy["decl"], fov=fov)
@@ -94,9 +93,9 @@ class SelectionToolWidget(v.VueTemplate):
             self.candidate_galaxy = galaxy
 
             if not self.selected_data.empty:
-                gal_names = [k for k in self.selected_data["name"]]
+                gal_ids = [k for k in self.selected_data["id"]]
 
-                if self.current_galaxy["name"] in gal_names:
+                if self.current_galaxy["id"] in gal_ids:
                     self.candidate_galaxy = {}
 
             self.selected = True
@@ -197,11 +196,6 @@ class SelectionToolWidget(v.VueTemplate):
             return
         if self.current_galaxy["id"]:
             data = {"galaxy_id": int(self.current_galaxy["id"])}
-        else:
-            name = self.current_galaxy["name"]
-            if not name.endswith(".fits"):
-                name += ".fits"
-            data = {"galaxy_name": name}
-        GLOBAL_STATE.request_session().put(
-            f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad", json=data
-        )
+            GLOBAL_STATE.request_session().put(
+                f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad", json=data
+            )


### PR DESCRIPTION
This PR reduces the size of the table creation widget that we need to send by only sending the RA, Dec, and ID fields to the WWT widget for creating the selection table layer. The galaxies field in the local state has been changed to an ID-keyed dictionary, so we can then use the ID of the selection data from WWT to look up the full data for the galaxy Python-side.