### PR TITLE
Add additional triggers to update background to SDSS 12

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -14,6 +14,7 @@ def SelectionTool(
     galaxy_added_callback: Callable,
     deselect_galaxy_callback: Callable,
     selected_measurement: dict | None,
+    sdss_12_counter: solara.Reactive[int],
 ):
     with rv.Card() as main:
         with rv.Card(class_="pa-0 ma-0", elevation=0):
@@ -29,6 +30,8 @@ def SelectionTool(
 
             tool_widget = solara.get_widget(tool_container)
             tool_widget.children = (selection_tool_widget,)
+
+            sdss_12_counter.subscribe(lambda _count: selection_tool_widget.set_sdss_12())
 
             def cleanup():
                 tool_widget.children = ()

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -232,6 +232,8 @@ def Page():
     #   in the ipywwt package itself.
     show_selection_tool, set_show_selection_tool = solara.use_state(False)
 
+    selection_tool_bg_count = solara.use_reactive(0)
+
     async def _delay_selection_tool():
         await asyncio.sleep(3)
         set_show_selection_tool(True)
@@ -499,7 +501,8 @@ def Page():
             initialize_bounds(max_spectrum_bounds.value)
         if COMPONENT_STATE.value.current_step >= Marker.rem_vel1:
             update_second_example_measurement() # either set them to current or keep from DB
-        pass
+        if COMPONENT_STATE.value.current_step_between(Marker.mee_gui1, Marker.sel_gal4):
+            selection_tool_bg_count.set(selection_tool_bg_count.value + 1)
 
     Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
     
@@ -634,7 +637,7 @@ def Page():
             if show_example_data_table:
                 selection_tool_galaxy = selected_example_measurement
             else:
-                selection_tool_galaxy= selected_measurement
+                selection_tool_galaxy = selected_measurement
             
             SelectionTool(
                 show_galaxies=COMPONENT_STATE.value.current_step_in(
@@ -648,6 +651,7 @@ def Page():
                     else None
                 ),
                 deselect_galaxy_callback=_deselect_galaxy_callback,
+                sdss_12_counter=selection_tool_bg_count,
             )
             
             if show_snackbar.value:

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -158,6 +158,7 @@ class SelectionToolWidget(v.VueTemplate):
             self._on_galaxy_selected(galaxy)
         if self._deselect_galaxy is not None:
             self._deselect_galaxy()
+        self.set_sdss_12()
         self.selected = False
 
     @property

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -40,7 +40,7 @@ class SelectionToolWidget(v.VueTemplate):
         self.widget = WWTWidget()
         
         def _setup():
-            self._set_sdss_12()
+            self.set_sdss_12()
             self.widget.center_on_coordinates(
                 self.START_COORDINATES,
                 fov=6 * u.arcmin,  # start in close enough to see galaxies
@@ -106,7 +106,7 @@ class SelectionToolWidget(v.VueTemplate):
 
         super().__init__(*args, **kwargs)
 
-    def _set_sdss_12(self):
+    def set_sdss_12(self):
         if self.widget.foreground != self.SDSS_12:
             self.widget.foreground = self.SDSS_12
         else:
@@ -125,7 +125,7 @@ class SelectionToolWidget(v.VueTemplate):
         )
 
     def show_galaxies(self, show=True):
-        self._set_sdss_12()
+        self.set_sdss_12()
         if self.sdss_layer is not None:
             if self.sdss_layer in self.widget.layers._layers:
                 self.widget.layers.remove_layer(self.sdss_layer)
@@ -170,7 +170,7 @@ class SelectionToolWidget(v.VueTemplate):
 
     def reset_view(self):
         print("in reset_view within selection_tool_widget.py")
-        self._set_sdss_12()
+        self.set_sdss_12()
         self.widget.center_on_coordinates(
             self.START_COORDINATES, fov=FULL_FOV, instant=True
         )

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -30,6 +30,8 @@ class SelectionToolWidget(v.VueTemplate):
     selected = Bool(False).tag(sync=True)
     highlighted = Bool(False).tag(sync=True)
 
+    SDSS_12 = "SDSS 12"
+
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame="icrs")
 
@@ -38,8 +40,7 @@ class SelectionToolWidget(v.VueTemplate):
         self.widget = WWTWidget()
         
         def _setup():
-            self.widget.background = "SDSS 12"
-            self.widget.foreground = "SDSS 12"
+            self._set_sdss_12()
             self.widget.center_on_coordinates(
                 self.START_COORDINATES,
                 fov=6 * u.arcmin,  # start in close enough to see galaxies
@@ -105,6 +106,17 @@ class SelectionToolWidget(v.VueTemplate):
 
         super().__init__(*args, **kwargs)
 
+    def _set_sdss_12(self):
+        if self.widget.foreground != self.SDSS_12:
+            self.widget.foreground = self.SDSS_12
+        else:
+            self.widget._on_foreground_change({"new": self.SDSS_12})
+
+        if self.widget.background != self.SDSS_12:
+            self.widget.background = self.SDSS_12
+        else:
+            self.widget.set_background_image({"new": self.SDSS_12})
+
     def center_on_start_coordinates(self):
         self.widget.center_on_coordinates(
             self.START_COORDINATES,
@@ -113,6 +125,7 @@ class SelectionToolWidget(v.VueTemplate):
         )
 
     def show_galaxies(self, show=True):
+        self._set_sdss_12()
         if self.sdss_layer is not None:
             if self.sdss_layer in self.widget.layers._layers:
                 self.widget.layers.remove_layer(self.sdss_layer)
@@ -157,6 +170,7 @@ class SelectionToolWidget(v.VueTemplate):
 
     def reset_view(self):
         print("in reset_view within selection_tool_widget.py")
+        self._set_sdss_12()
         self.widget.center_on_coordinates(
             self.START_COORDINATES, fov=FULL_FOV, instant=True
         )


### PR DESCRIPTION
This PR updates the stage 1 and the selection widget to update the foreground/background of the WWT widget to use SDSS 12 at multiple points. We also make sure to "force" the messages to get sent - if the traitlet values aren't set to SDSS 12, we use the normal traitlets machinery, but if they are then we just call the underlying method to send the message. We now invoke this functionality at this following points:
* Whenever the marker is changed within a given range at the beginning of the stage. When the marker is updated we then update a reactive counter which is used to call the SDSS 12 method of the widget inside the component
* Whenever the selected galaxy is changed
* Whenever the show galaxies flag is changed