### PR TITLE
Cherry pick smaller WWT table to short demo

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -23,9 +23,10 @@ def SelectionTool(
         def _add_widget():
             selection_tool_widget = SelectionToolWidget(
                 table_layer_data={
-                    k: [x.dict()[k] for x in LOCAL_STATE.value.galaxies]
-                    for k in LOCAL_STATE.value.galaxies[0].dict()
-                }
+                    k: [x.dict()[k] for x in LOCAL_STATE.value.galaxies.values()]
+                    for k in ["id", "ra", "decl"]
+                },
+                show_galaxies=show_galaxies,
             )
 
             tool_widget = solara.get_widget(tool_container)

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -42,16 +42,21 @@ def SelectionTool(
 
         solara.use_effect(_add_widget, dependencies=[])
 
+        def _on_galaxy_selected(gal: dict):
+            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
+            galaxy_added_callback(data)
+
+        def _on_current_galaxy_changed(change: dict):
+            gal = change["new"]
+            data = GalaxyData(**LOCAL_STATE.value.galaxies[gal["id"]])
+            galaxy_added_callback(data)
+
         def _setup_callbacks():
             selection_tool_widget = solara.get_widget(tool_container).children[0]
 
-            selection_tool_widget.on_galaxy_selected = (
-                lambda gal: galaxy_added_callback(GalaxyData(**gal))
-            )
+            selection_tool_widget.on_galaxy_selected = _on_galaxy_selected
             selection_tool_widget.observe(
-                lambda change: galaxy_selected_callback(
-                    GalaxyData(**change["new"]) if len(change["new"]) > 0 else None
-                ),
+                _on_current_galaxy_changed,
                 ["current_galaxy"],
             )
             selection_tool_widget.deselect_galaxy = deselect_galaxy_callback

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -141,10 +141,11 @@ class LocalState(BaseLocalState):
     last_route: Optional[str] = None
 
     @cached_property
-    def galaxies(self) -> list[GalaxyData]:
+    def galaxies(self) -> dict[int, GalaxyData]:
         from hubbleds.remote import LOCAL_API
 
-        return LOCAL_API.get_galaxies(LOCAL_STATE)
+        gal_data = LOCAL_API.get_galaxies(LOCAL_STATE)
+        return { galaxy.id: galaxy for galaxy in gal_data }
 
     def as_dict(self):
         return self.model_dump(exclude={

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -88,10 +88,9 @@ class SelectionToolWidget(v.VueTemplate):
             source = wwt.most_recent_source
             galaxy = source["layerData"]
 
-            for k in ["ra", "decl", "z"]:
+            for k in ["ra", "decl"]:
                 galaxy[k] = float(galaxy[k])
 
-            galaxy["element"] = galaxy["element"].replace("?", "α")  # Hacky fix for now
             fov = min(wwt.get_fov(), GALAXY_FOV)
 
             self.go_to_location(galaxy["ra"], galaxy["decl"], fov=fov)
@@ -99,9 +98,9 @@ class SelectionToolWidget(v.VueTemplate):
             self.candidate_galaxy = galaxy
 
             if not self.selected_data.empty:
-                gal_names = [k for k in self.selected_data["name"]]
+                gal_ids = [k for k in self.selected_data["id"]]
 
-                if self.current_galaxy["name"] in gal_names:
+                if self.current_galaxy["id"] in gal_ids:
                     self.candidate_galaxy = {}
 
             self.selected = True
@@ -233,11 +232,6 @@ class SelectionToolWidget(v.VueTemplate):
             return
         if self.current_galaxy["id"]:
             data = {"galaxy_id": int(self.current_galaxy["id"])}
-        else:
-            name = self.current_galaxy["name"]
-            if not name.endswith(".fits"):
-                name += ".fits"
-            data = {"galaxy_name": name}
-        GLOBAL_STATE.request_session().put(
-            f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad", json=data
-        )
+            GLOBAL_STATE.request_session().put(
+                f"{API_URL}/{HUBBLE_ROUTE_PATH}/mark-galaxy-bad", json=data
+            )

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -137,13 +137,15 @@ class SelectionToolWidget(v.VueTemplate):
 
     def show_galaxies(self, show=True):
         self.set_background()
-        if self.sdss_layer is not None:
-            if self.sdss_layer in self.widget.layers._layers:
-                self.widget.layers.remove_layer(self.sdss_layer)
-                self.sdss_layer = None
 
-        if show and self.sdss_layer is None:
-            layer = self.widget.layers.add_table_layer(self.sdss_table, marker_type="gaussian", size_scale=100, color="#00FF00", marker_scale="screen")
+        opacity = int(show)
+        if self.sdss_layer is None:
+            layer = self.widget.layers.add_table_layer(self.sdss_table,
+                                                       marker_type="gaussian",
+                                                       size_scale=100,
+                                                       color="#00FF00",
+                                                       marker_scale="screen",
+                                                       opacity=opacity)
                                                         
             # self.widget.layers.add_table_layer(self.sdss_table)
             # #try passing these as kwargs to add_table_layer.
@@ -151,6 +153,8 @@ class SelectionToolWidget(v.VueTemplate):
             # layer.size_scale = 100
             # layer.color = "#00FF00"
             self.sdss_layer = layer
+        else:
+            self.sdss_layer.opacity = opacity
 
     @property
     def on_galaxy_selected(self):


### PR DESCRIPTION
(From #748).

This seemed like a pretty straightforward cherry-pick, but when I run it, I have to switch back and forth btw guidelines several times to get the green dots, so seems like this update is not solving the issue. ☹️ 

If someone else would like to give it a go, please let me know what you find. Don't forget that you have to set `CDS_DISABLE_DB=true` in the command line

In case it's in any way related, I got this error when I killed the process:
```
hubbleds Pat$ /Users/Pat/anaconda3/envs/common-solara/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown

```