### PR TITLE
Fix issue with spectrum hovertext

### DIFF
--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -174,7 +174,8 @@ def SpectrumViewer(
                             color=spectrum_color,
                             width=2,
                         ),
-                      mode='lines', 
+                        mode='lines',
+                        hovertemplate="%{x:.0f} Å<extra></extra>",
                     ))
          
         fig.update_layout(


### PR DESCRIPTION
This fixes #749 by explicitly setting the hovertemplate of the spectrum scatter trace.