### PR TITLE
Add button for clearing WWT tile cache

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     ipyvue
     ipyvuetify
     ipywidgets
-    ipywwt @ git+https://github.com/nmearl/ipywwt.git
+    ipywwt @ git+https://github.com/Carifio24/ipywwt.git@clear-tile-cache
     itsdangerous
     numpy<2.0.0
     pandas

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -14,7 +14,7 @@ def SelectionTool(
     galaxy_added_callback: Callable,
     deselect_galaxy_callback: Callable,
     selected_measurement: dict | None,
-    sdss_12_counter: solara.Reactive[int],
+    bg_counter: solara.Reactive[int],
 ):
     with rv.Card() as main:
         with rv.Card(class_="pa-0 ma-0", elevation=0):
@@ -31,7 +31,7 @@ def SelectionTool(
             tool_widget = solara.get_widget(tool_container)
             tool_widget.children = (selection_tool_widget,)
 
-            sdss_12_counter.subscribe(lambda _count: selection_tool_widget.set_sdss_12())
+            bg_counter.subscribe(lambda _count: selection_tool_widget.set_background())
 
             def cleanup():
                 tool_widget.children = ()

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -488,7 +488,7 @@ def Page():
                     else None
                 ),
                 deselect_galaxy_callback=_deselect_galaxy_callback,
-                sdss_12_counter=selection_tool_bg_count,
+                bg_counter=selection_tool_bg_count,
             )
             
             if show_snackbar.value:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -65,11 +65,18 @@ logger = setup_logger("STAGE3")
 
 
 @solara.component
-def DistanceToolComponent(galaxy, show_ruler, angular_size_callback, ruler_count_callback, use_guard, bad_measurement_callback):
+def DistanceToolComponent(galaxy,
+                          show_ruler,
+                          angular_size_callback,
+                          ruler_count_callback,
+                          use_guard,
+                          bad_measurement_callback,
+                          bg_counter):
     tool = DistanceTool.element()
 
     def set_selected_galaxy():
         widget = solara.get_widget(tool)
+        widget.set_background()
         if galaxy:
             widget.measuring = False
             widget.go_to_location(galaxy["ra"], galaxy["decl"], fov=GALAXY_FOV)
@@ -112,6 +119,8 @@ def DistanceToolComponent(galaxy, show_ruler, angular_size_callback, ruler_count
 
         widget.observe(get_ruler_click_count, ["ruler_click_count"])
 
+        bg_counter.subscribe(lambda _count: widget.set_background())
+
     solara.use_effect(_define_callbacks, [])
     
     
@@ -123,6 +132,8 @@ def Page():
     # === Setup State Loading and Writing ===
     loaded_component_state = solara.use_reactive(False)
     router = solara.use_router()
+
+    distance_tool_bg_count = solara.use_reactive(0)
 
     async def _load_component_state():
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
@@ -298,6 +309,8 @@ def Page():
         if marker_old == Marker.est_dis3:
             _distance_cb(COMPONENT_STATE.value.meas_theta)
             Ref(COMPONENT_STATE.fields.fill_est_dist_values).set(True)
+
+        distance_tool_bg_count.set(distance_tool_bg_count.value + 1)
             
     Ref(COMPONENT_STATE.fields.current_step).subscribe_change(_on_marker_updated)
 
@@ -444,7 +457,8 @@ def Page():
                 angular_size_callback=_ang_size_cb,
                 ruler_count_callback=_get_ruler_clicks_cb,
                 bad_measurement_callback=_bad_measurement_cb,
-                use_guard=True
+                use_guard=True,
+                sdss_12_counter=distance_tool_bg_count,
             )
             
             if COMPONENT_STATE.value.bad_measurement:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -458,7 +458,7 @@ def Page():
                 ruler_count_callback=_get_ruler_clicks_cb,
                 bad_measurement_callback=_bad_measurement_cb,
                 use_guard=True,
-                sdss_12_counter=distance_tool_bg_count,
+                bg_counter=distance_tool_bg_count,
             )
             
             if COMPONENT_STATE.value.bad_measurement:

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -77,7 +77,6 @@ class ComponentState(BaseComponentState, BaseState):
             return Marker(v)
         return v
 
-
     @property
     def ang_siz2_gate(self):
         return bool(self.selected_example_galaxy)

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -186,3 +186,6 @@ class DistanceTool(v.VueTemplate):
     def vue_set_contrast(self, contrast, *_args):
         print(f"Contrast: {contrast}")
         self.contrast = contrast
+
+    def vue_clear_tile_cache(self, _args=None):
+        self.widget.clear_tile_cache()

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -88,6 +88,12 @@
             dark
             top 
             right
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
             @click="clear_tile_cache()">
             <v-icon>mdi-refresh</v-icon>
           </v-btn>

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -81,6 +81,24 @@
         </template>
         {{ measuring ? 'Stop measuring' : 'Start measuring' }}
       </v-tooltip>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top 
+            right
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
+            @click="clear_tile_cache()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </template>
+        Refresh images
     </div>
     <contrast-brightness-control 
       inline-style="padding: 0.5em 0;"

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -88,17 +88,31 @@
             dark
             top 
             right
+            @click="clear_tile_cache()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </template>
+        Refresh images
+      </v-tooltip>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top
+            left
             absolute
             style="margin-top: 96px"
             color="var(--success-dark)"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
-            @click="clear_tile_cache()">
-            <v-icon>mdi-refresh</v-icon>
+            @click="toggle_background()">
+            <v-icon>mdi-image-multiple</v-icon>
           </v-btn>
         </template>
-        Refresh images
+        {{ `Use ${background === 'SDSS 12' ? 'DSS' : 'SDSS'} Images` }}
+      </v-tooltip>
     </div>
     <contrast-brightness-control 
       inline-style="padding: 0.5em 0;"

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -169,6 +169,9 @@ class SelectionToolWidget(v.VueTemplate):
     def deselect_galaxy(self, cb):
         self._deselect_galaxy = cb
 
+    def reset_tiles(self):
+        self.widget.send({"type": "clear_tile_cache"})
+
     def reset_view(self):
         print("in reset_view within selection_tool_widget.py")
         self.set_sdss_12()
@@ -190,6 +193,9 @@ class SelectionToolWidget(v.VueTemplate):
         if self.selected_layer is not None:
             self.widget.layers.remove_layer(self.selected_layer)
         self.selected_layer = layer
+
+    def vue_clear_tile_cache(self, _args=None):
+        self.widget.clear_tile_cache()
 
     def vue_select_current_galaxy(self, _args=None):
         self.select_galaxy(self.current_galaxy)

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
@@ -172,17 +172,31 @@
             dark
             top 
             right
+            @click="clear_tile_cache()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </template>
+        Refresh images
+      </v-tooltip>
+
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top
+            left
             absolute
             style="margin-top: 96px"
             color="var(--success-dark)"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
-            @click="clear_tile_cache()">
-            <v-icon>mdi-refresh</v-icon>
+            @click="toggle_background()">
+            <v-icon>mdi-image-multiple</v-icon>
           </v-btn>
         </template>
-        Refresh images
+        {{ `Use ${background === 'SDSS 12' ? 'DSS' : 'SDSS'} Images` }}
       </v-tooltip>
     </div>
   </v-card>

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
@@ -172,6 +172,12 @@
             dark
             top 
             right
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
             @click="clear_tile_cache()">
             <v-icon>mdi-refresh</v-icon>
           </v-btn>

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
@@ -165,6 +165,25 @@
         </template>
         Reset view
       </v-tooltip>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top 
+            right
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
+            @click="clear_tile_cache()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </template>
+        Refresh images
+      </v-tooltip>
     </div>
   </v-card>
 </template>


### PR DESCRIPTION
This PR adds buttons for refreshing the WWT tile cache to both the selection and distance tool widgets. This PR requires https://github.com/nmearl/ipywwt/pull/6.