### PR TITLE
Allow toggling DSS/SDSS

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -31,7 +31,7 @@ def SelectionTool(
             tool_widget = solara.get_widget(tool_container)
             tool_widget.children = (selection_tool_widget,)
 
-            bg_counter.subscribe(lambda _count: selection_tool_widget.toggle_background())
+            bg_counter.subscribe(lambda _count: selection_tool_widget.set_background())
 
             def cleanup():
                 tool_widget.children = ()

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -14,7 +14,7 @@ def SelectionTool(
     galaxy_added_callback: Callable,
     deselect_galaxy_callback: Callable,
     selected_measurement: dict | None,
-    sdss_12_counter: solara.Reactive[int],
+    bg_counter: solara.Reactive[int],
 ):
     with rv.Card() as main:
         with rv.Card(class_="pa-0 ma-0", elevation=0):
@@ -31,7 +31,7 @@ def SelectionTool(
             tool_widget = solara.get_widget(tool_container)
             tool_widget.children = (selection_tool_widget,)
 
-            sdss_12_counter.subscribe(lambda _count: selection_tool_widget.set_sdss_12())
+            bg_counter.subscribe(lambda _count: selection_tool_widget.toggle_background())
 
             def cleanup():
                 tool_widget.children = ()

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -488,7 +488,7 @@ def Page():
                     else None
                 ),
                 deselect_galaxy_callback=_deselect_galaxy_callback,
-                sdss_12_counter=selection_tool_bg_count,
+                bg_counter=selection_tool_bg_count,
             )
             
             if show_snackbar.value:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -76,7 +76,7 @@ def DistanceToolComponent(galaxy,
 
     def set_selected_galaxy():
         widget = solara.get_widget(tool)
-        widget.set_sdss_12()
+        widget.set_background()
         if galaxy:
             widget.measuring = False
             widget.go_to_location(galaxy["ra"], galaxy["decl"], fov=GALAXY_FOV)
@@ -119,7 +119,7 @@ def DistanceToolComponent(galaxy,
 
         widget.observe(get_ruler_click_count, ["ruler_click_count"])
 
-        sdss_12_counter.subscribe(lambda _count: widget.set_sdss_12())
+        sdss_12_counter.subscribe(lambda _count: widget.set_background())
 
     solara.use_effect(_define_callbacks, [])
     

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -71,7 +71,7 @@ def DistanceToolComponent(galaxy,
                           ruler_count_callback,
                           use_guard,
                           bad_measurement_callback,
-                          sdss_12_counter):
+                          bg_counter):
     tool = DistanceTool.element()
 
     def set_selected_galaxy():
@@ -119,7 +119,7 @@ def DistanceToolComponent(galaxy,
 
         widget.observe(get_ruler_click_count, ["ruler_click_count"])
 
-        sdss_12_counter.subscribe(lambda _count: widget.set_background())
+        bg_counter.subscribe(lambda _count: widget.set_background())
 
     solara.use_effect(_define_callbacks, [])
     

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -77,7 +77,6 @@ class ComponentState(BaseComponentState, BaseState):
             return Marker(v)
         return v
 
-
     @property
     def ang_siz2_gate(self):
         return bool(self.selected_example_galaxy)

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -47,7 +47,7 @@ class DistanceTool(v.VueTemplate):
     bad_measurement = Bool(False).tag(sync=True)
 
     SDSS_12 = "SDSS 12"
-    DSS = "DSS"
+    DSS = "Digitized Sky Survey (Color)"
 
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame='icrs')

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -45,6 +45,8 @@ class DistanceTool(v.VueTemplate):
     galaxy_min_size = Angle("6 arcsec") # 3 x sdss resolution
     bad_measurement = Bool(False).tag(sync=True)
 
+    SDSS_12 = "SDSS 12"
+
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame='icrs')
 
@@ -68,14 +70,24 @@ class DistanceTool(v.VueTemplate):
         self._rt.stop()
         super().__del__()
 
+    def set_sdss_12(self):
+        if self.widget.foreground != self.SDSS_12:
+            self.widget.foreground = self.SDSS_12
+        else:
+            self.widget._on_foreground_change({"new": self.SDSS_12})
+
+        if self.widget.background != self.SDSS_12:
+            self.widget.background = self.SDSS_12
+        else:
+            self.widget.set_background_image({"new": self.SDSS_12})
+
     def _setup_widget(self):
-        # Temp update to set background to SDSS. Once we remove galaxies without SDSS WWT tiles from the catalog, make background DSS again, and set wwt.foreground_opacity = 0, per Peter Williams.
-        self.widget.background = 'SDSS 12'
-        self.widget.foreground = 'SDSS 12'
+        self.set_sdss_12()
         self.widget.center_on_coordinates(self.START_COORDINATES, fov= 42 * u.arcmin, #start in close enough to see galaxies
                                           instant=True)
 
     def reset_canvas(self):
+        self.set_sdss_12()
         self.send({"method": "reset", "args": []})
 
     def update_text(self):
@@ -95,6 +107,7 @@ class DistanceTool(v.VueTemplate):
                 self.view_changing = False
 
     def vue_toggle_measuring(self, _args=None):
+        self.set_sdss_12()
         self.measuring = not self.measuring
         self.ruler_click_count += 1
 

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -38,6 +38,7 @@ class DistanceTool(v.VueTemplate):
     _dec = Angle(0 * u.deg)
     wwtStyle = Dict().tag(sync=True)
     reset_style = Bool(False).tag(sync=True)
+    background = Unicode().tag(sync=True)
     
     # Guard
     guard = Bool(False).tag(sync=True)
@@ -46,12 +47,14 @@ class DistanceTool(v.VueTemplate):
     bad_measurement = Bool(False).tag(sync=True)
 
     SDSS_12 = "SDSS 12"
+    DSS = "DSS"
 
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame='icrs')
 
     def __init__(self, *args, **kwargs):
         self.widget = WWTWidget()
+        self.background = self.SDSS_12
         timer = Timer(3.0, self._setup_widget)
         timer.start()
         self.measuring = kwargs.get('measuring', False)
@@ -70,24 +73,31 @@ class DistanceTool(v.VueTemplate):
         self._rt.stop()
         super().__del__()
 
-    def set_sdss_12(self):
-        if self.widget.foreground != self.SDSS_12:
-            self.widget.foreground = self.SDSS_12
+    def set_background(self):
+        if self.widget.foreground != self.background:
+            self.widget.foreground = self.background
         else:
-            self.widget._on_foreground_change({"new": self.SDSS_12})
+            self.widget._on_foreground_change({"new": self.background})
 
-        if self.widget.background != self.SDSS_12:
-            self.widget.background = self.SDSS_12
+        if self.widget.background != self.background:
+            self.widget.background = self.background
         else:
-            self.widget.set_background_image({"new": self.SDSS_12})
+            self.widget.set_background_image({"new": self.background})
+
+    def vue_toggle_background(self, _args=None):
+        if self.background == self.SDSS_12:
+            self.background = self.DSS
+        else:
+            self.background = self.SDSS_12
+        self.set_background()
 
     def _setup_widget(self):
-        self.set_sdss_12()
+        self.set_background()
         self.widget.center_on_coordinates(self.START_COORDINATES, fov= 42 * u.arcmin, #start in close enough to see galaxies
                                           instant=True)
 
     def reset_canvas(self):
-        self.set_sdss_12()
+        self.set_background()
         self.send({"method": "reset", "args": []})
 
     def update_text(self):
@@ -107,7 +117,7 @@ class DistanceTool(v.VueTemplate):
                 self.view_changing = False
 
     def vue_toggle_measuring(self, _args=None):
-        self.set_sdss_12()
+        self.set_background()
         self.measuring = not self.measuring
         self.ruler_click_count += 1
 

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -81,6 +81,25 @@
         </template>
         {{ measuring ? 'Stop measuring' : 'Start measuring' }}
       </v-tooltip>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top
+            left
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
+            @click="toggle_background()">
+            <v-icon>mdi-image-multiple</v-icon>
+          </v-btn>
+        </template>
+        {{ `Use ${background === 'SDSS 12' ? 'DSS' : 'SDSS'} Images` }}
+      </v-tooltip>
     </div>
     <contrast-brightness-control 
       inline-style="padding: 0.5em 0;"

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -32,7 +32,7 @@ class SelectionToolWidget(v.VueTemplate):
     background = Unicode().tag(sync=True)
 
     SDSS_12 = "SDSS 12"
-    DSS = "DSS"
+    DSS = "Digitized Sky Survey (Color)"
 
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame="icrs")

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -11,7 +11,7 @@ from hubbleds.state import GLOBAL_STATE
 
 # from pywwt.jupyter import WWTJupyterWidget
 from ipywwt import WWTWidget
-from traitlets import Dict, Instance, Int, Bool, observe
+from traitlets import Dict, Instance, Int, Bool, Unicode, observe
 
 from ...utils import FULL_FOV, GALAXY_FOV
 from ...utils import HUBBLE_ROUTE_PATH
@@ -29,8 +29,10 @@ class SelectionToolWidget(v.VueTemplate):
     flagged = Bool(False).tag(sync=True)
     selected = Bool(False).tag(sync=True)
     highlighted = Bool(False).tag(sync=True)
+    background = Unicode().tag(sync=True)
 
     SDSS_12 = "SDSS 12"
+    DSS = "DSS"
 
     UPDATE_TIME = 1  # seconds
     START_COORDINATES = SkyCoord(180 * u.deg, 25 * u.deg, frame="icrs")
@@ -38,9 +40,11 @@ class SelectionToolWidget(v.VueTemplate):
     def __init__(self, table_layer_data: dict, *args, **kwargs):
         # self.widget = WWTJupyterWidget(hide_all_chrome=True)
         self.widget = WWTWidget()
+
+        self.background = self.SDSS_12
         
         def _setup():
-            self.set_sdss_12()
+            self.set_background()
             self.widget.center_on_coordinates(
                 self.START_COORDINATES,
                 fov=6 * u.arcmin,  # start in close enough to see galaxies
@@ -106,16 +110,23 @@ class SelectionToolWidget(v.VueTemplate):
 
         super().__init__(*args, **kwargs)
 
-    def set_sdss_12(self):
-        if self.widget.foreground != self.SDSS_12:
-            self.widget.foreground = self.SDSS_12
+    def set_background(self):
+        if self.widget.foreground != self.background:
+            self.widget.foreground = self.background
         else:
-            self.widget._on_foreground_change({"new": self.SDSS_12})
+            self.widget._on_foreground_change({"new": self.background})
 
-        if self.widget.background != self.SDSS_12:
-            self.widget.background = self.SDSS_12
+        if self.widget.background != self.background:
+            self.widget.background = self.background
         else:
-            self.widget.set_background_image({"new": self.SDSS_12})
+            self.widget.set_background_image({"new": self.background})
+
+    def vue_toggle_background(self, _args=None):
+        if self.background == self.SDSS_12:
+            self.background = self.DSS
+        else:
+            self.background = self.SDSS_12
+        self.set_background()
 
     def center_on_start_coordinates(self):
         self.widget.center_on_coordinates(
@@ -125,7 +136,7 @@ class SelectionToolWidget(v.VueTemplate):
         )
 
     def show_galaxies(self, show=True):
-        self.set_sdss_12()
+        self.set_background()
         if self.sdss_layer is not None:
             if self.sdss_layer in self.widget.layers._layers:
                 self.widget.layers.remove_layer(self.sdss_layer)
@@ -158,7 +169,7 @@ class SelectionToolWidget(v.VueTemplate):
             self._on_galaxy_selected(galaxy)
         if self._deselect_galaxy is not None:
             self._deselect_galaxy()
-        self.set_sdss_12()
+        self.set_background()
         self.selected = False
 
     @property
@@ -171,7 +182,7 @@ class SelectionToolWidget(v.VueTemplate):
 
     def reset_view(self):
         print("in reset_view within selection_tool_widget.py")
-        self.set_sdss_12()
+        self.set_background()
         self.widget.center_on_coordinates(
             self.START_COORDINATES, fov=FULL_FOV, instant=True
         )

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
@@ -165,6 +165,25 @@
         </template>
         Reset view
       </v-tooltip>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            fab
+            dark
+            top
+            left
+            absolute
+            style="margin-top: 96px"
+            color="var(--success-dark)"
+            class="selection-fab black--text"
+            v-bind="attrs"
+            v-on="on"
+            @click="toggle_background()">
+            <v-icon>mdi-image-multiple</v-icon>
+          </v-btn>
+        </template>
+        {{ `Use ${background === 'SDSS 12' ? 'DSS' : 'SDSS'} Images` }}
+      </v-tooltip>
     </div>
   </v-card>
 </template>


### PR DESCRIPTION
This PR adds a button that allows toggling the background imageset between DSS and SDSS in the selection and distance tools. Whichever background the student has used will be the one that the widget attempts to set on each update trigger. This PR is built on #755.