### PR TITLE
Update wwt viewer buttons and guidelines on demo

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
+++ b/src/hubbleds/pages/01-spectra-&-velocity/guidelines/GuidelineSelectGalaxies2.vue
@@ -75,6 +75,13 @@
         </v-btn>
         to reset the view and choose a different green dot.
       </p>
+      <p style="font-weight: 300">
+        If the galaxy image doesn't load correctly (and it remains very blurry), click 
+        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #CCCCCC;">
+          <v-icon style="color:black!important;">mdi-refresh</v-icon>
+        </v-btn>
+        to reload.
+      </p>     
     </div>
     <div v-if="state_view.total_galaxies ==5">
       <p>

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas2.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas2.vue
@@ -14,6 +14,13 @@
       <p>
         If you zoom towards or away from your galaxy, notice that the angular scale (marked by the light blue line on the left) changes.
       </p>
+      <p style="font-weight: 300">
+        If the galaxy image doesn't load correctly (and it remains very blurry), click 
+        <v-btn icon dark x-small disabled class="mx-1 black--text" elevation="2" style="background-color: #CCCCCC;">
+          <v-icon style="color:black!important;">mdi-refresh</v-icon>
+        </v-btn>
+        to reload.
+      </p>  
     </div>
   </scaffold-alert>
 </template>

--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -90,7 +90,7 @@
             right
             absolute
             style="margin-top: 96px"
-            color="var(--success-dark)"
+            color="#CCCCCC"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
@@ -99,25 +99,6 @@
           </v-btn>
         </template>
         Refresh images
-      </v-tooltip>
-      <v-tooltip top>
-        <template v-slot:activator="{ on, attrs }">
-          <v-btn
-            fab
-            dark
-            top
-            left
-            absolute
-            style="margin-top: 96px"
-            color="var(--success-dark)"
-            class="selection-fab black--text"
-            v-bind="attrs"
-            v-on="on"
-            @click="toggle_background()">
-            <v-icon>mdi-image-multiple</v-icon>
-          </v-btn>
-        </template>
-        {{ `Use ${background === 'SDSS9 color' ? 'DSS' : 'SDSS'} Images` }}
       </v-tooltip>
     </div>
     <contrast-brightness-control 

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.vue
@@ -174,58 +174,39 @@
             right
             absolute
             style="margin-top: 96px"
-            color="var(--success-dark)"
+            color="#CCCCCC"
             class="selection-fab black--text"
             v-bind="attrs"
             v-on="on"
+            v-show="Object.keys(candidate_galaxy).length !== 0"
             @click="clear_tile_cache()">
             <v-icon>mdi-refresh</v-icon>
           </v-btn>
         </template>
         Refresh images
       </v-tooltip>
-
-      <v-tooltip top>
-        <template v-slot:activator="{ on, attrs }">
-          <v-btn
-            fab
-            dark
-            top
-            left
-            absolute
-            style="margin-top: 96px"
-            color="var(--success-dark)"
-            class="selection-fab black--text"
-            v-bind="attrs"
-            v-on="on"
-            @click="toggle_background()">
-            <v-icon>mdi-image-multiple</v-icon>
-          </v-btn>
-        </template>
-        {{ `Use ${background === 'SDSS9 color' ? 'DSS' : 'SDSS'} Images` }}
-      </v-tooltip>
     </div>
   </v-card>
 </template>
 
 <style scoped>
-//#selection-root {
-//  --toolbar-height: 48px;
-//  --widget-height: 400px;
-//  height: calc(var(--toolbar-height) + var(--widget-height));
-//  width: 100%;
-//}
+/* #selection-root {
+  --toolbar-height: 48px;
+  --widget-height: 400px;
+  height: calc(var(--toolbar-height) + var(--widget-height));
+  width: 100%;
+} */
 
 .selection-content {
   width: 100%;
   height: 400px;
 }
 
-//.wwt-widget {
-//  height: 400px;
-//  width: 100%;
-//  position: absolute;
-//}
+/* .wwt-widget {
+  height: 400px;
+  width: 100%;
+  position: absolute;
+} */
 
 .selection-fab {
   --margin: 15px;


### PR DESCRIPTION
This removes the toggle to DSS since SDSS9 now loads so quickly; makes to refresh button drab gray since we hope no one will really need it, so it can be less prominent; updates guideline text to explain what refresh button does.