### PR TITLE
Fix issue with Doppler slideshow MathJax on a refresh

### DIFF
--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -954,8 +954,13 @@ mjx-mpadded {
 
 <script>
 export default {
+  mounted() {
+    this.refreshMathJax([this.$el]);
+  },
+
   methods: {
     mathJaxObserver(entries, _observer, intersecting) {
+      console.log("mjax observer");
       if (intersecting) {
         this.$nextTick(() => {
           this.refreshMathJax(entries.map(entry => entry.target));
@@ -969,9 +974,14 @@ export default {
     },
 
     refreshMathJax(containers) {
-      const containersToReset = containers.filter(this.containsMathJax);
-      this.removeMathJax(containersToReset);
-      this.$nextTick(() => MathJax.typesetPromise(containersToReset));
+      window.MathJax.startup.promise.then(() => {
+        const containersToReset = containers.filter(this.containsMathJax);
+        console.log(containersToReset);
+        console.log("mjax");
+        console.log(MathJax);
+        this.removeMathJax(containersToReset);
+        this.$nextTick(() => MathJax.typesetPromise(containersToReset));
+      });
     },
 
     containsMathJax(container) {

--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -960,7 +960,6 @@ export default {
 
   methods: {
     mathJaxObserver(entries, _observer, intersecting) {
-      console.log("mjax observer");
       if (intersecting) {
         this.$nextTick(() => {
           this.refreshMathJax(entries.map(entry => entry.target));
@@ -976,9 +975,6 @@ export default {
     refreshMathJax(containers) {
       window.MathJax.startup.promise.then(() => {
         const containersToReset = containers.filter(this.containsMathJax);
-        console.log(containersToReset);
-        console.log("mjax");
-        console.log(MathJax);
         this.removeMathJax(containersToReset);
         this.$nextTick(() => MathJax.typesetPromise(containersToReset));
       });

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -759,12 +759,20 @@ def Page():
                     if COMPONENT_STATE.value.current_step == Marker.rem_vel1:
                         add_example_measurements_to_glue()
 
+                @computed
+                def doppler_dialog_flag():
+                    return COMPONENT_STATE.value.show_doppler_dialog and loaded_component_state.value
+
                 DopplerSlideshow(
-                    dialog=COMPONENT_STATE.value.show_doppler_dialog,
+                    dialog=doppler_dialog_flag.value,
                     titles=COMPONENT_STATE.value.doppler_state.titles,
                     step=COMPONENT_STATE.value.doppler_state.step,
                     length=COMPONENT_STATE.value.doppler_state.length,
-                    lambda_obs=round(COMPONENT_STATE.value.obs_wave),
+                    lambda_obs=(
+                        selected_example_measurement.value.obs_wave_value
+                        if selected_example_measurement.value is not None
+                        else None
+                    ),
                     lambda_rest=(
                         selected_example_measurement.value.rest_wave_value
                         if selected_example_measurement.value is not None


### PR DESCRIPTION
This PR delays displaying the Doppler dialog until the component state has loaded and makes a few Promise-based tweaks to the slideshow template that seem to fix #735 for me.