### PR TITLE
Exclude Doppler dialog flag from model dump

### DIFF
--- a/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
+++ b/src/hubbleds/components/doppler_slideshow/SlideshowDopplerCalc5.vue
@@ -727,7 +727,7 @@
                 <div
                     class="font-weight-medium mt-3"
                 >
-                  Click <b>DONE</b> to close this pop-up window. The velocity will be filled in in the table for this
+                  Click <b>DONE</b> to close this pop-up window. The velocity will be entered in the table for this
                   galaxy.
                 </div>
               </v-card>
@@ -876,6 +876,10 @@
             color="accent"
             elevation="2"
             @click="() => {
+              // If we've already passed this step before, just advance to next step because we've already validated in the past
+              if (max_step_completed_5 > 4) {
+                set_step(step + 1);
+              }
               if (validateLightSpeed(['speed_light'])) {
                 set_student_c(parseAnswer(['speed_light']));
                 storeStudentVel(parseAnswer(['speed_light']), [lambda_obs, lambda_rest]);
@@ -883,7 +887,7 @@
               }
           }"
         >
-          calculate
+          {{ (max_step_completed_5 <= 4) ? 'calculate' : 'next'}}
         </v-btn>
         <v-btn
             v-if="step === length-1"

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -171,10 +171,6 @@ class ComponentState(BaseComponentState, BaseState):
         return self.zoom_tool_activated
 
     @property
-    def che_mea1_gate(self) -> bool:
-        return self.doppler_state.velocity_calculated
-
-    @property
     def dot_seq1_gate(self) -> bool:
         return self.dotplot_tutorial_finished
     

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -102,7 +102,7 @@ class ComponentState(BaseComponentState, BaseState):
     zoom_tool_active: bool = False # is it currently on?
     doppler_calc_reached: bool = False
     obs_wave: float = 0
-    show_doppler_dialog: bool = False
+    show_doppler_dialog: bool = Field(False, exclude=True)
     doppler_state: DopplerCalculation = DopplerCalculation()
     show_dotplot_tutorial_dialog: bool = False
     dotplot_tutorial_state: DotPlotTutorial = DotPlotTutorial()


### PR DESCRIPTION
This PR implements the idea discussed in https://github.com/cosmicds/hubbleds/issues/735#issuecomment-2612897972 - that is, if the student refreshes the page with the Doppler slideshow open in stage 1, they need to manually reopen it again after refresh.

For me, the app comes back to `dop_cal5` after a refresh, but it's indistinguishable from `dop_cal4`, and hitting next opens the dialog. Closing the dialog without completing it brings me back to `dop_cal4`, and completing the dialog brings me to `che_mea1` (the next marker), all of which I believe is the intended behavior.