### PR TITLE
Avoid new issues in latest Solara version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,8 +65,8 @@ install_requires =
     pydantic
     python-dateutil
     reacton
-    solara
-    solara-enterprise
+    solara==1.41.0
+    solara-enterprise==1.41.0
     traitlets
 
 [options.packages.find]


### PR DESCRIPTION
We need to investigate the issues when using the latest Solara version. From what I can divine from the logs, it actually seems to be specifically an issue with `solara-enterprise`, which is the interface to the Auth0 authentication services. It is unclear why, but it seems to trigger a web socket connection closing and seems to have ramifications for the usability of the rest of the app.