### PR TITLE
Temporarily pin the cosmicds version to a supporting fork

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     importlib-metadata
     astropy<7.0
     authlib
-    cosmicds @ git+https://github.com/cosmicds/cosmicds.git
+    cosmicds @ git+https://github.com/nmearl/cosmicds.git@short-demo
     glue-core
     glue-jupyter
     glue-plotly[jupyter]>=0.9.0


### PR DESCRIPTION
This is a **temporary** fix to ensure the solara versions in hubbleds and cosmicds are synchronized.