### PR TITLE
Pin to the latest working version of solara

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     importlib-metadata
     astropy<7.0
     authlib
-    cosmicds @ git+https://github.com/nmearl/cosmicds.git@short-demo
+    cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
     glue-plotly[jupyter]>=0.9.0
@@ -65,8 +65,9 @@ install_requires =
     pydantic
     python-dateutil
     reacton
-    solara==1.41.0
-    solara-enterprise==1.41.0
+    solara==1.42.0
+    solara-enterprise==1.42.0
+    solara-ui @ git+https://github.com/nmearl/solara.git@v1.42
     traitlets
 
 [options.packages.find]


### PR DESCRIPTION
This PR pins solara to the latest working version of solara that avoids the solara-enterprise auth0 issue. Note that this should be merged **after** cosmicds/cosmicds#366.