### PR TITLE
Pin to the latest working version of solara

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,9 +65,9 @@ install_requires =
     pydantic
     python-dateutil
     reacton
-    solara==1.43.0
-    solara-ui @ git+https://github.com/nmearl/solara.git
-    solara-enterprise==1.43.0
+    solara==1.42.0
+    solara-enterprise==1.42.0
+    solara-ui @ git+https://github.com/nmearl/solara.git@v1.42
     traitlets
 
 [options.packages.find]


### PR DESCRIPTION
This PR pins solara to the latest working version that avoids the solara-enterprise and auth0 issue.