### PR TITLE
Make home tool for slider viewers not use only visible data

### DIFF
--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -135,6 +135,9 @@ def Page():
             "class_hist": class_hist_viewer
         }
 
+        student_slider_viewer.state.reset_limits_from_visible = False
+        class_slider_viewer.state.reset_limits_from_visible = False
+
         two_hist_viewers = (all_student_hist_viewer, class_hist_viewer)
         for att in ('x_min', 'x_max'):
             link((all_student_hist_viewer.state, att), (class_hist_viewer.state, att))
@@ -292,7 +295,7 @@ def Page():
             viewer.figure.update_layout(hovermode="closest")
 
         for viewer in viewers.values():
-            viewer.state.reset_limits(visible_only=True)
+            viewer.state.reset_limits()
 
         gjapp.data_collection.hub.subscribe(gjapp.data_collection, NumericalDataChangedMessage,
                                             handler=partial(_update_bins, two_hist_viewers),
@@ -327,8 +330,7 @@ def Page():
         # viewer's limits
         if name == "class_hist":
             continue
-        visible_only = "slider" not in name
-        viewer.state.reset_limits(visible_only=visible_only)
+        viewer.state.reset_limits()
 
     def show_class_data(marker):
         if "Class Data" in GLOBAL_STATE.value.glue_data_collection:
@@ -574,7 +576,7 @@ def Page():
                 student_slider_subset.style.markersize = 12
                 if not student_slider_setup:
                     viewer = viewers["student_slider"]
-                    viewer.state.reset_limits(visible_only=False)
+                    viewer.state.reset_limits()
                     viewer.toolbar.tools["hubble:linefit"].activate()
                     set_student_slider_setup(True)
 
@@ -644,7 +646,7 @@ def Page():
                 class_slider_subset.style.color = color
                 if not class_slider_setup:
                     viewer = viewers["class_slider"]
-                    viewer.state.reset_limits(visible_only=False)
+                    viewer.state.reset_limits()
                     viewer.toolbar.tools["hubble:linefit"].activate()
                     set_class_slider_setup(True)
 

--- a/src/hubbleds/viewers/hubble_fit_viewer.py
+++ b/src/hubbleds/viewers/hubble_fit_viewer.py
@@ -1,4 +1,4 @@
-from echo import delay_callback, add_callback
+from echo import delay_callback
 from glue_plotly.viewers.scatter import PlotlyScatterView
 from .hubble_scatter_viewer import HubbleScatterViewerState
 from cosmicds.viewers import cds_viewer
@@ -10,7 +10,7 @@ __all__ = [
 
 class HubbleFitViewerState(HubbleScatterViewerState):
     
-    def reset_limits(self, visible_only=True):
+    def reset_limits(self, visible_only=None):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             super().reset_limits(visible_only=visible_only)
             if self.x_max is not None:

--- a/src/hubbleds/viewers/hubble_histogram_viewer.py
+++ b/src/hubbleds/viewers/hubble_histogram_viewer.py
@@ -11,7 +11,7 @@ __all__ = [
 
 class HubbleHistogramViewerState(CDSHistogramViewerState):
 
-    def reset_limits(self, visible_only=True):
+    def reset_limits(self, visible_only=None):
         with delay_callback(self, 'x_min', 'x_max'):
             super().reset_limits(visible_only=visible_only)
             self.x_min = round(self.x_min, 0) - 2.5 if self.x_min is not None else 0

--- a/src/hubbleds/viewers/hubble_scatter_viewer.py
+++ b/src/hubbleds/viewers/hubble_scatter_viewer.py
@@ -9,7 +9,7 @@ __all__ = [
 
 class HubbleScatterViewerState(CDSScatterViewerState):
 
-    def reset_limits(self, visible_only=True):
+    def reset_limits(self, visible_only=None):
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             super().reset_limits(visible_only=visible_only)
             self.x_min = min(self.x_min, 0) if self.x_min is not None else 0


### PR DESCRIPTION
This PR updates our viewers so that the slider viewers in stage 5 will not use only the visible values, but the entire data set, for resetting their limits. This relies on https://github.com/cosmicds/cosmicds/pull/368.