### PR TITLE
Exclude student data from class measurements request on demo

### DIFF
--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -301,7 +301,7 @@ class LocalAPI(BaseAPI):
         url = (
             f"{self.API_URL}/{local_state.value.story_id}/class-measurements/"
             f"{global_state.value.student.id}/{global_state.value.classroom.class_info['id']}"
-            f"?complete_only=true"
+            f"?complete_only=true&exclude_student=true"
         )
         r = self.request_session.get(url)
         measurement_json = r.json()


### PR DESCRIPTION
This PR uses the `exclude_student` query parameter added to the `/class-measurements` endpoint in https://github.com/cosmicds/cds-api/pull/171 to resolve #797.