### PR TITLE
Only create SDSS table layer once

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -25,7 +25,8 @@ def SelectionTool(
                 table_layer_data={
                     k: [x.dict()[k] for x in LOCAL_STATE.value.galaxies.values()]
                     for k in ["id", "ra", "decl"]
-                }
+                },
+                show_galaxies=show_galaxies,
             )
 
             tool_widget = solara.get_widget(tool_container)

--- a/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
+++ b/src/hubbleds/widgets/selection_tool_widget/selection_tool_widget.py
@@ -125,13 +125,19 @@ class SelectionToolWidget(v.VueTemplate):
 
     def show_galaxies(self, show=True):
         self.set_sdss()
-        if self.sdss_layer is not None:
-            if self.sdss_layer in self.widget.layers._layers:
-                self.widget.layers.remove_layer(self.sdss_layer)
-                self.sdss_layer = None
+        # if self.sdss_layer is not None:
+        #     if self.sdss_layer in self.widget.layers._layers:
+        #         self.widget.layers.remove_layer(self.sdss_layer)
+        #         self.sdss_layer = None
 
-        if show and self.sdss_layer is None:
-            layer = self.widget.layers.add_table_layer(self.sdss_table, marker_type="gaussian", size_scale=100, color="#00FF00", marker_scale="screen")
+        opacity = int(show)
+        if self.sdss_layer is None:
+            layer = self.widget.layers.add_table_layer(self.sdss_table,
+                                                       marker_type="gaussian",
+                                                       size_scale=100,
+                                                       color="#00FF00",
+                                                       marker_scale="screen",
+                                                       opacity=opacity)
                                                         
             # self.widget.layers.add_table_layer(self.sdss_table)
             # #try passing these as kwargs to add_table_layer.
@@ -139,6 +145,8 @@ class SelectionToolWidget(v.VueTemplate):
             # layer.size_scale = 100
             # layer.color = "#00FF00"
             self.sdss_layer = layer
+        else:
+            self.sdss_layer.opacity = opacity
 
     @property
     def on_galaxy_selected(self):


### PR DESCRIPTION
This is an attempt to resolve #746. As I was investigating I realized that we were deleting and re-creating the SDSS layer each time we wanted to show/hide it, which is unnecessary (it's always the same) and adds a lot more back-and-forth message passing to WWT.

This PR updates the selection tool widget to only create the SDSS layer once - we then show/hide it by adjusting the opacity. At least for me locally, this has removed the issue of the green dots not loading for me. This has been a pretty finicky problem at times, though, so if anyone else could try this on their machine I'd appreciate it.