### PR TITLE
Dynamically set dotplot bin spacing and restore hover text

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -281,7 +281,7 @@ footer .v-card__text {
 
 /* Hides the wavelength marker tracking the trace */
 div.plotly .hoverlayer g.hovertext {
-    display: none;
+    /* display: none; */
 }
 
  

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/DotplotTutorialSlideshow.vue
@@ -145,7 +145,7 @@
           class="black--text"
           color="accent"
           depressed
-          @click="step--"
+          @click="set_step(step-1)"
         >
           Back
         </v-btn>
@@ -175,7 +175,7 @@
           color="accent"
           class="black--text"
           depressed
-          @click="() => { step++; }"
+          @click="() => { set_step(step+1); }"
         >
           {{ step < length-1 ? 'next' : '' }}
         </v-btn>

--- a/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
+++ b/src/hubbleds/components/dotplot_tutorial_slideshow/dotplot_tutorial_slideshow.py
@@ -11,5 +11,6 @@ def DotplotTutorialSlideshow(
     dotplot_viewer: Any,
     event_tutorial_finished: Callable,
     event_show_dialog: Callable,
+    event_set_step: Callable,
 ):
     pass

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -176,20 +176,20 @@ def DotplotViewer(
             
             
             
-            # for layer in dotplot_view.layers:
-            #     for trace in layer.traces():
-            #         trace.update(hoverinfo="skip", hovertemplate=None)
+            for layer in dotplot_view.layers:
+                for trace in layer.traces():
+                    trace.update(hoverinfo="skip", hovertemplate=None)
 
             # this doesn't even get run;
-            # def no_hover_update(self: DotplotScatterLayerArtist):
-            #     logger.info(f"{title}: no_hover_update")
-            #     hide_ignored_layers()
-            #     with dotplot_view.figure.batch_update():
-            #         _original_update_data(self)
-            #         for trace in self.traces():
-            #             trace.update(hoverinfo="skip", hovertemplate=None)
-            #         self._update_zorder()
-            # DotplotScatterLayerArtist._update_data = no_hover_update
+            def no_hover_update(self: DotplotScatterLayerArtist):
+                logger.info(f"{title}: no_hover_update")
+                hide_ignored_layers()
+                with dotplot_view.figure.batch_update():
+                    _original_update_data(self)
+                    for trace in self.traces():
+                        trace.update(hoverinfo="skip", hovertemplate=None)
+                    self._update_zorder()
+            DotplotScatterLayerArtist._update_data = no_hover_update
             
                 
             def get_layer(layer_name):
@@ -284,6 +284,10 @@ def DotplotViewer(
                 yaxis=dict(
                     tickmode="auto",
                     titlefont_size=16,
+                ),
+                hoverlabel=dict(
+                    bgcolor="white",
+                    font_size=16,
                 ),
             )
             

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -126,9 +126,9 @@ def DotplotViewer(
         
         def _add_vertical_line(viewer: PlotlyBaseView, value: Number, color: str, label: str = None, line_ids: list[str] = []):
             line_id = str(uuid4())
-            print(line_id)
+            # print(line_id)
             line_ids.append(line_id)
-            viewer.figure.add_vline(x=value, line_color=color, line_width=2, name=line_id)
+            viewer.figure.add_vline(x=value, line_color=color, line_width=2, name=line_id, visible = vertical_line_visible.value)
 
         
         def _add_data(viewer: PlotlyBaseView, data: Union[Data, tuple]):

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -270,6 +270,7 @@ def DotplotViewer(
                 margin=PLOTLY_MARGINS,
                 showlegend=False,
                 hovermode="x",
+                clickmode="event",
                 spikedistance=-1,
                 xaxis=dict(
                     spikecolor="black",
@@ -302,10 +303,10 @@ def DotplotViewer(
 
                 
                 
-            dotplot_view.figure.update_layout(clickmode="event", hovermode="closest", showlegend=False)
+
             dotplot_view.selection_layer.on_click(on_click)
             unit_str = f" {unit}" if unit else ""
-            dotplot_view.selection_layer.update(hovertemplate=f"%{{x:,.0f}}{unit_str}<extra></extra>")
+            dotplot_view.selection_layer.update(hovertemplate=f"%{{x:,.0f}}{unit_str}<extra></extra>", hoverinfo="x")
             def reset_selection():
                 dotplot_view.set_selection_active(True)
                 # special treatment for go.Heatmap from https://stackoverflow.com/questions/58630928/how-to-hide-the-colorbar-and-legend-in-plotly-express-bar-graph#comment131880779_68555667

--- a/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
+++ b/src/hubbleds/components/dotplot_viewer/dotplot_viewer.py
@@ -65,6 +65,7 @@ def DotplotViewer(
     x_label: Optional[str] = None,
     y_label: Optional[str] = None,
     nbin: int = 75,
+    nbin_func: Optional[Callable] = None,
     x_bounds: list[float] = [],  # type: ignore
     on_x_bounds_changed: Callable = lambda x: None,
     reset_bounds: list = [],  # type: ignore
@@ -170,6 +171,8 @@ def DotplotViewer(
                     dotplot_view.state.x_min = x_bounds.value[0]
                     dotplot_view.state.x_max = x_bounds.value[1]
             
+            if nbin_func is not None:
+                dotplot_view.state.hist_n_bin = nbin_func(dotplot_view.state.x_min, dotplot_view.state.x_max)   
             
             
             
@@ -305,7 +308,6 @@ def DotplotViewer(
                 dotplot_view.selection_layer.update(visible=True, z = [list(range(201))], opacity=0, coloraxis='coloraxis')
                 dotplot_view.figure.update_coloraxes(showscale=False)
             
-
             
             
             def _on_reset_bounds(*args):
@@ -359,11 +361,15 @@ def DotplotViewer(
                 
             line_marker_at.subscribe(lambda new_val: _update_lines(value = new_val))
             vertical_line_visible.subscribe(lambda new_val: _update_lines())
+            def reset_hist_n_bin():
+                if nbin_func is not None:
+                    dotplot_view.state.hist_n_bin = nbin_func(dotplot_view.state.x_min, dotplot_view.state.x_max)
             def update_x_bounds(new_val):
                 logger.info(f"{title}: Updating x_bounds")
                 if new_val is not None and len(new_val) == 2:
                     dotplot_view.state.x_min = new_val[0]
                     dotplot_view.state.x_max = new_val[1]
+                reset_hist_n_bin()
                 reset_selection()
             x_bounds.subscribe(update_x_bounds)
             

--- a/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
+++ b/src/hubbleds/components/spectrum_viewer/spectrum_viewer.py
@@ -194,6 +194,7 @@ def SpectrumViewer(
                             width=2,
                         ),
                       mode='lines', 
+                      hoverinfo="x"
                     ))
          
         fig.update_layout(

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -939,6 +939,7 @@ def Page():
                         event_show_dialog=lambda v: Ref(
                             COMPONENT_STATE.fields.show_dotplot_tutorial_dialog
                         ).set(v),
+                        event_set_step = Ref(COMPONENT_STATE.fields.dotplot_tutorial_state.step).set,
                     )
                 
     # Dot Plot 1st measurement row

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -64,6 +64,14 @@ def is_wavelength_poorly_measured(measwave, restwave, z, tolerance = 0.5):
     fractional_difference = (((z_meas - z) / z)** 2)**0.5
     return fractional_difference > tolerance
 
+def nbin_func(xmin, xmax):
+    # full range is 246422.9213488496
+    frac_range = (xmax - xmin) / 246423
+    max_bins = 100
+    min_bins = 30
+    power = 1.5 # 
+    return 30 + int((frac_range ** power) * (max_bins - min_bins))
+
 @solara.component
 def Page():
     solara.Title("HubbleDS")
@@ -1047,6 +1055,7 @@ def Page():
                         x_label="Velocity (km/s)",
                         y_label="Count",
                         nbin=30,
+                        nbin_func=nbin_func,
                         x_bounds=dotplot_bounds.value,
                         on_x_bounds_changed=dotplot_bounds.set,
                         reset_bounds=list(


### PR DESCRIPTION
Allow dynamic setting of bin spacing based on the selected range,

Restore hover text

Fixes #841