### PR TITLE
Pin to plotly.py 5.x for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ install_requires =
     itsdangerous
     numpy<2.0.0
     pandas
+    plotly<6.0.0a0
     pydantic
     python-dateutil
     reacton


### PR DESCRIPTION
This PR pins our version of plotly.py to 5.x until we have a chance to update our Plotly config changes to be compatible with plotly.py 6.