### PR TITLE
don't display synced lines until after first click

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -358,7 +358,7 @@ def Page():
 
     @computed
     def show_synced_lines():
-        return Ref(COMPONENT_STATE.fields.current_step).value.value >= Marker.dot_seq5.value
+        return Ref(COMPONENT_STATE.fields.current_step).value.value >= Marker.dot_seq5.value and Ref(COMPONENT_STATE.fields.dotplot_click_count).value > 0
 
     
     ## ----- Make sure we are initialized in the correct state ----- ##
@@ -402,7 +402,8 @@ def Page():
     solara.use_effect(_reactive_subscription_setup, dependencies=[])
 
     
-    def dotlpot_click_callback(point):
+    def dotplot_click_callback(point):
+            Ref(COMPONENT_STATE.fields.dotplot_click_count).set(COMPONENT_STATE.value.dotplot_click_count + 1)
             sync_velocity_line.set(point.xs[0])
             wavelength = sync_example_velocity_to_wavelength(point.xs[0])
             if wavelength:
@@ -1051,7 +1052,7 @@ def Page():
                         vertical_line_visible=show_synced_lines.value,
                         line_marker_at=sync_velocity_line.value,
                         line_marker_color=LIGHT_GENERIC_COLOR,
-                        on_click_callback=dotlpot_click_callback,
+                        on_click_callback=dotplot_click_callback,
                         unit="km / s",
                         x_label="Velocity (km/s)",
                         y_label="Count",

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -106,6 +106,7 @@ class ComponentState(BaseComponentState, BaseState):
     show_dotplot_tutorial_dialog: bool = False
     dotplot_tutorial_state: DotPlotTutorial = DotPlotTutorial()
     dotplot_tutorial_finished: bool = False
+    dotplot_click_count: int = 0
     has_bad_velocities: bool = False
     has_multiple_bad_velocities: bool = False
     obs_wave_total: int = 0


### PR DESCRIPTION
The synced lines were appearing on the viewer, initialized at 0 when the user first goes to the correct guideline. This PR hides the lines until the user clicks on one of the viewers. 

I guess there is an issue where if the user decides to click in the spectrum viewer first, nothing will happen. Since the instructions invite them to click in the velocity dot plot first, I think this is ok? What do you think @johnarban?