### PR TITLE
Use dict instead of json to avoid NaN to None conversion

### DIFF
--- a/src/hubbleds/remote.py
+++ b/src/hubbleds/remote.py
@@ -442,7 +442,7 @@ class LocalAPI(BaseAPI):
         path = (Path(__file__).parent / "data" / "ExampleGalaxyDataFromStudents.csv").as_posix()
         # with open(path, 'r') as f:
         #     res_json = json.load(f)
-        res_json = json.loads(read_csv(path).to_json(orient='records'))
+        res_json = read_csv(path).to_dict(orient='records')
         
         seq = SeedSequence(70)
         gen = Generator(PCG64(seq))


### PR DESCRIPTION
Fix #850 - per @Carifio24 - The conversion to None causes glue to read in the column as categorical.