### PR TITLE
Unify example data loading and fix tutorial data issues

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -48,8 +48,8 @@ from hubbleds.utils import (
 from hubbleds.example_measurement_helpers import (
     create_example_subsets,
     link_example_seed_and_measurements,
-    link_seed_data,
-    _update_second_example_measurement
+    _update_second_example_measurement,
+    load_and_create_seed_data,
 )
 
 logger = setup_logger("STAGE")
@@ -120,45 +120,7 @@ def Page():
         )
 
         if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
-            example_seed_data = LOCAL_API.get_example_seed_measurement(LOCAL_STATE, which='both')
-            
-            data = Data(
-                label=EXAMPLE_GALAXY_SEED_DATA,
-                **{
-                    k: np.asarray([r[k] for r in example_seed_data])
-                    for k in example_seed_data[0].keys()
-                }
-            )
-            gjapp.data_collection.append(data)
-            # create 'first measurement' and 'second measurement' datasets
-            # create_measurement_subsets(gjapp, data)
-            first = Data(label = EXAMPLE_GALAXY_SEED_DATA + '_first', 
-                         **{k: np.asarray([r[k] for r in example_seed_data if r['measurement_number'] == 'first'])
-                            for k in example_seed_data[0].keys()}
-                            )
-            first.style.color = GENERIC_COLOR
-            gjapp.data_collection.append(first)
-            second = Data(label = EXAMPLE_GALAXY_SEED_DATA + '_second', 
-                         **{k: np.asarray([r[k] for r in example_seed_data if r['measurement_number'] == 'second'])
-                            for k in example_seed_data[0].keys()}
-                            )
-            second.style.color = GENERIC_COLOR
-            gjapp.data_collection.append(second)
-            
-            np.random.seed(42)
-            # 50% of the first measurements will be used for the tutorial
-            tutorial_data = [e for e in example_seed_data if np.random.rand() <= 0.5]
-            # filter some of the correct values to reduce counts
-            filter_func = lambda x: (x < 11_130 or x > 11_220) or np.random.rand() <= 0.75
-            tutorial_data = [e for e in tutorial_data if filter_func(e['velocity_value'])]
-            tutorial = Data(label = EXAMPLE_GALAXY_SEED_DATA + '_tutorial',
-                            **{k: np.asarray([r[k] for r in tutorial_data])
-                               for k in example_seed_data[0].keys()}
-                            )
-            tutorial.style.color = GENERIC_COLOR
-            gjapp.data_collection.append(tutorial)
-            
-            link_seed_data(gjapp)
+            load_and_create_seed_data(gjapp, LOCAL_STATE)
         
         return gjapp
 

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -66,7 +66,7 @@ from hubbleds.example_measurement_helpers import (
     create_example_subsets,
     link_example_seed_and_measurements,
     _update_second_example_measurement,
-    link_seed_data
+    load_and_create_seed_data
 )
 
 
@@ -202,26 +202,7 @@ def Page():
         
         # Get the example seed data
         if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
-            example_seed_data = LOCAL_API.get_example_seed_measurement(LOCAL_STATE, which = 'both')
-            data = Data(label=EXAMPLE_GALAXY_SEED_DATA, **{k: asarray([r[k] for r in example_seed_data]) for k in example_seed_data[0].keys()})
-            gjapp.data_collection.append(data)
-            
-            # create 'first measurement' and 'second measurement' datasets
-            # create_measurement_subsets(gjapp, data)
-            first = Data(label = EXAMPLE_GALAXY_SEED_DATA + '_first', 
-                         **{k: asarray([r[k] for r in example_seed_data if r['measurement_number'] == 'first'])
-                            for k in example_seed_data[0].keys()}
-                            )
-            first.style.color = GENERIC_COLOR
-            gjapp.data_collection.append(first)
-            second = Data(label = EXAMPLE_GALAXY_SEED_DATA + '_second', 
-                         **{k: asarray([r[k] for r in example_seed_data if r['measurement_number'] == 'second'])
-                            for k in example_seed_data[0].keys()}
-                            )
-            second.style.color = GENERIC_COLOR
-            gjapp.data_collection.append(second)
-            
-            link_seed_data(gjapp)
+            load_and_create_seed_data(gjapp, LOCAL_STATE)
         measurements_setup.set(True)
         
         return gjapp

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -1,4 +1,5 @@
 import solara
+from solara.lab import computed
 
 
 from reacton import ipyvuetify as rv
@@ -167,6 +168,7 @@ def DistanceToolComponent(galaxy,
 @solara.component
 def Page():
     solara.Title("HubbleDS")
+    print("Stage 3")
     
     # === Setup State Loading and Writing ===
     loaded_component_state = solara.use_reactive(False)
@@ -372,9 +374,9 @@ def Page():
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")
    
         
-    @solara.lab.computed
+    @computed
     def use_second_measurement():
-        return COMPONENT_STATE.value.current_step_at_or_after(Marker.dot_seq5)
+        return Ref(COMPONENT_STATE.fields.current_step).value >= Marker.dot_seq5
         
             
     def _update_distance_measurement(update_example: bool, galaxy, theta, measurement_number = 'first'):
@@ -418,9 +420,9 @@ def Page():
     fill_galaxy_pressed = solara.use_reactive(COMPONENT_STATE.value.distances_total >= 5)
     current_brightness = solara.use_reactive(1.0)
     
-    @solara.lab.computed
+    @computed
     def sync_dotplot_axes():
-        return COMPONENT_STATE.value.current_step_between(Marker.dot_seq1, Marker.dot_seq4a)
+        return Ref(COMPONENT_STATE.fields.current_step_between).value(Marker.dot_seq1, Marker.dot_seq4a)
     
     def setup_zoom_sync():
         
@@ -448,7 +450,7 @@ def Page():
     
     Ref(COMPONENT_STATE.fields.current_step).subscribe_change(_on_marker_updated)
 
-    @solara.lab.computed
+    @computed
     def example_galaxy_measurement_number():
         if use_second_measurement.value:
             return 'second'
@@ -538,18 +540,18 @@ def Page():
             current_step = Ref(COMPONENT_STATE.fields.current_step)
             current_step.subscribe(show_ruler_range)
 
-            @solara.lab.computed
+            @computed
             def on_example_galaxy_marker():
-                return COMPONENT_STATE.value.current_step.value <= Marker.dot_seq5c.value
+                return Ref(COMPONENT_STATE.fields.current_step).value <= Marker.dot_seq5c
 
-            @solara.lab.computed
+            @computed
             def current_galaxy():
                 if on_example_galaxy_marker.value:
-                    return COMPONENT_STATE.value.selected_example_galaxy
+                    return Ref(COMPONENT_STATE.fields.selected_example_galaxy).value
                 else:
-                    return COMPONENT_STATE.value.selected_galaxy
+                    return Ref(COMPONENT_STATE.fields.selected_galaxy).value
 
-            @solara.lab.computed
+            @computed
             def current_data():
                 return LOCAL_STATE.value.example_measurements if on_example_galaxy_marker.value else LOCAL_STATE.value.measurements
 
@@ -786,15 +788,15 @@ def Page():
                     if COMPONENT_STATE.value.is_current_step(Marker.cho_row1):
                         transition_to(COMPONENT_STATE, Marker.ang_siz2)
                 
-                @solara.lab.computed
+                @computed
                 def selected_example_galaxy_index() -> list:
-                    if COMPONENT_STATE.value.selected_example_galaxy is None:
+                    if Ref(COMPONENT_STATE.fields.selected_example_galaxy).value is None:
                         return []
-                    if 'id' not in COMPONENT_STATE.value.selected_example_galaxy:
+                    if 'id' not in Ref(COMPONENT_STATE.fields.selected_example_galaxy).value:
                         return []
                     return [0]
                 
-                @solara.lab.computed
+                @computed
                 def example_galaxy_data():
                     if use_second_measurement.value:
                         return [
@@ -828,17 +830,17 @@ def Page():
                     selected_galaxy = Ref(COMPONENT_STATE.fields.selected_galaxy)
                     selected_galaxy.set(value)
                 
-                @solara.lab.computed
+                @computed
                 def selected_galaxy_index():
                     try:
-                        return [LOCAL_STATE.value.get_measurement_index(COMPONENT_STATE.value.selected_galaxy["id"])]
+                        return [LOCAL_STATE.value.get_measurement_index(Ref(COMPONENT_STATE.fields.selected_galaxy).value["id"])]
                     except:
                         return []
 
-                @solara.lab.computed
+                @computed
                 def table_kwargs():
-                    ang_size_tot = COMPONENT_STATE.value.angular_sizes_total
-                    table_data = [s.model_dump(exclude={'galaxy': {'spectrum'}, 'measurement_number':True}) for s in LOCAL_STATE.value.measurements]
+                    ang_size_tot = Ref(COMPONENT_STATE.fields.angular_sizes_total).value
+                    table_data = [s.model_dump(exclude={'galaxy': {'spectrum'}, 'measurement_number':True}) for s in Ref(LOCAL_STATE.fields.measurements).value]
                     return {
                         "title": "My Galaxies",
                         "headers": common_headers, # + [{ "text": "Measurement Number", "value": "measurement_number" }],
@@ -848,7 +850,7 @@ def Page():
                         "selected_indices": selected_galaxy_index.value,
                         "show_select": True,
                         "button_icon": "mdi-tape-measure",
-                        "show_button": COMPONENT_STATE.value.current_step_at_or_after(Marker.fil_rem1),
+                        "show_button": Ref(COMPONENT_STATE.fields.current_step_at_or_after).value(Marker.fil_rem1),
                         "event_on_button_pressed": lambda _: fill_galaxy_distances()
                     }
 

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -253,14 +253,7 @@ def Page():
         logger.info('Initializing state')
         
         if COMPONENT_STATE.value.current_step.value >= Marker.cho_row1.value:
-            logger.info('Setting selected example galaxy')
             selected_example_galaxy = Ref(COMPONENT_STATE.fields.selected_example_galaxy)
-            if len(LOCAL_STATE.value.example_measurements) > 0:
-                logger.info('Setting selected example galaxy')
-                if COMPONENT_STATE.value.current_step_at_or_after(Marker.ang_siz2):
-                    num = 1 if COMPONENT_STATE.value.current_step_at_or_after(Marker.dot_seq5) else 0
-                    selected_example_galaxy.set(LOCAL_STATE.value.example_measurements[num].galaxy.model_dump(exclude={'spectrum'}))
-                    logger.info(f'Selected example galaxy on init: {selected_example_galaxy.value}')
         
         angular_sizes_total = 0
         for measurement in LOCAL_STATE.value.measurements:

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -188,7 +188,6 @@ class LocalState(BaseLocalState):
         if tag in self.free_responses['responses']:
             return self.free_responses['responses'][tag]['response'] != ""
         elif tag in self.mc_scoring['scores']:
-            print(self.mc_scoring['scores'][tag])
             return self.mc_scoring['scores'][tag]['score'] is not None
 
         return False


### PR DESCRIPTION
Fix #854: Move example data loading into a single function to address missing tutorial data when transitioning backwards between stages 3 and 1. 

Fix #856: Don't set example galaxy on init. this forces it to be set and prevents it from changing which can prevent the distance tool from going to it again

Fix bunch of computed references in stage 3.