### PR TITLE
Add example measurements to seed data

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -205,8 +205,6 @@ def Page():
     solara.use_memo(_glue_sync_setup, dependencies=[Ref(LOCAL_STATE.fields.measurements_loaded)])
 
     def _update_seed_data_with_examples(example_data):
-        print("Updating seed data")
-
         update_data = [
             [EXAMPLE_GALAXY_SEED_DATA, example_data],
             [EXAMPLE_GALAXY_SEED_DATA + "_first", [m for m in example_data if m.measurement_number == "first"]],

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -207,7 +207,6 @@ def Page():
             example_measurements.set([example_measurements.value[0], updated])
         else:
             logger.info('\t\t no changes for second measurement')
-        _update_seed_data_with_examples(example_measurements.value)
     
     def add_example_measurements_to_glue():
         logger.info('in add_example_measurements_to_glue')


### PR DESCRIPTION
This PR is intended to resolve #859. As glue doesn't support "stacked" histograms (and the dotplot is just a reskinned histogram), we decided in a dev meeting earlier this way to work around this by including the student measurements in the example data to fake the same effect.

Thus the approach here is to update the relevant glue `Data` objects with the example measurements whenever they're updated. To do this, we only keep existing elements of the data that aren't from the current student, then add the new measurement(s) and update the existing `Data` object. Note that since we're potentially changing the data's size, we can't call `update_components`. So what we do here instead is to create a new `Data` object with the updated components and then call `update_values_from_data`.