### PR TITLE
Include nodejs in EBS deployment requirements

### DIFF
--- a/.ebextensions/01_install.config
+++ b/.ebextensions/01_install.config
@@ -5,6 +5,7 @@ option_settings:
 packages:
   yum:
     git: []
+    nodejs: []
 
 commands:
   01_install:


### PR DESCRIPTION
Currently, the installation fails on EBS due to the fact that the new ipywwt widget builds the static files on the fly. This PR includes the nodejs installation requirements.