### PR TITLE
fix exploration tool css (short demo)

### DIFF
--- a/src/hubbleds/widgets/exploration_tool/exploration_tool.vue
+++ b/src/hubbleds/widgets/exploration_tool/exploration_tool.vue
@@ -62,7 +62,7 @@
 </template>
 
 <style scoped>
-#exploration-widget .p-Widget, iframe {
+#exploration-widget .p-Widget, #exploration-widget .p-Widget iframe {
   height: 350px !important;
   width: 100% !important;
 }


### PR DESCRIPTION
The current `exploration_tool.vue` just uses `#exploration-widget .p-Widget, iframe`. This would work if these were actually scoped components, but scoping doesn't seem to work. 

Instead if Introduction is run before the Stage 1, the SelectionTool is also forced to 350px, which causes an orange underlay to be visible below the SelectionTool. 