### PR TITLE
Fix unreadable text on light mode server error card

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -99,6 +99,14 @@ h4 {
     background-color: #FAFAFA;
 }
 
+.v-application.theme--light .server-error {
+    color: black !important;
+}
+
+.v-application.theme--dark .server-error {
+    color: white !important;
+}
+
 /* Captions have slightly less contrast than general text */
 .v-application .caption {
     font-size: 1rem !important;

--- a/src/hubbleds/templates/index.html.j2
+++ b/src/hubbleds/templates/index.html.j2
@@ -276,7 +276,7 @@
     <v-card style="border: 1px solid #DD2C00;">
         <v-card-title v-if="needsRefresh" class="text-h5 info">Trying to reconnect</v-card-title>
         <v-card-title v-else class="text-h5 info">Apologies, we encountered a problem</v-card-title>
-        <v-card-text class="mt-5">
+        <v-card-text class="mt-5 server-error">
             <v-progress-circular indeterminate size="50" class="center-self mb-3" style="text-align: center; justify-self: center;">
             </v-progress-circular>
             <p>


### PR DESCRIPTION
This fixes #908.

@johnarban helped me figure out that there is something applying `theme--dark` to the overlay component that we're using for the server error card, so the solution is to specify that any `.server-error` child of the `.v-application.theme--light` class should have black text. This prevents it from honoring the rogue `theme--dark` classes that get applied in between.