### PR TITLE
Exclude bad measurement flags from component state serialization

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -107,8 +107,8 @@ class ComponentState(BaseComponentState, BaseState):
     dotplot_tutorial_state: DotPlotTutorial = DotPlotTutorial()
     dotplot_tutorial_finished: bool = False
     dotplot_click_count: int = 0
-    has_bad_velocities: bool = False
-    has_multiple_bad_velocities: bool = False
+    has_bad_velocities: bool = Field(False, exclude=True)
+    has_multiple_bad_velocities: bool = Field(False, exclude=True)
     obs_wave_total: int = 0
     velocities_total: int = 0
     show_reflection_dialog: bool = False

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -1,7 +1,7 @@
 import solara
 import enum
 
-from pydantic import field_validator, computed_field
+from pydantic import field_validator, Field, computed_field
 
 from cosmicds.state import BaseState
 from hubbleds.base_marker import BaseMarker 
@@ -59,7 +59,7 @@ class ComponentState(BaseComponentState, BaseState):
     meas_theta: float = 0.0
     ruler_click_count: int = 0
     n_meas: int = 0
-    bad_measurement: bool = False
+    bad_measurement: bool = Field(False, exclude=True)
     distances_total: int = 0
     fill_est_dist_values: bool = False
     


### PR DESCRIPTION
This PR resolves #907 by excluding the various "bad measurement value" flags from component state serialization.