### PR TITLE
Stage 3 wait for WWT to load to allow advancing

### DIFF
--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -105,7 +105,7 @@ def DistanceToolComponent(galaxy,
                           guard_range
                           ):
 
-    wwt_ready = solara.use_reactive(False)
+    wwt_ready = Ref(COMPONENT_STATE.fields.wwt_ready)
     tool = DistanceTool.element()
 
     def set_selected_galaxy():

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -66,6 +66,7 @@ class ComponentState(BaseComponentState, BaseState):
     show_dotplot_lines: bool = True
     angular_size_line: Optional[float | int] = None
     distance_line: Optional[float | int] = None
+    wwt_ready: bool = Field(False, exclude=True)
     
     @computed_field
     @property
@@ -79,6 +80,10 @@ class ComponentState(BaseComponentState, BaseState):
         if isinstance(v, int):
             return Marker(v)
         return v
+    
+    @property
+    def cho_row1_gate(self) -> bool:
+        return self.wwt_ready    
 
     @property
     def ang_siz2_gate(self):

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas1.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas1.vue
@@ -15,6 +15,9 @@
         (Open/close menu with <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #172c4d; border-radius: 5px;"><v-icon style="color:white!important;">mdi-menu</v-icon></v-btn> above)
       </div>
     </template>
+    <template #before-next>
+      Viewer loading
+    </template>
     <div
       class="mb-4"
     >


### PR DESCRIPTION
It's less critical in Stage 3, but I think it's still useful to prevent the user from advancing before WWT is ready. Is this correct, @Carifio24?