### PR TITLE
Fix #902 -  Nones being added to sample data

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -185,7 +185,7 @@ def Page():
                 )[1]
 
             for component in data.main_components:
-                update[component.label].append(getattr(measurement, component.label, None))
+                update[component.label].append(getattr(measurement, component.label, None) or float('nan'))
 
         new_data = Data(label=data.label, **update)
         data.update_values_from_data(new_data)

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -185,7 +185,10 @@ def Page():
                 )[1]
 
             for component in data.main_components:
-                update[component.label].append(getattr(measurement, component.label, None) or float('nan'))
+                value = getattr(measurement, component.label, None)
+                if value is None:
+                    value = float('nan')
+                update[component.label].append(value)
 
         new_data = Data(label=data.label, **update)
         data.update_values_from_data(new_data)


### PR DESCRIPTION
By adding the example data directly to the sample data in `_update_seed_data_with_examples`, this circumvented the process @Carifio24 had put in place to take care of None values in the data. This fixes #902 by replacing `None` with `float('nan')` when adding it to data sample data. 
