### PR TITLE
Add "insurance policy" timeout to WWT gating

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -413,7 +413,7 @@ def Page():
 
     # Insurance policy
     async def _wwt_ready_timeout():
-        await asyncio.sleep(10)
+        await asyncio.sleep(7)
         Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
 
     solara.lab.use_task(_wwt_ready_timeout)

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -563,6 +563,13 @@ def Page():
                 on_wwt_ready=lambda: Ref(COMPONENT_STATE.fields.wwt_ready).set(True),
             )
             
+            # Insurance policy
+            async def _wwt_ready_timeout():
+                await asyncio.sleep(10)
+                Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
+
+            solara.use_task(_wwt_ready_timeout)
+            
             if show_snackbar.value:
                 solara.Info(label=LOCAL_STATE.value.snackbar_message)        
 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -410,8 +410,13 @@ def Page():
             selection_tool_bg_count.set(selection_tool_bg_count.value + 1)
 
     Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
-    
 
+    # Insurance policy
+    async def _wwt_ready_timeout():
+        await asyncio.sleep(10)
+        Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
+
+    solara.lab.use_task(_wwt_ready_timeout)
     
     with solara.Row():
         with solara.Column():
@@ -561,14 +566,7 @@ def Page():
                 deselect_galaxy_callback=_deselect_galaxy_callback,
                 candidate_galaxy=selection_tool_candidate_galaxy.value,
                 on_wwt_ready=lambda: Ref(COMPONENT_STATE.fields.wwt_ready).set(True),
-            )
-            
-            # Insurance policy
-            async def _wwt_ready_timeout():
-                await asyncio.sleep(10)
-                Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
-
-            solara.use_task(_wwt_ready_timeout)
+            ) 
             
             if show_snackbar.value:
                 solara.Info(label=LOCAL_STATE.value.snackbar_message)        

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -483,7 +483,7 @@ def Page():
 
     # Insurance policy
     async def _wwt_ready_timeout():
-        await asyncio.sleep(10)
+        await asyncio.sleep(7)
         Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
 
     solara.lab.use_task(_wwt_ready_timeout)

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -1,6 +1,7 @@
 import solara
 from solara.lab import computed
 
+import asyncio
 import numpy as np
 
 from reacton import ipyvuetify as rv
@@ -102,11 +103,18 @@ def DistanceToolComponent(galaxy,
                           brightness_callback,
                           reset_canvas,
                           background_counter,
-                          guard_range
+                          guard_range,
+                          on_wwt_ready=None,
                           ):
 
-    wwt_ready = Ref(COMPONENT_STATE.fields.wwt_ready)
+    wwt_ready = solara.use_reactive(False)
     tool = DistanceTool.element()
+
+    def _on_wwt_ready(ready):
+        if ready and (on_wwt_ready is not None):
+            on_wwt_ready()
+
+    wwt_ready.subscribe(_on_wwt_ready)
 
     def set_selected_galaxy():
         widget = solara.get_widget(tool)
@@ -473,6 +481,13 @@ def Page():
     
     Ref(COMPONENT_STATE.fields.current_step).subscribe_change(_on_marker_updated)
 
+    # Insurance policy
+    async def _wwt_ready_timeout():
+        await asyncio.sleep(10)
+        Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
+
+    solara.lab.use_task(_wwt_ready_timeout)
+
     @computed
     def example_galaxy_measurement_number():
         if use_second_measurement.value:
@@ -647,7 +662,8 @@ def Page():
                 brightness_callback=brightness_callback,
                 reset_canvas=reset_canvas.value,
                 background_counter=distance_tool_bg_count,
-                guard_range=example_guard_range if on_example_galaxy_marker.value else normal_guard_range
+                guard_range=example_guard_range if on_example_galaxy_marker.value else normal_guard_range,
+                on_wwt_ready=lambda: Ref(COMPONENT_STATE.fields.wwt_ready).set(True),
             )
             
             if COMPONENT_STATE.value.bad_measurement:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -105,7 +105,7 @@ def DistanceToolComponent(galaxy,
                           guard_range
                           ):
 
-    wwt_ready = solara.use_reactive(False)
+    wwt_ready = Ref(COMPONENT_STATE.fields.wwt_ready)
     tool = DistanceTool.element()
 
     def set_selected_galaxy():

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -66,6 +66,7 @@ class ComponentState(BaseComponentState, BaseState):
     show_dotplot_lines: bool = True
     angular_size_line: Optional[float | int] = None
     distance_line: Optional[float | int] = None
+    wwt_ready: bool = Field(False, exclude=True)
     
     @computed_field
     @property
@@ -79,6 +80,10 @@ class ComponentState(BaseComponentState, BaseState):
         if isinstance(v, int):
             return Marker(v)
         return v
+    
+    @property
+    def cho_row1_gate(self) -> bool:
+        return self.wwt_ready    
 
     @property
     def ang_siz2_gate(self):

--- a/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas1.vue
+++ b/src/hubbleds/pages/03-distance-measurements/guidelines/GuidelineAngsizeMeas1.vue
@@ -15,6 +15,9 @@
         (Open/close menu with <v-btn icon tile dark x-small disabled class="mx-1" elevation="2" style="background-color: #172c4d; border-radius: 5px;"><v-icon style="color:white!important;">mdi-menu</v-icon></v-btn> above)
       </div>
     </template>
+    <template #before-next>
+      Viewer loading
+    </template>
     <div
       class="mb-4"
     >


### PR DESCRIPTION
This PR resolves #928 by implementing the timeout described there via tasks in stages 1 and 3. Currently the time is set to 10 seconds, @patudom feel free to adjust that.

I think the simplest way to test that is to comment out the `on_wwt_ready` arguments into the selection/distance tool components and check that the gate is opened after the specified amount of time.