### PR TITLE
Prevent bad measurement banner from showing up

### DIFF
--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -129,6 +129,8 @@ class DistanceTool(v.VueTemplate):
 
     @observe('measuredDistance')
     def _on_measured_distance_changed(self, change):
+        if change["new"] == 0:
+            return
         fov = self.widget.get_fov()
         widget_height = self._height_from_pixel_str(self.widget.layout.height)
         ang_size = Angle(((change["new"] / widget_height) * fov))


### PR DESCRIPTION
Adds back a check for invalid measurement that results from a canvas reset. This was removed in 84d6c741ab61fc49c522c8db4b315fffbda34730.