### PR TITLE
demo: don't hide jump to stage 3 button

### DIFF
--- a/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
+++ b/src/hubbleds/components/stage_2_slideshow/Stage2Slideshow.vue
@@ -831,7 +831,7 @@
 
       <!-- first button below just being used for testing, delete when using live with students -->
       <v-btn
-        v-if="step < 12 && debug"
+        v-if="step < 12"
         class="demo-button"
         depressed
         @click="() => {


### PR DESCRIPTION
[This](https://github.com/cosmicds/cosmicds/pull/378) will make it the default to deploy hubbleds with `SHOW_TEAM_INTERFACE` and `DEBUG_MODE` to be false. This small change on the demo branch ensures that even with that change, all the jump buttons in the demo still appear.