### PR TITLE
Fix hook name in distance tool component

### DIFF
--- a/src/hubbleds/widgets/distance_tool/distance_tool.vue
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.vue
@@ -141,7 +141,7 @@ export default {
     resizeObserver.observe(this.canvas);
   },
 
-  unmounted() {
+  beforeDestroy() {
     window.removeEventListener('resize', this.handleResize);
     resizeObserver.unobserve(this.canvas);
   },


### PR DESCRIPTION
This PR renames `unmounted` -> `beforeDestroy` in the distance tool component.