### PR TITLE
Use Black Sky + SDSS for selection and distance tools

### DIFF
--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -4,8 +4,9 @@ import astropy.units as u
 import solara
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from ipywwt import WWTWidget
 from reacton import ipyvuetify as rv
+
+from hubbleds.widgets.hubble_wwt import HubbleWWTWidget
 
 from ...state import LOCAL_STATE
 from ...utils import GALAXY_FOV
@@ -148,7 +149,7 @@ def SelectionTool(
         """
         Add the WWT widget to the container.
         """
-        wwt_widget = WWTWidget(use_remote=True)
+        wwt_widget = HubbleWWTWidget(use_remote=True)
         wwt_widget.observe(lambda change: show_wwt.set(change["new"]), "_wwt_ready")
 
         wwt_widget_container = solara.get_widget(wwt_container)
@@ -249,7 +250,7 @@ def SelectionTool(
     solara.use_effect(_on_show_galaxies, dependencies=[show_galaxies])
 
     def _go_to_location(
-        wwt_widget: WWTWidget,
+        wwt_widget: HubbleWWTWidget,
         coords: SkyCoord,
         fov: u.Quantity,
         instant: Optional[bool] = None,

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -5,8 +5,9 @@ import ipyvue as v
 from astropy.coordinates import Angle, SkyCoord
 from cosmicds.utils import RepeatedTimer, load_template
 from ipywidgets import DOMWidget, widget_serialization
-from ipywwt import WWTWidget
 from traitlets import Instance, Bool, Float, Int, Unicode, observe, Dict
+
+from hubbleds.widgets.hubble_wwt import HubbleWWTWidget
 
 from ...utils import GALAXY_FOV, angle_to_json, \
     angle_from_json
@@ -54,7 +55,7 @@ class DistanceTool(v.VueTemplate):
     START_COORDINATES = SkyCoord(170 * u.deg, 13.3 * u.deg, frame='icrs')
 
     def __init__(self, *args, **kwargs):
-        self.widget = WWTWidget(use_remote=True)
+        self.widget = HubbleWWTWidget(use_remote=True)
         self.background = self.SDSS
         self.measuring = kwargs.get('measuring', False)
         self.guard = kwargs.get('guard', False)

--- a/src/hubbleds/widgets/hubble_wwt.py
+++ b/src/hubbleds/widgets/hubble_wwt.py
@@ -1,0 +1,16 @@
+from traitlets import Unicode
+
+from ipywwt import WWTWidget
+
+
+class HubbleWWTWidget(WWTWidget):
+
+    background = Unicode(
+        "Black Sky Background",
+        help="The layer to show in the background (`str`)",
+    ).tag(wwt=None, wwt_reset=True)
+
+    foreground = Unicode(
+        "SDSS9 color",
+        help="The layer to show in the foreground (`str`)",
+    ).tag(wwt=None, wwt_reset=True)


### PR DESCRIPTION
This PR updates the selection and distance tools to use the Black Sky Background as the background and SDSS as the foreground. To do this, we create a `HubbleWWTWidget` that subclasses the `ipywwt` widget. This subclass sets these to be the default values, which should help with getting these values set inside WWT right off the bat.