### PR TITLE
remove wwt ready gates

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -139,14 +139,6 @@ class ComponentState(BaseComponentState, BaseState):
         )
 
     @property
-    def sel_gal1_gate(self) -> bool:
-        return self.wwt_ready
-
-    @property
-    def sel_gal2_gate(self) -> bool:
-        return self.wwt_ready
-
-    @property
     def not_gal1_gate(self) -> bool:
         return self.total_galaxies >= 1
 

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -80,10 +80,6 @@ class ComponentState(BaseComponentState, BaseState):
         if isinstance(v, int):
             return Marker(v)
         return v
-    
-    @property
-    def cho_row1_gate(self) -> bool:
-        return self.wwt_ready    
 
     @property
     def ang_siz2_gate(self):


### PR DESCRIPTION
This fixes #958. Especially if I'm using throttled internet, the gates to advance past the first guideline of Stages 1 & 3 sometimes still do not open, even with the manual timeout we added in #930.

Given that we've now set up WWT to always show SDSS + Black Sky Background, I think we can do without the gates because it's less likely that students will end up in a weird state with the WWT layers, so I am undoing them here.