### PR TITLE
Fix db load issues

### DIFF
--- a/src/hubbleds/00-test-page/__init__.py
+++ b/src/hubbleds/00-test-page/__init__.py
@@ -51,7 +51,7 @@ def Page():
     
     solara.lab.use_task(_load_component_state)
     
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -260,8 +260,7 @@ def SelectionTool(
         fov: u.Quantity,
         instant: Optional[bool] = None,
         motion_counted: bool = True,
-    ):  
-        print(f"Going to location: {coords}, fov: {fov}, instant: {instant}, motion_counted: {motion_counted}")
+    ):
         if instant is None:
             if motion_counted:
                 instant = motions_left <= 0

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -173,6 +173,11 @@ def SelectionTool(
         """
         Set up the WWT widget when it is ready.
         """
+        # Apparently, `use_effect` triggers immediately, and then based on
+        #  dependencies. So we need to check if the WWT is ready.
+        if not show_wwt.value:
+            return
+
         wwt_widget = solara.get_widget(wwt_container).children[0]
 
         # Update the displayed foreground and background

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -1,16 +1,10 @@
 import solara
-from cosmicds.components import MathJaxSupport, PlotlySupport, \
-    GoogleAnalyticsSupport
-from cosmicds.components import MathJaxSupport, PlotlySupport, \
-    GoogleAnalyticsSupport
 from cosmicds.layout import BaseLayout, BaseSetup
-from cosmicds.layout import BaseLayout, BaseSetup
-from cosmicds.logger import setup_logger
 from cosmicds.logger import setup_logger
 from hubbleds.remote import LOCAL_API
+from hubbleds.utils import push_to_route
 from solara.toestand import Ref
 
-from .state import GLOBAL_STATE
 from .state import GLOBAL_STATE, LOCAL_STATE
 
 logger = setup_logger("LAYOUT")
@@ -19,27 +13,23 @@ logger = setup_logger("LAYOUT")
 @solara.component
 def Layout(children=[]):
     BaseSetup(
-        story_name=LOCAL_STATE.value.story_id,
-        story_title=LOCAL_STATE.value.title
+        story_name=LOCAL_STATE.value.story_id, story_title=LOCAL_STATE.value.title
     )
 
     student_id = Ref(GLOBAL_STATE.fields.student.id)
     loaded_states = solara.use_reactive(False)
+    route_restored = Ref(LOCAL_STATE.fields.route_restored)
 
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
 
     route_current, routes_current_level = solara.use_route(peek=True)
 
-    if route_current in routes_current_level:
-        Ref(LOCAL_STATE.fields.last_route).set(router.path)
-
-    route_index = next((i for i, r in enumerate(router.routes) if r.path == router.path.strip('/')), None)
-    Ref(LOCAL_STATE.fields.max_route_index).set(max(route_index or 0, LOCAL_STATE.value.max_route_index or 0))
-
     def _load_global_local_states():
         if student_id.value is None:
-            logger.warning(f"Failed to load measurements: ID `{GLOBAL_STATE.value.student.id}` not found.")
+            logger.warning(
+                f"Failed to load measurements: ID `{GLOBAL_STATE.value.student.id}` not found."
+            )
             return
 
         logger.info(
@@ -57,8 +47,6 @@ def Layout(children=[]):
         )
 
         logger.info("Finished loading state.")
-        if LOCAL_STATE.value.last_route is not None:
-            router.push(LOCAL_STATE.value.last_route)
 
         Ref(LOCAL_STATE.fields.measurements_loaded).set(True)
 
@@ -85,15 +73,59 @@ def Layout(children=[]):
                 f"Did not write {'story state' if not put_state else ''} "
                 f"{'measurements' if not put_meas else ''} "
                 f"{'sample measurements' if not put_samp else ''} "
-                f"to database.")
+                f"to database."
+            )
 
     solara.lab.use_task(
         _write_local_global_states, dependencies=[GLOBAL_STATE.value, LOCAL_STATE.value]
     )
 
-    BaseLayout(
-        local_state=LOCAL_STATE,
-        children=children,
-        story_name=LOCAL_STATE.value.story_id,
-        story_title=LOCAL_STATE.value.title,
-    )
+    def _store_user_location():
+        if not route_restored.value:
+            return
+
+        logger.info(f"Storing path location as `{route_current.path}`")
+        # Store the current route index so that users will be returned to their
+        #  previous location when they return to the app
+        Ref(LOCAL_STATE.fields.last_route).set(f"{route_current.path}")
+
+        route_index = next(
+            (
+                i
+                for i, r in enumerate(router.routes)
+                if r.path == router.path.strip("/")
+            ),
+            None,
+        )
+        Ref(LOCAL_STATE.fields.max_route_index).set(
+            max(route_index or 0, LOCAL_STATE.value.max_route_index or 0)
+        )
+
+    solara.use_effect(_store_user_location, dependencies=[route_current])
+
+    def _restore_user_location():
+        if not route_restored.value:
+            if (
+                LOCAL_STATE.value.last_route is not None
+                and route_current.path != LOCAL_STATE.value.last_route
+            ):
+                logger.info(
+                    f"Restoring path location to `{LOCAL_STATE.value.last_route}`"
+                )
+                push_to_route(router, location, LOCAL_STATE.value.last_route)
+            else:
+                logger.info("IT's done.")
+                route_restored.set(True)
+
+    solara.use_memo(_restore_user_location)
+
+    # The rendering takes a moment while the route resolves, this can appear as
+    #  a flicker before the true page loads. Here, we hide the page until the
+    #  route is restored.
+    if route_restored.value:
+        BaseLayout(
+            local_state=LOCAL_STATE,
+            children=children,
+            story_name=LOCAL_STATE.value.story_id,
+            story_title=LOCAL_STATE.value.title,
+        )

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -24,6 +24,7 @@ def Layout(children=[]):
     location = solara.use_context(solara.routing._location_context)
 
     route_current, routes_current_level = solara.use_route(peek=True)
+    route_index = routes_current_level.index(route_current)
 
     def _load_global_local_states():
         if student_id.value is None:
@@ -88,15 +89,6 @@ def Layout(children=[]):
         # Store the current route index so that users will be returned to their
         #  previous location when they return to the app
         Ref(LOCAL_STATE.fields.last_route).set(f"{route_current.path}")
-
-        route_index = next(
-            (
-                i
-                for i, r in enumerate(router.routes)
-                if r.path == router.path.strip("/")
-            ),
-            None,
-        )
         Ref(LOCAL_STATE.fields.max_route_index).set(
             max(route_index or 0, LOCAL_STATE.value.max_route_index or 0)
         )

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -106,7 +106,6 @@ def Layout(children=[]):
                 )
                 push_to_route(router, location, LOCAL_STATE.value.last_route)
             else:
-                logger.info("IT's done.")
                 route_restored.set(True)
 
     solara.use_memo(_restore_user_location)

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -17,11 +17,13 @@ def Layout(children=[]):
     loaded_states = solara.use_reactive(False)
 
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
+
     Ref(LOCAL_STATE.fields.last_route).set(router.path)
     route_index = next((i for i, r in enumerate(router.routes) if r.path == router.path.strip('/')), None)
     Ref(LOCAL_STATE.fields.max_route_index).set(max(route_index or 0, LOCAL_STATE.value.max_route_index or 0))
 
-    async def _load_global_local_states():
+    def _load_global_local_states():
         if not GLOBAL_STATE.value.student.id:
             logger.warning("Failed to load measurements: no student was found.")
             return
@@ -48,9 +50,8 @@ def Layout(children=[]):
 
         Ref(LOCAL_STATE.fields.measurements_loaded).set(True)
 
-    solara.lab.use_task(_load_global_local_states, dependencies=[student_id.value])
-
-    # solara.use_memo(_load_local_state, dependencies=[student_id.value])
+    # solara.lab.use_task(_load_global_local_states, dependencies=[student_id.value])
+    solara.use_memo(_load_global_local_states, dependencies=[student_id.value])
 
     async def _write_local_global_states():
         if not loaded_states.value:

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -80,9 +80,10 @@ def nbin_func(xmin, xmax):
 @solara.component
 def Page():
     solara.Title("HubbleDS")
-    logger.info("Rendering Stage 1: Spectra & Velocity")
+
     loaded_component_state = solara.use_reactive(False)
     selection_tool_candidate_galaxy = solara.use_reactive(None)
+
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -85,7 +85,6 @@ def Page():
     selection_tool_candidate_galaxy = solara.use_reactive(None)
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
-    
 
     def _load_component_state():
         # Load stored component state from database, measurement data is
@@ -97,7 +96,8 @@ def Page():
         if len(LOCAL_STATE.value.measurements) != total_galaxies.value:
             logger.error(
                 "Detected mismatch between stored measurements and current "
-                "recorded number of galaxies."
+                f"recorded number of galaxies. Stored: {len(LOCAL_STATE.value.measurements)}, "
+                f"Current: {total_galaxies.value}."
             )
             total_galaxies.set(len(LOCAL_STATE.value.measurements))
 
@@ -106,7 +106,7 @@ def Page():
 
     solara.use_memo(_load_component_state, dependencies=[])
 
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 
@@ -347,8 +347,6 @@ def Page():
     def print_selected_example_galaxy(galaxy):
         print('selected example galaxy is now:', galaxy)
 
-    
-
     sync_wavelength_line = solara.use_reactive(6565.0)
     sync_velocity_line = solara.use_reactive(0.0)
     spectrum_bounds = solara.use_reactive([])
@@ -383,10 +381,7 @@ def Page():
         logger.info('Setting spectrum range from dotplot range')
         lambda_rest = LOCAL_STATE.value.example_measurements[0].rest_wave_value
         return [v2w(v, lambda_rest) for v in value]
-            
-    
 
-    
     def _reactive_subscription_setup():
         Ref(COMPONENT_STATE.fields.selected_galaxy).subscribe(print_selected_galaxy)
         Ref(COMPONENT_STATE.fields.selected_example_galaxy).subscribe(print_selected_example_galaxy)
@@ -558,7 +553,6 @@ def Page():
                                         else None
 
             def _on_wwt_ready_callback():
-                print("CALLED")
                 Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
             
             SelectionTool(

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -770,7 +770,7 @@ def Page():
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineEndStage1.vue",
-                event_next_callback=lambda _: push_to_route(router, location, location, "02-distance-introduction"),
+                event_next_callback=lambda _: push_to_route(router, location, "02-distance-introduction"),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.end_sta1),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -430,7 +430,7 @@ def Page():
         with rv.Col(cols=12, lg=4):
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineIntro.vue",
-                event_back_callback=lambda _: push_to_route(router, location, location, "/"),
+                event_back_callback=lambda _: push_to_route(router, location, "/"),
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.mee_gui1),

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -418,13 +418,6 @@ def Page():
 
     Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
 
-    # Insurance policy
-    async def _wwt_ready_timeout():
-        await asyncio.sleep(7)
-        Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
-
-    solara.lab.use_task(_wwt_ready_timeout)
-
     if show_team_interface:
         with rv.Row():
             with solara.Column():
@@ -563,6 +556,10 @@ def Page():
             selection_tool_galaxy = selection_tool_measurement.value.galaxy.model_dump() \
                                         if (selection_tool_measurement.value is not None and selection_tool_measurement.value.galaxy is not None) \
                                         else None
+
+            def _on_wwt_ready_callback():
+                print("CALLED")
+                Ref(COMPONENT_STATE.fields.wwt_ready).set(True)
             
             SelectionTool(
                 show_galaxies=COMPONENT_STATE.value.current_step_in(
@@ -574,7 +571,7 @@ def Page():
                 background_counter=selection_tool_bg_count,
                 deselect_galaxy_callback=_deselect_galaxy_callback,
                 candidate_galaxy=selection_tool_candidate_galaxy.value,
-                on_wwt_ready=lambda: Ref(COMPONENT_STATE.fields.wwt_ready).set(True),
+                on_wwt_ready=_on_wwt_ready_callback,
             ) 
             
             if show_snackbar.value:

--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -139,6 +139,14 @@ class ComponentState(BaseComponentState, BaseState):
         )
 
     @property
+    def sel_gal1_gate(self) -> bool:
+        return self.wwt_ready
+
+    @property
+    def sel_gal2_gate(self) -> bool:
+        return self.wwt_ready
+
+    @property
     def not_gal1_gate(self) -> bool:
         return self.total_galaxies >= 1
 

--- a/src/hubbleds/pages/02-distance-introduction/__init__.py
+++ b/src/hubbleds/pages/02-distance-introduction/__init__.py
@@ -30,7 +30,7 @@ def Page():
 
     solara.use_memo(_load_component_state, dependencies=[])
 
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/pages/02-distance-introduction/__init__.py
+++ b/src/hubbleds/pages/02-distance-introduction/__init__.py
@@ -17,6 +17,7 @@ def Page():
     solara.Title("HubbleDS")
     loaded_component_state = solara.use_reactive(False)
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
 
     async def _load_component_state():
         # Load stored component state from database, measurement data is
@@ -85,7 +86,7 @@ def Page():
             "mc_score_2": get_multiple_choice(LOCAL_STATE, COMPONENT_STATE, "how-much-closer-galaxies"), 
             "score_tag_2": "how-much-closer-galaxies",
         },
-        event_slideshow_finished=lambda _: push_to_route(router, "03-distance-measurements"),
+        event_slideshow_finished=lambda _: push_to_route(router, location, "03-distance-measurements"),
         debug = LOCAL_STATE.value.debug_mode,
         speech=speech.value.model_dump(),
     )

--- a/src/hubbleds/pages/02-distance-introduction/__init__.py
+++ b/src/hubbleds/pages/02-distance-introduction/__init__.py
@@ -19,7 +19,7 @@ def Page():
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
 
-    async def _load_component_state():
+    def _load_component_state():
         # Load stored component state from database, measurement data is
         # considered higher-level and is loaded when the story starts
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
@@ -28,7 +28,7 @@ def Page():
         logger.info("Finished loading component state for stage 2.")
         loaded_component_state.set(True)
 
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
 
     async def _write_component_state():
         if not loaded_component_state.value:
@@ -41,8 +41,6 @@ def Page():
             logger.info("Wrote component state for stage 2 to database.")
         else:
             logger.info("Did not write component state for stage 2 to database.")
-
-        
 
     logger.info("Trying to write component state for stage 2.")
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -205,6 +205,7 @@ def Page():
     # === Setup State Loading and Writing ===
     loaded_component_state = solara.use_reactive(False)
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
 
     distance_tool_bg_count = solara.use_reactive(0)
 
@@ -312,7 +313,7 @@ def Page():
             measurement.student_id = GLOBAL_STATE.value.student.id
         Ref(LOCAL_STATE.fields.measurements).set(dummy_measurements)
         Ref(COMPONENT_STATE.fields.angular_sizes_total).set(5)
-        push_to_route(router, "04-explore-data")
+        push_to_route(router, location, "04-explore-data")
 
     def _fill_thetas():
         dummy_measurements = LOCAL_API.get_dummy_data()
@@ -501,7 +502,7 @@ def Page():
         with rv.Col():
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineAngsizeMeas1.vue",
-                event_back_callback=lambda _: push_to_route(router, "02-distance-introduction"),
+                event_back_callback=lambda _: push_to_route(router, location, "02-distance-introduction"),
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.ang_siz1),
@@ -765,7 +766,7 @@ def Page():
                 solara.Button(label="DEMO SHORTCUT: FILL θ MEASUREMENTS", on_click=_fill_thetas, style="text-transform: none", classes=["demo-button"])
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineFillRemainingGalaxies.vue",
-                event_next_callback=lambda _: push_to_route(router, "04-explore-data"),
+                event_next_callback=lambda _: push_to_route(router, location, "04-explore-data"),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.fil_rem1),

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -209,12 +209,12 @@ def Page():
 
     distance_tool_bg_count = solara.use_reactive(0)
 
-    async def _load_component_state():
+    def _load_component_state():
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
         logger.info("Finished loading component state")
         loaded_component_state.set(True)
     
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
     
     async def _write_component_state():
         if not loaded_component_state.value:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -216,7 +216,7 @@ def Page():
     
     solara.use_memo(_load_component_state, dependencies=[])
     
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/pages/03-distance-measurements/component_state.py
+++ b/src/hubbleds/pages/03-distance-measurements/component_state.py
@@ -82,6 +82,10 @@ class ComponentState(BaseComponentState, BaseState):
         return v
 
     @property
+    def cho_row1_gate(self) -> bool:
+        return self.wwt_ready
+
+    @property
     def ang_siz2_gate(self):
         return bool(self.selected_example_galaxy)
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -460,7 +460,7 @@ def Page():
                     with rv.Col(class_="no-padding"):
 
                         def _layer_toggled(data):
-                            if data["visible"] and data["index"] is 3:
+                            if data["visible"] and data["index"] == 3:
                                 Ref(COMPONENT_STATE.fields.class_data_displayed).set(True)
 
                         PlotlyLayerToggle(chart_id="line-draw-viewer",

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -49,7 +49,11 @@ def Page():
 
     skip_waiting_room, set_skip_waiting_room = solara.use_state(False)
 
-    # LOCAL_API.update_class_size(GLOBAL_STATE)
+    def check_completed_students_count():
+        logger.info("Checking how many students have completed measurements")
+        count = LOCAL_API.get_students_completed_measurements_count(GLOBAL_STATE, LOCAL_STATE)
+        logger.info(f"Count: {count}")
+        return count
 
     def _load_component_state():
         # Load stored component state from database, measurement data is
@@ -120,12 +124,6 @@ def Page():
         return gjapp, viewers
 
     gjapp, viewers = solara.use_memo(glue_setup, dependencies=[])
-
-    def check_completed_students_count():
-        logger.info("Checking how many students have completed measurements")
-        count = LOCAL_API.get_students_completed_measurements_count(GLOBAL_STATE, LOCAL_STATE)
-        logger.info(f"Count: {count}")
-        return count
 
     def load_class_data():
         logger.info("Loading class data")

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -55,6 +55,12 @@ def Page():
         logger.info(f"Count: {count}")
         return count
 
+    def _on_waiting_room_advance():
+        if class_ready_task.pending:
+            class_ready_task.cancel()
+        load_class_data()
+        transition_next(COMPONENT_STATE)
+
     def _load_component_state():
         # Load stored component state from database, measurement data is
         # considered higher-level and is loaded when the story starts
@@ -182,12 +188,6 @@ def Page():
             await asyncio.sleep(10)
 
     class_ready_task = solara.lab.use_task(keep_checking_class_data, dependencies=[])
-
-    def _on_waiting_room_advance():
-        if class_ready_task.pending:
-            class_ready_task.cancel()
-        load_class_data()
-        transition_next(COMPONENT_STATE)
 
     student_plot_data = solara.use_reactive(LOCAL_STATE.value.measurements)
     async def _load_student_data():

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -51,7 +51,7 @@ def Page():
 
     # LOCAL_API.update_class_size(GLOBAL_STATE)
 
-    async def _load_component_state():
+    def _load_component_state():
         # Load stored component state from database, measurement data is
         # considered higher-level and is loaded when the story starts
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
@@ -69,7 +69,7 @@ def Page():
             _on_waiting_room_advance()
         loaded_component_state.set(True)
 
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
 
     async def _write_component_state():
         if not loaded_component_state.value:

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -115,7 +115,10 @@ def Page():
 
     def _on_waiting_room_advance():
         if class_ready_task.pending:
-            class_ready_task.cancel()
+            try:
+                class_ready_task.cancel()
+            except RuntimeError:
+                pass
         load_class_data()
         transition_next(COMPONENT_STATE)
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -33,6 +33,7 @@ def Page():
     solara.Title("HubbleDS")
     loaded_component_state = solara.use_reactive(False)
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
 
     completed_count = solara.use_reactive(0)
 
@@ -202,7 +203,7 @@ def Page():
         load_class_data()
 
     def _jump_stage_5():
-        push_to_route(router, "05-class-results-uncertainty")
+        push_to_route(router, location, "05-class-results-uncertainty")
 
     current_step = Ref(COMPONENT_STATE.fields.current_step)
 
@@ -256,7 +257,7 @@ def Page():
         with rv.Col():
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineExploreData.vue",
-                event_back_callback=lambda _: push_to_route(router, "03-distance-measurements"),
+                event_back_callback=lambda _: push_to_route(router, location, "03-distance-measurements"),
                 event_next_callback = lambda _: transition_next(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.exp_dat1),
@@ -432,7 +433,7 @@ def Page():
             )
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineShortcomingsEst2.vue",
-                event_next_callback=lambda _: push_to_route(router, "05-class-results-uncertainty"),
+                event_next_callback=lambda _: push_to_route(router, location, "05-class-results-uncertainty"),
                 event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.sho_est2),

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -118,7 +118,7 @@ def Page():
             try:
                 class_ready_task.cancel()
             except RuntimeError:
-                pass
+                return
         load_class_data()
         transition_next(COMPONENT_STATE)
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -172,8 +172,12 @@ def Page():
 
         Ref(LOCAL_STATE.fields.enough_students_ready).set(value)
         set_skip_waiting_room(value)
-        if value and COMPONENT_STATE.value.current_step == Marker.wwt_wait:
-            _on_waiting_room_advance()
+        if value:
+            if COMPONENT_STATE.value.current_step == Marker.wwt_wait:
+                _on_waiting_room_advance()
+            else:
+                load_class_data()
+
         loaded_component_state.set(True)
 
     solara.use_memo(_load_component_state, dependencies=[])
@@ -200,6 +204,7 @@ def Page():
             student_plot_data.set(measurements)
     solara.lab.use_task(_load_student_data)
 
+    # TODO: not sure what this is supposed to do
     if not (class_ready_task.finished or class_ready_task.pending):
         load_class_data()
 

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -71,7 +71,7 @@ def Page():
 
     solara.use_memo(_load_component_state, dependencies=[])
 
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -52,7 +52,9 @@ def Page():
     loaded_component_state = solara.use_reactive(False)
     student_slider_setup, set_student_slider_setup = solara.use_state(False)
     class_slider_setup, set_class_slider_setup = solara.use_state(False)
+
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
 
     async def _load_component_state():
         # Load stored component state from database, measurement data is
@@ -388,7 +390,7 @@ def Page():
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)
 
     def _jump_stage_6():
-        push_to_route(router, "06-prodata")
+        push_to_route(router, location, "06-prodata")
 
     if show_team_interface:
         with solara.Row():
@@ -430,7 +432,7 @@ def Page():
             with rv.Col():
                 ScaffoldAlert(
                     GUIDELINE_ROOT / "GuidelineRandomVariability.vue",
-                    event_back_callback=lambda _: push_to_route(router, "04-explore-data"),
+                    event_back_callback=lambda _: push_to_route(router, location, "04-explore-data"),
                     event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                     can_advance=COMPONENT_STATE.value.can_transition(next=True),
                     allow_back=False,
@@ -909,7 +911,7 @@ def Page():
                 ScaffoldAlert(
                     # TODO: event_next_callback should go to next stage but I don't know how to set that up.
                     GUIDELINE_ROOT / "GuidelineMoreDataDistribution.vue",
-                    event_next_callback=lambda _: push_to_route(router, "06-prodata"),
+                    event_next_callback=lambda _: push_to_route(router, location, "06-prodata"),
                     event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                     can_advance=COMPONENT_STATE.value.can_transition(next=True),
                     show=COMPONENT_STATE.value.is_current_step(Marker.mor_dat1),

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -56,7 +56,7 @@ def Page():
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
 
-    async def _load_component_state():
+    def _load_component_state():
         # Load stored component state from database, measurement data is
         # considered higher-level and is loaded when the story starts
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
@@ -65,7 +65,7 @@ def Page():
         logger.info("Finished loading component state for stage 4.")
         loaded_component_state.set(True)
 
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
 
     async def _write_component_state():
         if not loaded_component_state.value:
@@ -77,9 +77,6 @@ def Page():
             logger.info("Wrote stage 5 component state to database.")
         else:
             logger.info("Did not write stage 5 component state to database.")
-
-
-        
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -396,8 +396,8 @@ def Page():
             with solara.Column():
                 solara.Button(label="Shortcut: Jump to Stage 6", on_click=_jump_stage_6, classes=["demo-button"])
 
-    def _on_component_state_loaded(value: bool):
-        if not value:
+    def _parse_component_state():
+        if not loaded_component_state.value:
             return
 
         student_low_age = Ref(COMPONENT_STATE.fields.student_low_age)
@@ -417,7 +417,7 @@ def Page():
         class_low_age.set(round(min(all_class_summ_data["age_value"])))
         class_high_age.set(round(max(all_class_summ_data["age_value"])))
 
-    loaded_component_state.subscribe(_on_component_state_loaded)
+    solara.use_memo(_parse_component_state, dependencies=[loaded_component_state.value])
 
     #--------------------- Row 1: OUR DATA HUBBLE VIEWER -----------------------
     if (

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -67,7 +67,7 @@ def Page():
 
     solara.use_memo(_load_component_state, dependencies=[])
 
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -88,7 +88,7 @@ def Page():
     
     solara.use_memo(_load_component_state, dependencies=[])
     
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -81,12 +81,12 @@ def Page():
     router = solara.use_router()
     location = solara.use_context(solara.routing._location_context)
 
-    async def _load_component_state():
+    def _load_component_state():
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
         logger.info("Finished loading component state")
         loaded_component_state.set(True)
     
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
     
     async def _write_component_state():
         if not loaded_component_state.value:

--- a/src/hubbleds/pages/06-prodata/__init__.py
+++ b/src/hubbleds/pages/06-prodata/__init__.py
@@ -77,7 +77,9 @@ def Page():
     solara.Title("HubbleDS")
     # === Setup State Loading and Writing ===
     loaded_component_state = solara.use_reactive(False)
+
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
 
     async def _load_component_state():
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
@@ -266,7 +268,7 @@ def Page():
         with rv.Col():
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineProfessionalData0.vue",
-                event_back_callback=lambda _: push_to_route(router, "05-class-results-uncertainty"),
+                event_back_callback=lambda _: push_to_route(router, location, "05-class-results-uncertainty"),
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.pro_dat0),

--- a/src/hubbleds/pages/__init__.py
+++ b/src/hubbleds/pages/__init__.py
@@ -34,7 +34,7 @@ def Page():
 
     solara.use_memo(_load_component_state, dependencies=[])
 
-    async def _write_component_state():
+    def _write_component_state():
         if not loaded_component_state.value:
             return
 
@@ -47,15 +47,14 @@ def Page():
 
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
 
-    exploration_tool = ExplorationTool()
-    exploration_tool1 = ExplorationTool()
-    exploration_tool2 = ExplorationTool()
+    def _get_exploration_tool():
+        return ExplorationTool()
 
-    exploration_tools = [exploration_tool, exploration_tool1, exploration_tool2]
+    exploration_tool = solara.use_memo(_get_exploration_tool, dependencies=[])
 
     def go_to_location(options):
         index = options.get("index", 0)
-        tool = exploration_tools[index]
+        tool = exploration_tool #exploration_tools[index]
         fov_as = options.get("fov", 216000)
         fov = fov_as * u.arcsec
         ra = options.get("ra")
@@ -86,8 +85,8 @@ def Page():
         event_slideshow_finished=lambda _: push_to_route(router, location, "01-spectra-&-velocity"),
         debug=LOCAL_STATE.value.debug_mode,
         exploration_tool=exploration_tool,
-        exploration_tool1=exploration_tool1,
-        exploration_tool2=exploration_tool2,
+        exploration_tool1=exploration_tool,
+        exploration_tool2=exploration_tool,
         event_go_to_location=go_to_location,
         speech=speech.value.model_dump(),
         show_team_interface=GLOBAL_STATE.value.show_team_interface

--- a/src/hubbleds/pages/__init__.py
+++ b/src/hubbleds/pages/__init__.py
@@ -23,14 +23,16 @@ logger = setup_logger("STAGE INTRO")
 def Page():
     solara.Title("HubbleDS")
     router = solara.use_router()
+    location = solara.use_context(solara.routing._location_context)
     
     loaded_component_state = solara.use_reactive(False)
-    async def _load_component_state():
+
+    def _load_component_state():
         LOCAL_API.get_stage_state(GLOBAL_STATE, LOCAL_STATE, COMPONENT_STATE)
         logger.info("Finished loading component state.")
         loaded_component_state.set(True)
 
-    solara.lab.use_task(_load_component_state)
+    solara.use_memo(_load_component_state, dependencies=[])
 
     async def _write_component_state():
         if not loaded_component_state.value:
@@ -81,7 +83,7 @@ def Page():
             "Vesto Slipher and Spectral Data"
         ],
         image_location=get_image_path(router, "stage_intro"),
-        event_slideshow_finished=lambda _: push_to_route(router, "01-spectra-&-velocity"),
+        event_slideshow_finished=lambda _: push_to_route(router, location, "01-spectra-&-velocity"),
         debug=LOCAL_STATE.value.debug_mode,
         exploration_tool=exploration_tool,
         exploration_tool1=exploration_tool1,

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -135,6 +135,7 @@ class LocalState(BaseLocalState):
     stage_4_class_data_students: list[int] = []
     stage_5_class_data_students: list[int] = []
     last_route: Optional[str] = None
+    route_restored: bool = Field(False, exclude=True)
 
     @cached_property
     def galaxies(self) -> dict[int, GalaxyData]:

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -11,12 +11,16 @@ from glue_jupyter.app import JupyterApplication
 from numbers import Number
 from typing import List, Set, Tuple, TypeVar, Optional, cast, Any
 from collections.abc import Callable
+import solara
 from solara.routing import Router
 from solara.toestand import Reactive
+from solara.server import settings
 
 from hubbleds.state import StudentMeasurement
 from glue.core import Data
 from numpy import asarray
+
+from pathlib import Path
 
 try:
     from astropy.cosmology import Planck18 as planck
@@ -321,5 +325,9 @@ def subset_by_label(data, label):
         value = next((s for s in data.subsets if s.label == label), None)
         return value
 
-def push_to_route(router: Router, route: str):
-    router.push(f"{router.root_path}/{route}") 
+def push_to_route(router: Router, location, route: str):
+    if route != '/':
+        path = Path(f"{router.root_path}/{route}")
+        router.push(str(path))
+    else:
+        location.pathname = settings.main.base_url


### PR DESCRIPTION
This PR covers three main issues that we've been seeing:

## 1. Potential race conditions

There seems to be a problem wherein component states are not properly populated by the time their values are evaluated. This seems to be an issue that @patudom was experiencing, but I was unable to reproduce. Under the assumption that it's a race condition, I've converted all our `_load_component_states` to use `use_memo` instead of `use_task`. This means that the page should not load until the component state has been populated. I have also made the same change to the top-level `_load_global_local_states` function as well. **NOTE** Writing is still done asynchronously, so as not to cause any stuttering in the front-end user interface.

**BIG NOTE**: There is a weird caveat in the Solara docs about whether to include `dependencies=[]` in the hooks; from the `use_memo` docs:

> dependencies can take the value None, in which case dependencies are automatically obtained from nonlocal variables. If an empty list is passed as dependencies instead, the function is only executed once over the entire lifetime of the component.

What I interpret this to mean is that *if the intention is to run a function only once, or in response to a variable change **always set the `dependencies` argument***.

## 2. Further improvements to the routing

I ran across an issue in which the `push_to_route` utility function would not work appropriately when navigating to the root page of the app when the app is hosted at an endpoint. This is the same issue found in the navigation routing that was addressed in an earlier PR. Thus, I've included the appropriate fix to `push_to_route` function: it now must also be passed a `location` context.

## 3. Fully fix the wwt ready functionality

This was an annoying one (as I'm sure you all know!) but I finally realized something I had forgotten: `use_effect` is run _immediately_ **and then** every time its dependency changes. That means that upon page load, the `on_wwt_ready` callback passed to the `SelectionTool` was being run immediately, setting `wwt_ready` on the component state to true. This is why later attempts to set `wwt_ready` seemed to do nothing: since it was already `True`, no changes were being registered. To fix this, we simply check to see if we've actually received the ready notification from the WWT research app before we attempt to interact with the selection tool. Thus, I have also added back the step gates.