### PR TITLE
Update short-demo layout to use new BaseSetup and BaseLayout

### DIFF
--- a/src/hubbleds/assets/custom.css
+++ b/src/hubbleds/assets/custom.css
@@ -279,7 +279,13 @@ header.cosmicds-appbar > div.v-toolbar__content > h3 {
     align-items: center;
 }
 
-header.cosmicds-appbar > div.v-toolbar__content > h3::after {
+header.cosmicds-appbar > div.v-toolbar__content > h2 {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+header.cosmicds-appbar > div.v-toolbar__content > h2::after {
     content: "Shortened DEMO Version:\AProgress and measurements are NOT saved";
     white-space: pre-wrap;
     display: block;
@@ -296,7 +302,7 @@ header.cosmicds-appbar > div.v-toolbar__content > h3::after {
     padding-inline: 15px;
     padding-block: 5px;
     border-radius: 10px;
-    margin-left: 25px;  
+    margin-left: 3rem;  
     
     line-height: 1.2;
 }

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -1,5 +1,5 @@
 from os import getenv
-from cosmicds.layout import BaseLayout
+from cosmicds.layout import BaseLayout, BaseSetup
 from .state import GLOBAL_STATE, LOCAL_STATE
 import solara
 from solara.toestand import Ref
@@ -12,6 +12,12 @@ logger = setup_logger("LAYOUT")
 
 @solara.component
 def Layout(children=[]):
+    BaseSetup(
+        force_demo=True,
+        story_name=LOCAL_STATE.value.story_id, 
+        story_title=LOCAL_STATE.value.title
+    )
+
 
     student_id = Ref(GLOBAL_STATE.fields.student.id)
     loaded_states = solara.use_reactive(False)
@@ -72,11 +78,9 @@ def Layout(children=[]):
         _write_local_global_states, dependencies=[GLOBAL_STATE.value, LOCAL_STATE.value]
     )
 
-    with BaseLayout(
+    BaseLayout(
         local_state=LOCAL_STATE,
         children=children,
         story_name=LOCAL_STATE.value.story_id,
         story_title=LOCAL_STATE.value.title,
-        force_demo=True
-    ):
-        pass
+    )


### PR DESCRIPTION
This ought to replace #973. The demo runs and behaves as necessary. It doesn't update the routing on the hubble side because there is no last route or anything to keep track of. 