### PR TITLE
Pin cosmicds repo to last commit before incompatible cosmicds updates

### DIFF
--- a/.github/workflows/selenium-tests.yml
+++ b/.github/workflows/selenium-tests.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/checkout@v4
         with:
-          ref: short-demo
+          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     importlib-metadata
     astropy<7.0
     authlib
-    cosmicds @ git+https://github.com/cosmicds/cosmicds.git
+    cosmicds @ git+https://github.com/cosmicds/cosmicds.git@eb7b921f2d38d6ce928ec7e7110c743f48f872bc
     glue-core
     glue-jupyter
     glue-plotly[jupyter]>=0.9.0

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -4,7 +4,7 @@ import astropy.units as u
 import solara
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from ipywwt import WWTWidget
+from hubbleds.widgets.hubble_wwt import HubbleWWTWidget
 from reacton import ipyvuetify as rv
 
 from ...state import LOCAL_STATE
@@ -145,7 +145,7 @@ def SelectionTool(
         """
         Add the WWT widget to the container.
         """
-        wwt_widget = WWTWidget(use_remote=True)
+        wwt_widget = HubbleWWTWidget(use_remote=True)
         wwt_widget.observe(lambda change: show_wwt.set(change["new"]), "_wwt_ready")
 
         wwt_widget_container = solara.get_widget(wwt_container)

--- a/src/hubbleds/components/selection_tool/__init__.py
+++ b/src/hubbleds/components/selection_tool/__init__.py
@@ -163,6 +163,11 @@ def SelectionTool(
         """
         Set up the WWT widget when it is ready.
         """
+        # Apparently, `use_effect` triggers immediately, and then based on
+        #  dependencies. So we need to check if the WWT is ready.
+        if not show_wwt.value:
+            return
+
         wwt_widget = solara.get_widget(wwt_container).children[0]
 
         # Update the displayed foreground and background

--- a/src/hubbleds/widgets/distance_tool/distance_tool.py
+++ b/src/hubbleds/widgets/distance_tool/distance_tool.py
@@ -6,7 +6,7 @@ import ipyvue as v
 from astropy.coordinates import Angle, SkyCoord
 from cosmicds.utils import RepeatedTimer, load_template
 from ipywidgets import DOMWidget, widget_serialization
-from ipywwt import WWTWidget
+from hubbleds.widgets.hubble_wwt import HubbleWWTWidget
 from traitlets import Instance, Bool, Float, Int, Unicode, observe, Dict
 
 from ...utils import GALAXY_FOV, angle_to_json, \
@@ -55,7 +55,7 @@ class DistanceTool(v.VueTemplate):
     START_COORDINATES = SkyCoord(170 * u.deg, 13.3 * u.deg, frame='icrs')
 
     def __init__(self, *args, **kwargs):
-        self.widget = WWTWidget(use_remote=True)
+        self.widget = HubbleWWTWidget(use_remote=True)
         self.background = self.SDSS
         self.measuring = kwargs.get('measuring', False)
         self.guard = kwargs.get('guard', False)

--- a/src/hubbleds/widgets/hubble_wwt.py
+++ b/src/hubbleds/widgets/hubble_wwt.py
@@ -1,0 +1,16 @@
+from traitlets import Unicode
+
+from ipywwt import WWTWidget
+
+
+class HubbleWWTWidget(WWTWidget):
+
+    background = Unicode(
+        "Black Sky Background",
+        help="The layer to show in the background (`str`)",
+    ).tag(wwt=None, wwt_reset=True)
+
+    foreground = Unicode(
+        "SDSS9 color",
+        help="The layer to show in the foreground (`str`)",
+    ).tag(wwt=None, wwt_reset=True)


### PR DESCRIPTION
This pins the `short-demo` branch to use the latest cosmicds commit that is current on the demo server. (https://github.com/cosmicds/cosmicds/commit/eb7b921f2d38d6ce928ec7e7110c743f48f872bc, per @nmearl) 