### PR TITLE
Minor hubbleds fixes

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -958,7 +958,7 @@ def Page():
                     )
                 
     # Dot Plot 1st measurement row
-    if COMPONENT_STATE.value.current_step_between(Marker.obs_wav2, Marker.rem_vel1): 
+    if COMPONENT_STATE.value.current_step_between(Marker.int_dot1, Marker.rem_vel1): 
         with rv.Row(class_="no-y-padding"):
             with rv.Col(cols=12, lg=4, class_="no-y-padding"):
                 ScaffoldAlert(

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -750,7 +750,7 @@ def Page():
             ScaffoldAlert(
                 GUIDELINE_ROOT / "GuidelineRepeatRemainingGalaxies.vue",
                 event_next_callback=lambda _: transition_next(COMPONENT_STATE),
-                event_back_callback=lambda _: transition_to(COMPONENT_STATE, Marker.dot_seq5),
+                event_back_callback=lambda _: transition_previous(COMPONENT_STATE),
                 can_advance=COMPONENT_STATE.value.can_transition(next=True),
                 show=COMPONENT_STATE.value.is_current_step(Marker.rep_rem1),
                 scroll_on_mount=False,


### PR DESCRIPTION
Minor hubbleds fixes

- fix #965 - `rep_rem1` should just go back to the previous marker
- fix #957 - We were rendering the row for the dotplot guidelines too early. Adding this causes the page to reload.  The spectrum viewer does not preserve it's state when re-rendering, causing the state of the toggle buttons to reset. This just prevents that from happening