### PR TITLE
Fix changes in stage 3 calling subscriptions in stage 1

### DIFF
--- a/src/hubbleds/components/data_table/data_table.py
+++ b/src/hubbleds/components/data_table/data_table.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 DEFAULT_HEADERS = [
     {
-        "text": "Galaxy Name",
+        "text": "Galaxy ID",
         "align": "start",
         "sortable": False,
         "value": "name",

--- a/src/hubbleds/data_management.py
+++ b/src/hubbleds/data_management.py
@@ -17,7 +17,8 @@ EXAMPLE_GALAXY_SEED_DATA = "example_galaxy_seed_data"
 EXAMPLE_GALAXY_DATA = "example_galaxy"
 EXAMPLE_GALAXY_MEASUREMENTS = "example_galaxy_data"
 EXAMPLE_GALAXY_STUDENT_DATA = "example_galaxy_student_data"
-
+EXAMPLE_GALAXY_MEASUREMENTS_FIRST =  'first measurement'
+EXAMPLE_GALAXY_MEASUREMENTS_SECOND = 'second measurement'
 STUDENT_SLIDER_SUBSET_LABEL = "student_slider_subset"
 CLASS_SLIDER_SUBSET_LABEL = "class_slider_subset"
 

--- a/src/hubbleds/example_measurement_helpers.py
+++ b/src/hubbleds/example_measurement_helpers.py
@@ -3,6 +3,8 @@ from glue.core import Data
 from glue_jupyter import JupyterApplication
 from .data_management import (
     EXAMPLE_GALAXY_MEASUREMENTS, 
+    EXAMPLE_GALAXY_MEASUREMENTS_FIRST,
+    EXAMPLE_GALAXY_MEASUREMENTS_SECOND,
     EXAMPLE_GALAXY_SEED_DATA,
     DB_VELOCITY_FIELD,
     DB_MEASWAVE_FIELD,
@@ -72,7 +74,7 @@ def link_seed_data(gjapp):
         #     _add_link(gjapp, egsd, DB_DISTANCE_FIELD, second, DB_DISTANCE_FIELD)
 
 
-def _update_second_example_measurement(example_measurements: list[StudentMeasurement]):
+def _init_second_example_measurement(example_measurements: list[StudentMeasurement]):
         changed = ''
         if len(example_measurements) == 2:
             first = example_measurements[0]
@@ -136,3 +138,18 @@ def load_and_create_seed_data(gjapp: JupyterApplication, local_state: Reactive[L
     gjapp.data_collection.append(tutorial)
     
     link_seed_data(gjapp)
+    
+from .utils import subset_by_label
+def assert_example_measurements_in_glue(gjapp: JupyterApplication):
+    if EXAMPLE_GALAXY_MEASUREMENTS not in gjapp.data_collection:
+        raise ValueError(
+            f"Missing {EXAMPLE_GALAXY_MEASUREMENTS} in glue data collection."
+        )
+    if subset_by_label(gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS], EXAMPLE_GALAXY_MEASUREMENTS_FIRST) is None:
+        raise ValueError(
+            f"Missing {EXAMPLE_GALAXY_MEASUREMENTS_FIRST} in glue data collection."
+        )
+    if subset_by_label(gjapp.data_collection[EXAMPLE_GALAXY_MEASUREMENTS], EXAMPLE_GALAXY_MEASUREMENTS_SECOND) is None:
+        raise ValueError(
+            f"Missing {EXAMPLE_GALAXY_MEASUREMENTS_SECOND} in glue data collection."
+        )

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -131,10 +131,11 @@ def Page():
     def glue_setup() -> JupyterApplication:
         gjapp = _glue_setup()
         if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
-            raise ValueError(
+            logger.error(
                 f"Missing {EXAMPLE_GALAXY_SEED_DATA} in glue data collection."
             )
-        seed_data_setup.set(True)
+        else:
+            seed_data_setup.set(True)
         return gjapp
     
 
@@ -537,7 +538,7 @@ def Page():
             show_values = Ref(COMPONENT_STATE.fields.show_dop_cal4_values)
             
             def _on_validate_transition(validated):
-                logger.info("Validated transition to dop_cal5: %s", validated)
+                logger.debug("Validated transition to dop_cal5: %s", validated)
                 validation_4_failed.set(not validated)
                 show_values.set(validated)
                 if not validated:
@@ -547,7 +548,7 @@ def Page():
                     transition_to(COMPONENT_STATE, Marker.dop_cal5)
 
                 show_doppler_dialog = Ref(COMPONENT_STATE.fields.show_doppler_dialog)
-                logger.info("Setting show_doppler_dialog to %s", validated)
+                logger.debug("Setting show_doppler_dialog to %s", validated)
                 show_doppler_dialog.set(validated)
 
             

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -757,7 +757,7 @@ def Page():
                 
                 
                 common_headers = [
-                                    {"text": "Galaxy Name", "align": "start","sortable": False,"value": "name",},
+                                    {"text": "Galaxy ID", "align": "start","sortable": False,"value": "name",},
                                     {"text": "Element", "value": "element"},
                                     {"text": "&lambda;<sub>rest</sub> (&Aring;)",
                                      "value": "rest_wave_value"},
@@ -766,7 +766,7 @@ def Page():
                                     {"text": "Velocity (km/s)", "value": "velocity_value"},
                                 ]
                 if use_second_measurement.value:
-                    measnum_header = {"text": "Measurement Number", "value": "measurement_number"}
+                    measnum_header = {"text": "Measurement", "value": "measurement_number"}
                     common_headers.append(measnum_header)
 
                 

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -49,10 +49,14 @@ from hubbleds.utils import (
     get_image_path,
 )
 from hubbleds.example_measurement_helpers import (
-    create_example_subsets,
-    link_example_seed_and_measurements,
-    _update_second_example_measurement,
-    load_and_create_seed_data,
+    assert_example_measurements_in_glue
+)
+
+from hubbleds.stage_one_and_three_setup import (
+    initialize_second_example_measurement,
+    _add_or_update_example_measurements_to_glue,
+    _glue_setup,
+    _update_seed_data_with_examples,
 )
 
 from hubbleds.demo_helpers import (set_dummy_wavelength_and_velocity, 
@@ -63,8 +67,6 @@ logger = setup_logger("STAGE")
 
 GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 
-EXAMPLE_GALAXY_MEASUREMENTS_FIRST = EXAMPLE_GALAXY_MEASUREMENTS + '_first'
-EXAMPLE_GALAXY_MEASUREMENTS_SECOND = EXAMPLE_GALAXY_MEASUREMENTS + '_second'
 
 
 def is_wavelength_poorly_measured(measwave, restwave, z, tolerance = 0.5):
@@ -126,22 +128,26 @@ def Page():
     solara.lab.use_task(_write_component_state, dependencies=[COMPONENT_STATE.value])
     
     seed_data_setup = solara.use_reactive(False)
-    def _glue_setup() -> JupyterApplication:
-        # NOTE: use_memo has to be part of the main page render. Including it
-        #  in a conditional will result in an error.
-        gjapp = JupyterApplication(
-            GLOBAL_STATE.value.glue_data_collection, GLOBAL_STATE.value.glue_session
-        )
-
+    def glue_setup() -> JupyterApplication:
+        gjapp = _glue_setup()
         if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
-            load_and_create_seed_data(gjapp, LOCAL_STATE)
-            seed_data_setup.set(True)
+            raise ValueError(
+                f"Missing {EXAMPLE_GALAXY_SEED_DATA} in glue data collection."
+            )
+        seed_data_setup.set(True)
         return gjapp
+    
 
-    gjapp = solara.use_memo(_glue_setup, dependencies=[])
+    gjapp = solara.use_memo(glue_setup, dependencies=[])
+    
+    example_data_setup = solara.use_reactive(False)
+    def add_or_update_example_measurements_to_glue():
+        if (gjapp is not None):
+            _add_or_update_example_measurements_to_glue(gjapp)
+            assert_example_measurements_in_glue(gjapp)
+            example_data_setup.set(True)
 
-    def add_or_update_data(data: Data):
-        return _add_or_update_data(gjapp, data)
+
 
     def _state_callback_setup():
         # We want to minize duplicate state handling, but also keep the states
@@ -152,6 +158,30 @@ def Page():
         measurements.subscribe_change(
             lambda *args: total_galaxies.set(len(measurements.value))
         )
+        
+        example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
+        def _on_example_measurement_change(meas):
+            # make sure the 2nd one is initialized
+            initialize_second_example_measurement()
+            
+            # make sure it is in glue
+            add_or_update_example_measurements_to_glue()
+
+            # make sure it is in the seed data
+            _update_seed_data_with_examples(gjapp, meas)
+            
+        example_measurements.subscribe(
+            _on_example_measurement_change
+        )
+        
+        def _on_marker_updated(marker):
+            if COMPONENT_STATE.value.current_step.value >= Marker.rem_vel1.value:
+                initialize_second_example_measurement() # either set them to current or keep from DB
+            if COMPONENT_STATE.value.current_step_between(Marker.mee_gui1, Marker.sel_gal4):
+                selection_tool_bg_count.set(selection_tool_bg_count.value + 1)
+
+        Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
+
 
     solara.use_memo(_state_callback_setup, dependencies=[])
 
@@ -169,94 +199,14 @@ def Page():
     def selected_measurement():
         return Ref(LOCAL_STATE.fields.get_measurement).value(Ref(COMPONENT_STATE.fields.selected_galaxy).value)
     
-    def add_link(from_dc_name, from_att, to_dc_name, to_att):
-        _add_link(gjapp, from_dc_name, from_att, to_dc_name, to_att)
 
-    def _update_seed_data_with_examples(example_data):
-        logger.info('in _update_seed_data_with_examples')
-        label = EXAMPLE_GALAXY_SEED_DATA + "_first"
-        if label not in gjapp.data_collection:
-            return 
-
-        student = Ref(GLOBAL_STATE.fields.student)
-        data = gjapp.data_collection[label]
-        keep = data[STUDENT_ID_COMPONENT] != student.value.id
-        update = {
-            c.label: list(data[c][keep])
-            for c in data.main_components
-        }
-
-        examples_count = len(example_data)
-        if examples_count == 1:
-            measurement = example_data[0]
-        elif examples_count >= 2:
-            numbers = ("first", "second")
-            measurement = \
-                sorted(example_data,
-                       key=lambda v: numbers.index(v.measurement_number) if v.measurement_number in numbers else len(numbers)
-                )[1]
-
-            for component in data.main_components:
-                value = getattr(measurement, component.label, None)
-                if value is None:
-                    value = float('nan')
-                update[component.label].append(value)
-
-        new_data = Data(label=data.label, **update)
-        data.update_values_from_data(new_data)
-
-    
-
-
-    def update_second_example_measurement():
-        example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
-        if len(example_measurements.value) < 2:
-            # logger.info('No second example measurement to update')
-            return
-        
-        changed, updated = _update_second_example_measurement(example_measurements.value)
-        
-        if changed != '':
-            logger.info(f'Updating second example measurement: {changed}')
-            example_measurements.set([example_measurements.value[0], updated])
-        else:
-            logger.info('\t\t no changes for second measurement')
-    
-    example_data_setup = solara.use_reactive(False)
-    def add_example_measurements_to_glue():
-        if len(LOCAL_STATE.value.example_measurements) > 0:
-            logger.info(f'has {len(LOCAL_STATE.value.example_measurements)} example measurements')
-            example_measurements_glue = models_to_glue_data(
-                LOCAL_STATE.value.example_measurements,
-                label=EXAMPLE_GALAXY_MEASUREMENTS,
-            )
-            example_measurements_glue.style.color = MY_DATA_COLOR
-            create_example_subsets(gjapp, example_measurements_glue)
-
-            use_this = add_or_update_data(example_measurements_glue)
-            use_this.style.color = MY_DATA_COLOR
-
-            link_example_seed_and_measurements(gjapp)
-            if not example_data_setup.value:
-                logger.info('added example measurements to glue')
-            else:
-                logger.info('updated example measurements in glue')
-            example_data_setup.set(True)
-        else:
-            logger.info('add_example_measurements_to_glue: no example measurements yet')
-
-    
-    def _glue_sync_setup():
-        logger.info('running _glue_sync_setup')
+    def _init_glue_data_setup():
+        logger.info("The glue data use effect")
         if Ref(LOCAL_STATE.fields.measurements_loaded).value:
-            add_example_measurements_to_glue() # does nothing if data already added to glue
-            update_second_example_measurement() # does nothing if no second example measurement
+            add_or_update_example_measurements_to_glue()
+            initialize_second_example_measurement()
 
-    solara.use_memo(_glue_sync_setup, dependencies=[Ref(LOCAL_STATE.fields.measurements_loaded).value])
-    example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
-    example_measurements.subscribe(lambda *args: _glue_sync_setup()) 
-    example_measurements.subscribe(_update_seed_data_with_examples)
-
+    solara.use_effect(_init_glue_data_setup, dependencies=[Ref(LOCAL_STATE.fields.measurements_loaded).value])
     selection_tool_bg_count = solara.use_reactive(0)
 
     def _fill_galaxies():
@@ -398,13 +348,7 @@ def Page():
     speech = Ref(GLOBAL_STATE.fields.speech)
 
 
-    def _on_marker_updated(marker):
-        if COMPONENT_STATE.value.current_step.value >= Marker.rem_vel1.value:
-            update_second_example_measurement() # either set them to current or keep from DB
-        if COMPONENT_STATE.value.current_step_between(Marker.mee_gui1, Marker.sel_gal4):
-            selection_tool_bg_count.set(selection_tool_bg_count.value + 1)
 
-    Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
 
     if GLOBAL_STATE.value.show_team_interface:
         with rv.Row():
@@ -663,8 +607,6 @@ def Page():
                         )
                     )
                     
-                    if COMPONENT_STATE.value.current_step.value == Marker.rem_vel1.value:
-                        add_example_measurements_to_glue()
 
                 DopplerSlideshow(
                     dialog=COMPONENT_STATE.value.show_doppler_dialog,

--- a/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/__init__.py
@@ -237,8 +237,11 @@ def Page():
             use_this.style.color = MY_DATA_COLOR
 
             link_example_seed_and_measurements(gjapp)
+            if not example_data_setup.value:
+                logger.info('added example measurements to glue')
+            else:
+                logger.info('updated example measurements in glue')
             example_data_setup.set(True)
-            logger.info('added example measurements to glue')
         else:
             logger.info('add_example_measurements_to_glue: no example measurements yet')
 

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -781,7 +781,7 @@ def Page():
 
                 common_headers = [
                     {
-                        "text": "Galaxy Name",
+                        "text": "Galaxy ID",
                         "align": "start",
                         "sortable": False,
                         "value": "name"

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -379,16 +379,16 @@ def Page():
             index = LOCAL_STATE.value.get_measurement_index(galaxy["id"])
             if index is not None:
                 measurements = LOCAL_STATE.value.measurements
-                measurement = Ref(LOCAL_STATE.fields.measurements[index])
-                measurement.set(
-                    measurement.value.model_copy(
+                measurement = measurements[index]
+                measurement = (
+                    measurement.model_copy(
                         update={
                             "ang_size_value": arcsec_value,
                             "brightness": brightness
                             }
                         )
                 )
-                measurements[index] = measurement.value
+                measurements[index] = measurement
                 Ref(LOCAL_STATE.fields.measurements).set(measurements)
                 count.set(count.value + 1)
             else:
@@ -426,15 +426,15 @@ def Page():
             index = LOCAL_STATE.value.get_measurement_index(galaxy["id"])
             if index is not None:
                 measurements = LOCAL_STATE.value.measurements
-                measurement = Ref(LOCAL_STATE.fields.measurements[index])
-                measurement.set(
-                    measurement.value.model_copy(
+                measurement = measurements[index]
+                measurement = (
+                    measurement.model_copy(
                         update={
                             "est_dist_value": distance
                             }
                         )
                 )
-                measurements[index] = measurement.value
+                measurements[index] = measurement
                 Ref(LOCAL_STATE.fields.measurements).set(measurements)
             else:
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -81,16 +81,16 @@ GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 logger = setup_logger("STAGE3")
 
 def update_second_example_measurement():
+    logger.info("update_second_example_measurement")
     example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
     if len(example_measurements.value) < 2:
         logger.info('No second example measurement to update')
         return
     
     changed, updated = _update_second_example_measurement(example_measurements.value)
-    logger.info('Updating second example measurement')
     
     if changed != '':
-        logger.info(f'\t\t setting example_measurements: {changed}')
+        logger.info(f'Updating second example measurement: {changed}')
         example_measurements.set([example_measurements.value[0], updated])
     else:
         logger.info('\t\t no changes for second measurement')
@@ -354,22 +354,24 @@ def Page():
             LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
             
     def _update_angular_size(update_example: bool, galaxy, angular_size, count, meas_num = 'first', brightness = 1.0):
+        logger.info("_update_angular_size")
         # if bool(galaxy) and angular_size is not None:
         arcsec_value = int(angular_size.to(u.arcsec).value)
         if update_example:
             index = LOCAL_STATE.value.get_example_measurement_index(galaxy["id"], measurement_number=meas_num)
             if index is not None:
+                logger.info(f'updating example measurement {index}')
                 measurements = LOCAL_STATE.value.example_measurements
-                measurement = Ref(LOCAL_STATE.fields.example_measurements[index])
-                measurement.set(
-                    measurement.value.model_copy(
+                measurement = measurements[index]
+                measurement =(
+                    measurement.model_copy(
                         update={
                             "ang_size_value": arcsec_value,
                             "brightness": brightness
                             }
                         )
                 )
-                measurements[index] = measurement.value
+                measurements[index] = measurement
                 Ref(LOCAL_STATE.fields.example_measurements).set(measurements)
             else:
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")
@@ -400,21 +402,23 @@ def Page():
         
             
     def _update_distance_measurement(update_example: bool, galaxy, theta, measurement_number = 'first'):
+        logger.info("_update_distance_measurement")
         # if bool(galaxy) and theta is not None:
         distance = distance_from_angular_size(theta)
         if update_example:
             index = LOCAL_STATE.value.get_example_measurement_index(galaxy["id"], measurement_number=measurement_number)
             if index is not None:
+                logger.info(f'updating example measurement {index}')
                 measurements = LOCAL_STATE.value.example_measurements
-                measurement = Ref(LOCAL_STATE.fields.example_measurements[index])
-                measurement.set(
-                    measurement.value.model_copy(
+                measurement = measurements[index]
+                measurement = (
+                    measurement.model_copy(
                         update={
                             "est_dist_value": distance
                             }
                         )
                 )
-                measurements[index] = measurement.value
+                measurements[index] = measurement
                 Ref(LOCAL_STATE.fields.example_measurements).set(measurements)
             else:
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -81,10 +81,9 @@ GUIDELINE_ROOT = Path(__file__).parent / "guidelines"
 logger = setup_logger("STAGE3")
 
 def update_second_example_measurement():
-    logger.info("update_second_example_measurement")
     example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
     if len(example_measurements.value) < 2:
-        logger.info('No second example measurement to update')
+        logger.debug('No second example measurement to update')
         return
     
     changed, updated = _update_second_example_measurement(example_measurements.value)
@@ -329,8 +328,9 @@ def Page():
             if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
                 example_data_setup.set(True)
                 link_example_seed_and_measurements(gjapp)
+            logger.info('added example measurements to glue')
         else:
-            logger.info('no example measurements yet')
+            logger.info('add_example_measurements_to_glue: no example measurements yet')
     
     
     def _glue_data_setup():
@@ -354,13 +354,11 @@ def Page():
             LOCAL_API.put_measurements(GLOBAL_STATE, LOCAL_STATE)
             
     def _update_angular_size(update_example: bool, galaxy, angular_size, count, meas_num = 'first', brightness = 1.0):
-        logger.info("_update_angular_size")
         # if bool(galaxy) and angular_size is not None:
         arcsec_value = int(angular_size.to(u.arcsec).value)
         if update_example:
             index = LOCAL_STATE.value.get_example_measurement_index(galaxy["id"], measurement_number=meas_num)
             if index is not None:
-                logger.info(f'updating example measurement {index}')
                 measurements = LOCAL_STATE.value.example_measurements
                 measurement = measurements[index]
                 measurement =(
@@ -402,13 +400,11 @@ def Page():
         
             
     def _update_distance_measurement(update_example: bool, galaxy, theta, measurement_number = 'first'):
-        logger.info("_update_distance_measurement")
         # if bool(galaxy) and theta is not None:
         distance = distance_from_angular_size(theta)
         if update_example:
             index = LOCAL_STATE.value.get_example_measurement_index(galaxy["id"], measurement_number=measurement_number)
             if index is not None:
-                logger.info(f'updating example measurement {index}')
                 measurements = LOCAL_STATE.value.example_measurements
                 measurement = measurements[index]
                 measurement = (
@@ -613,10 +609,8 @@ def Page():
                 # the above, but if the student goes back, the distance should update if the distance is already set.
                 if on_example_galaxy_marker.value:
                     index = LOCAL_STATE.value.get_example_measurement_index(current_galaxy.value["id"], measurement_number=example_galaxy_measurement_number.value)
-                    logger.info("============== auto_fill_distance ===============")
-                    logger.info(f'index: {index}')
                     if index is not None and LOCAL_STATE.value.example_measurements[index].est_dist_value is not None:
-                        logger.info("autofill the distance")
+                        logger.info(f"autofill the distance of index {index}")
                         auto_fill_distance = True
                 if auto_fill_distance:
                     _distance_cb(angle.to(u.arcsec).value)
@@ -641,7 +635,7 @@ def Page():
                 ruler_click_count.set(count)
             
             def brightness_callback(brightness):
-                logger.info(f'Brightness: {brightness}')
+                # logger.info(f'Brightness: {brightness}')
                 current_brightness.set(brightness / 100)
                 
             example_guard_range = [Angle("6 arcsec"), Angle("6 arcmin")]

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -316,7 +316,6 @@ def Page():
     
     example_data_setup = solara.use_reactive(False)
     def add_example_measurements_to_glue():
-        logger.info('in add_example_measurements_to_glue')
         if len(LOCAL_STATE.value.example_measurements) > 0:
             logger.info(f'has {len(LOCAL_STATE.value.example_measurements)} example measurements')
             example_measurements_glue = models_to_glue_data(LOCAL_STATE.value.example_measurements, label=EXAMPLE_GALAXY_MEASUREMENTS)
@@ -326,9 +325,13 @@ def Page():
             use_this = add_or_update_data(example_measurements_glue)
             use_this.style.color = MY_DATA_COLOR
             if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
-                example_data_setup.set(True)
+                if not example_data_setup.value:
+                    logger.info('added example measurements to glue')
+                else:
+                    logger.info('updated example measurements in glue')
                 link_example_seed_and_measurements(gjapp)
-            logger.info('added example measurements to glue')
+            example_data_setup.set(True)
+                
         else:
             logger.info('add_example_measurements_to_glue: no example measurements yet')
     
@@ -339,6 +342,7 @@ def Page():
     
     
     solara.use_effect(_glue_data_setup, dependencies=[Ref(LOCAL_STATE.fields.measurements_loaded)])
+    Ref(LOCAL_STATE.fields.example_measurements).subscribe(lambda *args: _glue_data_setup())
 
     if GLOBAL_STATE.value.show_team_interface:
         with solara.Row():
@@ -391,7 +395,7 @@ def Page():
                 count.set(count.value + 1)
             else:
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")
-        _glue_data_setup()
+        
    
         
     @computed
@@ -434,7 +438,7 @@ def Page():
                 Ref(LOCAL_STATE.fields.measurements).set(measurements)
             else:
                 raise ValueError(f"Could not find measurement for galaxy {galaxy['id']}")
-        _glue_data_setup()
+
     
     ang_size_dotplot_range = solara.use_reactive([])
     dist_dotplot_range = solara.use_reactive([])

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -324,12 +324,12 @@ def Page():
             
             use_this = add_or_update_data(example_measurements_glue)
             use_this.style.color = MY_DATA_COLOR
+            link_example_seed_and_measurements(gjapp)
             if EXAMPLE_GALAXY_MEASUREMENTS in gjapp.data_collection:
                 if not example_data_setup.value:
                     logger.info('added example measurements to glue')
                 else:
                     logger.info('updated example measurements in glue')
-                link_example_seed_and_measurements(gjapp)
             example_data_setup.set(True)
                 
         else:

--- a/src/hubbleds/pages/03-distance-measurements/__init__.py
+++ b/src/hubbleds/pages/03-distance-measurements/__init__.py
@@ -141,7 +141,7 @@ def DistanceToolComponent(galaxy,
     solara.use_effect(turn_on_guard, [use_guard])
     
     def _reset_canvas():
-        logger.info('resetting canvas')
+        logger.debug('resetting canvas')
         widget = cast(DistanceTool,solara.get_widget(tool))
         widget.reset_canvas()
     
@@ -222,10 +222,11 @@ def Page():
     def glue_setup() -> JupyterApplication:
         gjapp = _glue_setup()
         if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
-            raise ValueError(
+            logger.error(
                 f"Missing {EXAMPLE_GALAXY_SEED_DATA} in glue data collection."
             )
-        seed_data_setup.set(True)
+        else:
+            seed_data_setup.set(True)
         return gjapp
     
 
@@ -762,7 +763,7 @@ def Page():
                     count = 0
                     has_ang_size = all(measurement.ang_size_value is not None for measurement in dataset)
                     if not has_ang_size:
-                        logger.error("\n ======= Not all galaxies have angular sizes ======= \n")
+                        logger.error("\n fill_galaxy_distances: Not all galaxies have angular sizes  \n")
                     for measurement in dataset:
                         if measurement.galaxy is not None and measurement.ang_size_value is not None:
                             count += 1
@@ -795,7 +796,7 @@ def Page():
                     flag = galaxy.get("value", True)
                     value = galaxy["item"]["galaxy"] if flag else None
                     selected_example_galaxy = Ref(COMPONENT_STATE.fields.selected_example_galaxy)
-                    logger.info(f"selected_example_galaxy: {value}")
+                    logger.debug(f"selected_example_galaxy: {value}")
                     selected_example_galaxy.set(value)
                     if COMPONENT_STATE.value.is_current_step(Marker.cho_row1):
                         transition_to(COMPONENT_STATE, Marker.ang_siz2)
@@ -958,19 +959,15 @@ def Page():
                 
                 
                 def set_angular_size_line(points):
-                    logger.info("Called set_angular_size_line")
                     angular_size_line = Ref(COMPONENT_STATE.fields.angular_size_line)
                     if len(points.xs) > 0:
-                        logger.info(f"Setting angular size line with {points.xs}")
                         distance = points.xs[0]
                         angular_size = DISTANCE_CONSTANT / distance
                         angular_size_line.set(angular_size)
                 
                 def set_distance_line(points):
-                    logger.info("Called set_distance_line")
                     distance_line = Ref(COMPONENT_STATE.fields.distance_line)
                     if len(points.xs) > 0:
-                        logger.info(f"Setting distance line with {points.xs}")
                         angular_size = points.xs[0]
                         distance = DISTANCE_CONSTANT / angular_size
                         distance_line.set(distance)

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -259,7 +259,22 @@ def Page():
                 class_ready_task.cancel()
         except RuntimeError:
             pass
-        
+    
+    def _state_callback_setup():
+        def _on_marker_update(marker):
+            if marker is Marker.tre_lin1:
+                # What we really want is for the viewer to check if this layer is visible when it gets to this marker, and if so, clear it.
+                clear_class_layer.set(clear_class_layer.value + 1)
+
+            # This has the same issues as above.
+            if marker is Marker.age_uni1:
+                clear_drawn_line.set(clear_drawn_line.value + 1)
+                draw_active.set(False)
+            
+        current_step.subscribe(_on_marker_update)
+    
+    solara.use_memo(_state_callback_setup, dependencies=[])
+    
     if (len(LOCAL_STATE.value.measurements) == 0 
         or not all(m.completed for m in LOCAL_STATE.value.measurements) # all([]) = True :/
         ):
@@ -461,17 +476,6 @@ def Page():
                 show=COMPONENT_STATE.value.is_current_step(Marker.sho_est2),
             )
 
-        def _on_marker_update(marker):
-            if marker is Marker.tre_lin1:
-                # What we really want is for the viewer to check if this layer is visible when it gets to this marker, and if so, clear it.
-                clear_class_layer.set(clear_class_layer.value + 1)
-
-            # This has the same issues as above.
-            if marker is Marker.age_uni1:
-                clear_drawn_line.set(clear_drawn_line.value + 1)
-                draw_active.set(False)
-            
-        current_step.subscribe(_on_marker_update)
 
         with rv.Col(class_="no-padding"):
             if COMPONENT_STATE.value.current_step_between(Marker.tre_dat1, Marker.sho_est2):

--- a/src/hubbleds/pages/04-explore-data/__init__.py
+++ b/src/hubbleds/pages/04-explore-data/__init__.py
@@ -330,7 +330,7 @@ def Page():
                 items=[x.model_dump() for x in LOCAL_STATE.value.measurements],
                 headers=[
                     {
-                        "text": "Galaxy Name",
+                        "text": "Galaxy ID",
                         "align": "start",
                         "sortable": False,
                         "value": "galaxy.name"

--- a/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
+++ b/src/hubbleds/pages/05-class-results-uncertainty/__init__.py
@@ -378,9 +378,6 @@ def Page():
             show_class_data(marker)
             show_student_data(marker)
 
-    current_step = Ref(COMPONENT_STATE.fields.current_step)
-    
-    current_step.subscribe(update_layer_viewer_visibilities)
     update_layer_viewer_visibilities(COMPONENT_STATE.value.current_step)
 
     class_best_fit_clicked = Ref(COMPONENT_STATE.fields.class_best_fit_clicked)
@@ -405,7 +402,14 @@ def Page():
         if marker <= Marker.sho_mya1 or marker >= Marker.con_int2:
             show_class_hide_my_age_subset(True)
 
-    Ref(COMPONENT_STATE.fields.current_step).subscribe(_on_marker_updated)
+    def _state_callback_setup():
+        current_step = Ref(COMPONENT_STATE.fields.current_step)
+        current_step.subscribe(update_layer_viewer_visibilities)
+        current_step.subscribe(_on_marker_updated)
+        
+    solara.use_memo(_state_callback_setup, dependencies=[])
+
+    
 
     line_fit_tool = viewers["layer"].toolbar.tools['hubble:linefit']
     add_callback(line_fit_tool, 'active',  _on_best_fit_line_shown)

--- a/src/hubbleds/stage_one_and_three_setup.py
+++ b/src/hubbleds/stage_one_and_three_setup.py
@@ -1,0 +1,107 @@
+from solara.toestand import Ref, Reactive
+from glue_jupyter import JupyterApplication
+from glue.core.data import Data
+from .state import GLOBAL_STATE, LOCAL_STATE
+from .data_management import (
+    EXAMPLE_GALAXY_SEED_DATA,
+    EXAMPLE_GALAXY_MEASUREMENTS,
+    STUDENT_ID_COMPONENT,
+)
+from .viewer_marker_colors import (
+    MY_DATA_COLOR,
+    MY_DATA_COLOR_NAME,
+    GENERIC_COLOR,
+    LIGHT_GENERIC_COLOR
+)
+
+
+from .utils import (
+    DISTANCE_CONSTANT, 
+    GALAXY_FOV,
+    distance_from_angular_size,
+    models_to_glue_data,
+    _add_or_update_data, _add_link,
+    push_to_route,
+    subset_by_label,
+    get_image_path
+    )
+
+from .example_measurement_helpers import (
+    create_example_subsets,
+    link_example_seed_and_measurements,
+    _init_second_example_measurement,
+    load_and_create_seed_data
+)
+
+def initialize_second_example_measurement():
+    example_measurements = Ref(LOCAL_STATE.fields.example_measurements)
+    if len(example_measurements.value) < 2:
+        return
+    
+    changed, updated = _init_second_example_measurement(example_measurements.value)
+    
+    if changed != '':
+        if updated is not None:
+            example_measurements.set([example_measurements.value[0], updated])
+
+def _add_or_update_example_measurements_to_glue(gjapp: JupyterApplication):
+        if len(LOCAL_STATE.value.example_measurements) > 0:
+            # make the glue data object
+            example_measurements_glue = models_to_glue_data(
+                LOCAL_STATE.value.example_measurements,
+                label=EXAMPLE_GALAXY_MEASUREMENTS,
+            )
+            example_measurements_glue.style.color = MY_DATA_COLOR
+            create_example_subsets(gjapp, example_measurements_glue)
+
+            # add or update it in glue
+            use_this = _add_or_update_data(gjapp, example_measurements_glue)
+            use_this.style.color = MY_DATA_COLOR
+            
+            # link the measurements to the seed data
+            link_example_seed_and_measurements(gjapp)
+
+def _glue_setup() -> JupyterApplication:
+        gjapp = gjapp = JupyterApplication(
+            GLOBAL_STATE.value.glue_data_collection, GLOBAL_STATE.value.glue_session
+        )
+        
+        # Get the example seed data
+        if EXAMPLE_GALAXY_SEED_DATA not in gjapp.data_collection:
+            load_and_create_seed_data(gjapp, LOCAL_STATE)
+        
+        return gjapp
+
+
+
+def _update_seed_data_with_examples(gjapp, example_data):
+    label = EXAMPLE_GALAXY_SEED_DATA + "_first"
+    if label not in gjapp.data_collection:
+        return 
+
+    student = Ref(GLOBAL_STATE.fields.student)
+    data = gjapp.data_collection[label]
+    keep = data[STUDENT_ID_COMPONENT] != student.value.id
+    update = {
+        c.label: list(data[c][keep])
+        for c in data.main_components
+    }
+
+    examples_count = len(example_data)
+    if examples_count == 1:
+        measurement = example_data[0]
+    elif examples_count >= 2:
+        numbers = ("first", "second")
+        measurement = \
+            sorted(example_data,
+                    key=lambda v: numbers.index(v.measurement_number) if v.measurement_number in numbers else len(numbers)
+            )[1]
+
+        for component in data.main_components:
+            value = getattr(measurement, component.label, None)
+            if value is None:
+                value = float('nan')
+            update[component.label].append(value)
+
+    new_data = Data(label=data.label, **update)
+    data.update_values_from_data(new_data)

--- a/src/hubbleds/state.py
+++ b/src/hubbleds/state.py
@@ -209,7 +209,7 @@ from typing import TypeVar
 BaseComponentStateT = TypeVar('BaseComponentStateT', bound='BaseComponentState')
 
 def get_free_response(local_state: Reactive[LocalState], component_state: Reactive[BaseComponentStateT], tag: str):
-    logger.info(f"Getting Free Response for tag: {tag}")
+    logger.debug(f"Getting Free Response for tag: {tag}")
     # check if the question present
     if tag in local_state.value.free_responses['responses']:
         
@@ -233,7 +233,7 @@ def fix_free_responses_stage_missing(tag, local_state: Reactive[LocalState], com
         
         
 def get_multiple_choice(local_state: Reactive[LocalState], component_state: Reactive[BaseComponentStateT], tag: str):
-    logger.info(f"Getting MC Score for tag: {tag}")
+    logger.debug(f"Getting MC Score for tag: {tag}")
     if tag in local_state.value.mc_scoring['scores']:
         if 'stage' not in local_state.value.mc_scoring['scores'][tag]:
             new = local_state.value.mc_scoring['scores'][tag]
@@ -260,13 +260,12 @@ def mc_callback(
 
     mc_scoring = Ref(local_state.fields.mc_scoring).value.copy()['scores']
     piggybank_total = Ref(local_state.fields.piggybank_total)
-    logger.info(f"MC Callback Event: {event[0]}")
 
     # mc-initialize-callback returns data which is a string
     if event[0] == "mc-initialize-response":
         # check for a missing tag
         if event[1] not in mc_scoring.keys():
-            logger.info(f"Initializing MC Score for tag: {event[1]}")
+            logger.debug(f"Initializing MC Score for tag: {event[1]}")
             new_score = dict(
                 tag=event[1], 
                 score=None, 
@@ -321,9 +320,9 @@ def fr_callback(
     
     free_responses = Ref(local_state.fields.free_responses).value.copy()['responses']
     
-    logger.info(f"Free Response Callback Event: {event[0]}")
     if event[0] == "fr-initialize":
         if event[1]["tag"] not in free_responses.keys():
+            logger.debug(f"Initializing Free Response for tag: {event[1]['tag']}")
             new = dict(tag=event[1]["tag"], response="", initialized=True, stage=component_state.value.stage_id)
             free_responses = {**free_responses, event[1]["tag"]: new }
             Ref(local_state.fields.free_responses).set({'responses': free_responses})

--- a/src/hubbleds/utils.py
+++ b/src/hubbleds/utils.py
@@ -320,6 +320,8 @@ def _add_link(gjapp, from_dc_name, from_att, to_dc_name, to_att):
         to_dc = gjapp.data_collection[to_dc_name]
     if not basic_link_exists(gjapp.data_collection, from_dc.id[from_att], to_dc.id[to_att]):
         gjapp.add_link(from_dc, from_att, to_dc, to_att)
+    else:
+        print(f"Link already exists between {from_dc.label} and {to_dc.label} for {from_att} and {to_att}")
     
 def subset_by_label(data, label):
         value = next((s for s in data.subsets if s.label == label), None)


### PR DESCRIPTION
This PR hopefully fixes #980. There were several issues.

1) With fbec07f122efa48caca41e2fb2f818a3604bfd03: Apparently modifying the elements via a ref to the indexed measurement was causing it to make the subscriptions in Stage 1 to fire. _I don't really know why...something, something, solara...something was a Ref to the same underlying object_
2) The biggest issue and a source of a lot of traffic was that our subscriptions were being recreated with each render. So they would run once for a change, and then twice, and then 3x, ........ Most of these were small, but they built up. At some point I knew this, and even guarded against it when using them.
3) We also had irrelevant calls to some functions, that were causing us to duplicate work
4) This also cleans up some of the repetitive setup in stage 1 and 3 and puts the functions in to a single place, and then they get called. I also made the setup much more symmetric, so that stage 1 & 3 should behave similarly. You will notice a difference between how `example_measurement` and `measurements` are handled in Stage 3 - I am not sure, but I think this is because their values are watched differently.
