### PR TITLE
use @Carifio24's dot plot size fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.12.1
+    glue-plotly @ git+https://github.com/Carifio24/glue-plotly.git@dot-size-update
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
This is a temporary fix for #942. (We will update this properly once Jon's PR gets merged in the glue-plotly repo).