### PR TITLE
Revert "Merge pull request #995 from patudom/use-glue-plotly-dot-plot…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly @ git+https://github.com/Carifio24/glue-plotly.git@dot-size-update
+    glue-plotly[jupyter]>=0.12.1
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
…-dot-size-fix"

This reverts commit c8f1c86a8d2104752a158dca9fafb4dc68ac96d5, reversing changes made to 7c5140d4a23779865d1a8020fedb3a110f6ab114.