### PR TITLE
Allow user to progress with >5 galaxies from sel_gal3

### DIFF
--- a/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
+++ b/src/hubbleds/pages/01-spectra-&-velocity/component_state.py
@@ -156,11 +156,11 @@ class ComponentState(BaseComponentState, BaseState):
 
     @property
     def sel_gal4_gate(self) -> bool:
-        return self.total_galaxies == 5
+        return self.total_galaxies >= 5
 
     @property
     def cho_row1_gate(self) -> bool:
-        return self.total_galaxies == 5
+        return self.total_galaxies >= 5
 
     @property
     def mee_spe1_gate(self) -> bool:


### PR DESCRIPTION
This PR address #885. This really shouldn't be an issue, as the buttons which set `measurements` replace the set entirely or count the number of galaxies already present. This PR just loosen's the gate on a couple markers, to behave similarly to stage 3 (looking for `>=5` rather than `==5`. 