### PR TITLE
Bump glue-plotly version to 0.12.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - glfw==2.7.0
   - glue-core==1.21.0
   - glue-jupyter==0.21.0
-  - glue-plotly==0.12.1
+  - glue-plotly==0.12.3
   - glue-vispy-viewers==1.2.1
   - h11==0.14.0
   - hsluv==5.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     cosmicds @ git+https://github.com/cosmicds/cosmicds.git
     glue-core
     glue-jupyter
-    glue-plotly[jupyter]>=0.12.1
+    glue-plotly[jupyter]>=0.12.3
     ipyvue
     ipyvuetify
     ipywidgets


### PR DESCRIPTION
This PR bumps our glue-plotly version to 0.12.3 so that we get the latest updates to the dotplot sizing.