### PR TITLE
Forcibly clear the global and local states on load

### DIFF
--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -28,8 +28,7 @@ def Layout(children=[]):
 
     def _load_global_local_states():
         # Force reset global and local states
-        logger.info("Clearing global and local states.")
-        GLOBAL_STATE.set(GLOBAL_STATE.value.__class__())
+        logger.info("Clearing local states.")
         LOCAL_STATE.set(LOCAL_STATE.value.__class__())
 
         if student_id.value is None:

--- a/src/hubbleds/layout.py
+++ b/src/hubbleds/layout.py
@@ -27,6 +27,11 @@ def Layout(children=[]):
     route_index = routes_current_level.index(route_current)
 
     def _load_global_local_states():
+        # Force reset global and local states
+        logger.info("Clearing global and local states.")
+        GLOBAL_STATE.set(GLOBAL_STATE.value.__class__())
+        LOCAL_STATE.set(LOCAL_STATE.value.__class__())
+
         if student_id.value is None:
             logger.warning(
                 f"Failed to load measurements: ID `{GLOBAL_STATE.value.student.id}` not found."


### PR DESCRIPTION
An attempt to solve the issue of users being pathed to the incorrect location on app load.