### PR TITLE
Pin uvicorn version to avoid deprecations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ install_requires =
     solara==1.44.1
     solara-enterprise==1.44.1
     traitlets
+    uvicorn==0.35.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This avoids an issue on deployment where the newer uvicorn versions have removed `LOOP_CHOICES`, which is relied upon by other dependencies.