### PR TITLE
Add demo mode toggle for routing configuration

### DIFF
--- a/src/hubbleds/server.py
+++ b/src/hubbleds/server.py
@@ -1,3 +1,4 @@
+import os
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -7,20 +8,23 @@ from solara.server import settings
 import solara.server.starlette
 
 
+# Check if we need to run in demo mode
+force_demo = os.getenv("CDS_FORCE_DEMO", "false").strip().lower() == "true"
+
+
 def root(request: Request):
     return JSONResponse({"Error Message": "Go back whence ye came."})
 
 
-routes = [
-    Route("/", endpoint=root),
-    # Mount("/hubbles-law/", solara.server.starlette.app),
-    Mount("/hubbles-law/", routes=solara.server.starlette.routes),
-]
-
-# middleware = [
-#     Middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True),
-#     Middleware(SessionMiddleware, secret_key="some-secret", max_age=None),
-# ]
+if force_demo:
+    routes = [
+        Mount("/", routes=solara.server.starlette.routes),
+    ]
+else:
+    routes = [
+        Route("/", endpoint=root),
+        Mount("/hubbles-law/", routes=solara.server.starlette.routes),
+    ]
 
 
 app = Starlette(routes=routes, middleware=solara.server.starlette.middleware)


### PR DESCRIPTION
Forgot that we do special routing for the true hubble app, so we need to have a switch to handle the demo mode which does not exist at a special endpoint.